### PR TITLE
fix: show platform modules with actions in sidebar

### DIFF
--- a/Homeboy/Core/CLI/CLIModuleTypes.swift
+++ b/Homeboy/Core/CLI/CLIModuleTypes.swift
@@ -13,6 +13,13 @@ struct CLIModuleEntry: Decodable, Identifiable {
     let configured: Bool
     let linked: Bool
     let path: String  // Module directory path for manifest reading
+    let actions: [CLIModuleAction]?  // Present when module defines actions
+}
+
+struct CLIModuleAction: Decodable {
+    let id: String
+    let label: String
+    let type: String
 }
 
 /// Response wrapper for `homeboy module list --json`

--- a/Homeboy/Core/Modules/ModuleManager.swift
+++ b/Homeboy/Core/Modules/ModuleManager.swift
@@ -33,7 +33,7 @@ struct LoadedModule: Identifiable {
     }
 
     var entrypointPath: String {
-        guard let entrypoint = manifest.runtime.entrypoint else { return "" }
+        guard let entrypoint = manifest.runtime?.entrypoint else { return "" }
         return "\(modulePath)/\(entrypoint)"
     }
 
@@ -118,12 +118,14 @@ class ModuleManager: ObservableObject, ConfigurationObserving {
                 return
             }
 
-            // Filter to executable modules only (platform modules don't have UI)
-            let executableEntries = data.modules.filter { $0.runtime == "executable" }
+            // Include executable modules and platform modules that have actions
+            let visibleEntries = data.modules.filter {
+                $0.runtime == "executable" || !($0.actions ?? []).isEmpty
+            }
 
             // Load manifests from CLI-reported paths
             var loadedModules: [LoadedModule] = []
-            for entry in executableEntries {
+            for entry in visibleEntries {
                 if let module = loadManifest(from: entry) {
                     loadedModules.append(module)
                 }

--- a/Homeboy/Core/Modules/ModuleManifest.swift
+++ b/Homeboy/Core/Modules/ModuleManifest.swift
@@ -10,11 +10,11 @@ struct ModuleManifest: Codable, Identifiable {
     let author: String
     let homepage: String?
     
-    let runtime: RuntimeConfig
-    let inputs: [InputConfig]
-    let output: OutputConfig
-    let actions: [ActionConfig]
-    let settings: [SettingConfig]
+    let runtime: RuntimeConfig?
+    let inputs: [InputConfig]?
+    let output: OutputConfig?
+    let actions: [ActionConfig]?
+    let settings: [SettingConfig]?
     let requires: RequirementsConfig?
     
     /// Path to the module directory (set after loading, not from JSON)
@@ -167,6 +167,9 @@ struct ActionConfig: Codable, Identifiable {
     let builtin: BuiltinAction?
     let column: String?
     
+    // Command action properties
+    let command: String?
+    
     // API action properties
     let endpoint: String?
     let method: String?
@@ -176,6 +179,7 @@ struct ActionConfig: Codable, Identifiable {
     enum ActionType: String, Codable {
         case builtin
         case api
+        case command
     }
     
     enum BuiltinAction: String, Codable {
@@ -224,6 +228,7 @@ struct SettingConfig: Codable, Identifiable {
     
     enum SettingType: String, Codable {
         case text
+        case string
         case toggle
         case stepper
     }

--- a/Homeboy/ViewModels/ModuleViewModel.swift
+++ b/Homeboy/ViewModels/ModuleViewModel.swift
@@ -31,7 +31,7 @@ class ModuleViewModel: ObservableObject, ConfigurationObserving {
     
     /// Whether this module is a CLI module with subtarget support
     var isCLIModule: Bool {
-        module?.manifest.runtime.type == .cli
+        module?.manifest.runtime?.type == .cli
     }
     
     /// Whether the current project has subtargets (for showing site selector)
@@ -72,12 +72,12 @@ class ModuleViewModel: ObservableObject, ConfigurationObserving {
     /// Initialize input values from module manifest
     func initializeInputValues(from module: LoadedModule) {
         // Set default network site for CLI modules
-        if module.manifest.runtime.type == .cli {
-            selectedNetworkSite = module.manifest.runtime.defaultSite ?? "main"
+        if module.manifest.runtime?.type == .cli {
+            selectedNetworkSite = module.manifest.runtime?.defaultSite ?? "main"
         }
         
         // Set default input values
-        for input in module.manifest.inputs {
+        for input in module.manifest.inputs ?? [] {
             if let defaultValue = input.default {
                 inputValues[input.id] = defaultValue.stringValue
             } else {
@@ -148,7 +148,7 @@ class ModuleViewModel: ObservableObject, ConfigurationObserving {
             if output.success {
                 results = output.results ?? []
                 // Auto-select all rows if selectable
-                if module.manifest.output.selectable {
+                if module.manifest.output?.selectable == true {
                     selectedRows = Set(results.indices)
                 }
                 if let errors = output.errors, !errors.isEmpty {
@@ -263,7 +263,7 @@ class ModuleViewModel: ObservableObject, ConfigurationObserving {
     private func exportToCsv(module: LoadedModule) {
         guard !results.isEmpty else { return }
         
-        let columns = module.manifest.output.schema.items?.keys.sorted() ?? []
+        let columns = module.manifest.output?.schema.items?.keys.sorted() ?? []
         guard !columns.isEmpty else { return }
         
         var csv = columns.joined(separator: ",") + "\n"

--- a/Homeboy/Views/Modules/ModuleActionsBar.swift
+++ b/Homeboy/Views/Modules/ModuleActionsBar.swift
@@ -8,7 +8,7 @@ struct ModuleActionsBar: View {
     
     var body: some View {
         HStack {
-            ForEach(module.manifest.actions) { action in
+            ForEach(module.manifest.actions ?? []) { action in
                 actionButton(for: action)
             }
             
@@ -54,7 +54,7 @@ struct ModuleActionsBar: View {
         }
         
         // Check row selection for selectable outputs
-        if module.manifest.output.selectable && viewModel.selectedRows.isEmpty {
+        if module.manifest.output?.selectable == true && viewModel.selectedRows.isEmpty {
             return (false, "Select rows first")
         }
         

--- a/Homeboy/Views/Modules/ModuleContainerView.swift
+++ b/Homeboy/Views/Modules/ModuleContainerView.swift
@@ -83,7 +83,7 @@ struct ModuleContainerView: View {
                 }
                 
             case .ready:
-                if module.manifest.runtime != nil {
+                if let _ = module.manifest.runtime {
                     ModuleReadyView(module: module, viewModel: viewModel)
                 } else {
                     PlatformModuleView(module: module)

--- a/Homeboy/Views/Modules/ModuleInputsView.swift
+++ b/Homeboy/Views/Modules/ModuleInputsView.swift
@@ -20,7 +20,7 @@ struct ModuleInputsView: View {
                 }
             }
             
-            ForEach(module.manifest.inputs) { input in
+            ForEach(module.manifest.inputs ?? []) { input in
                 inputField(for: input)
             }
             

--- a/Homeboy/Views/Modules/ModuleResultsView.swift
+++ b/Homeboy/Views/Modules/ModuleResultsView.swift
@@ -9,7 +9,7 @@ struct ModuleResultsView: View {
     @State private var sortDescriptor: DataTableSortDescriptor<IndexedRow>?
     
     private var columnNames: [String] {
-        module.manifest.output.schema.items?.keys.sorted() ?? []
+        module.manifest.output?.schema.items?.keys.sorted() ?? []
     }
     
     var body: some View {
@@ -39,7 +39,7 @@ struct ModuleResultsView: View {
             
             Spacer()
             
-            if module.manifest.output.selectable {
+            if module.manifest.output?.selectable == true {
                 Text("\(viewModel.selectedRows.count) selected")
                     .font(.caption)
                     .foregroundColor(.secondary)

--- a/Homeboy/Views/Modules/ModuleSetupView.swift
+++ b/Homeboy/Views/Modules/ModuleSetupView.swift
@@ -44,7 +44,7 @@ struct ModuleSetupView: View {
                         .frame(maxWidth: 400)
                     
                     // Dependencies list
-                    if let dependencies = module.manifest.runtime.dependencies, !dependencies.isEmpty {
+                    if let dependencies = module.manifest.runtime?.dependencies, !dependencies.isEmpty {
                         VStack(alignment: .leading, spacing: 4) {
                             Text("Dependencies:")
                                 .font(.caption)
@@ -58,7 +58,7 @@ struct ModuleSetupView: View {
                         .cornerRadius(8)
                     }
                     
-                    if let browsers = module.manifest.runtime.playwrightBrowsers, !browsers.isEmpty {
+                    if let browsers = module.manifest.runtime?.playwrightBrowsers, !browsers.isEmpty {
                         VStack(alignment: .leading, spacing: 4) {
                             Text("Playwright Browsers:")
                                 .font(.caption)


### PR DESCRIPTION
## Problem

Platform modules (`runtime='platform'`) were filtered out entirely by `ModuleManager`, which only showed `executable` modules. This caused the desktop app to show "No modules installed" even when platform modules like OpenClaw were installed.

## Root Cause

`ModuleManager.loadModules()` had this filter:
```swift
let executableEntries = data.modules.filter { $0.runtime == "executable" }
```

This excluded all platform modules, which provide project-type behavior (pinned files, CLI wrapping, actions) but don't have a runtime with inputs/outputs.

## Fix

- **ModuleManager:** Include platform modules that have actions defined
- **ModuleManifest:** Make runtime, inputs, output, settings optional
- **ActionConfig:** Add command action type and command field
- **SettingConfig:** Add string setting type
- **ModuleContainerView:** New PlatformModuleView for runtime-less modules — action buttons grid + command output console
- **All views/viewmodels:** Handle optional manifest fields safely

## Context

Enables the new OpenClaw module (`Extra-Chill/homeboy-modules`) to appear in the sidebar with its actions (Gateway Status, View Config, List Cron Jobs, etc.).