### PR TITLE
feat: add InitOutput parsing with extensions and config gaps

### DIFF
--- a/Homeboy/App/ContentView.swift
+++ b/Homeboy/App/ContentView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Navigation items: core tools are static, extensions are dynamic
 enum NavigationItem: Hashable {
     case coreTool(CoreTool)
-    case extension(String)  // Extension ID
+    case extensionItem(String) // Extension ID
 }
 
 /// Built-in core tools (not extensions)
@@ -71,11 +71,11 @@ struct ContentView: View {
             SettingsView()
                 .opacity(selectedItem == .coreTool(.settings) ? 1 : 0)
             
-            // Dynamic extensions
-            ForEach(extensionManager.extensions) { extension in
-                ExtensionContainerView(extensionId: extension.id)
-                    .opacity(selectedItem == .extension(extension.id) ? 1 : 0)
-            }
+        // Dynamic extensions
+        ForEach(extensionManager.extensions) { ext in
+            ExtensionContainerView(extensionId: ext.id)
+                .opacity(selectedItem == .extensionItem(ext.id) ? 1 : 0)
+        }
             
             // Empty state
             if selectedItem == nil {

--- a/Homeboy/Core/CLI/HomeboyCLI.swift
+++ b/Homeboy/Core/CLI/HomeboyCLI.swift
@@ -292,6 +292,109 @@ struct ProjectMutationOutput: Decodable {
     let deleted: [String]?
 }
 
+// MARK: - Init Output Models (NEW)
+
+/// Output from `homeboy init --json` command
+/// Provides full context including extensions, components, and config gaps
+struct InitOutput: Decodable {
+    let command: String
+    let status: InitStatus
+    let summary: InitSummary
+    let context: ContextOutput
+    let nextSteps: [String]
+    let components: [ComponentSummary]
+    let extensions: [ExtensionEntry]?  // NEW: Extension runtime status
+    let servers: [ServerRecordCLI]
+    let projects: [ProjectListItem]
+    let version: VersionSnapshot?
+    let git: GitSnapshot?
+    let lastRelease: ReleaseSnapshot?
+    let changelog: ChangelogSnapshot?
+    let agentContextFiles: [String]
+    let warnings: [String]
+}
+
+struct InitStatus: Decodable {
+    let totalComponents: Int
+    let configGaps: Int?
+    let gapDetails: [ConfigGapDetail]?
+    let hasUncommitted: [String]?
+    let needsVersionBump: [String]?
+    let readyToDeploy: [String]?
+}
+
+struct InitSummary: Decodable {
+    let byExtension: [String: Int]?
+    let byStatus: [String: Int]
+}
+
+struct ContextOutput: Decodable {
+    let cwd: String
+    let gitRoot: String?
+    let managed: Bool
+    let matchedComponents: [String]?
+    let suggestion: String?
+}
+
+struct ComponentSummary: Decodable, Identifiable {
+    let id: String
+    let path: String
+    let status: String
+    let codeCommits: Int?
+    let commitsSinceVersion: Int?
+    let docsOnlyCommits: Int?
+}
+
+/// Extension entry from init output - shows runtime status
+struct ExtensionEntry: Decodable, Identifiable {
+    let id: String
+    let name: String
+    let version: String
+    let description: String
+    let runtime: String        // "executable" or "platform"
+    let compatible: Bool       // Version compatibility
+    let ready: Bool            // Runtime ready (deps installed)
+    let readyReason: String?   // Why not ready (if applicable)
+    let readyDetail: String?   // Detailed reason
+    let linked: Bool           // Symlinked (dev) vs installed
+}
+
+struct VersionSnapshot: Decodable {
+    let componentId: String?
+    let version: String?
+    let targets: [ComponentRecordCLI.VersionTargetCLI]?
+}
+
+struct GitSnapshot: Decodable {
+    let branch: String
+    let ahead: Int
+    let behind: Int
+    let clean: Bool
+    let commitsSinceVersion: Int?
+    let baselineRef: String?
+}
+
+struct ReleaseSnapshot: Decodable {
+    let tag: String?
+    let date: String?
+    let summary: String?
+}
+
+struct ChangelogSnapshot: Decodable {
+    let label: String?
+    let path: String?
+}
+
+/// Config gap with actionable fix command
+struct ConfigGapDetail: Decodable, Identifiable {
+    let componentId: String
+    let field: String
+    let reason: String
+    let command: String
+    
+    var id: String { "\(componentId).\(field)" }
+}
+
 @MainActor
 final class HomeboyCLI {
     static let shared = HomeboyCLI()
@@ -302,9 +405,21 @@ final class HomeboyCLI {
         cli.isInstalled
     }
 
-    private init() {}
+private init() {}
 
-    // MARK: - Project Commands
+// MARK: - Init Command
+
+/// Run `homeboy init` to get full context including extensions and components
+/// This is the primary way the desktop app discovers the workspace state
+func initWorkspace(path: String? = nil) async throws -> InitOutput {
+    var args = ["init"]
+    if let p = path {
+        args.append(contentsOf: ["--path", p])
+    }
+    return try await cli.executeCommand(args, dataType: InitOutput.self, source: "Init", timeout: 30)
+}
+
+// MARK: - Project Commands
 
     func projectList() async throws -> [ProjectListItem] {
         let output: ProjectListOutput = try await cli.executeCommand(

--- a/Homeboy/Core/Copyable/AppError.swift
+++ b/Homeboy/Core/Copyable/AppError.swift
@@ -46,7 +46,7 @@ extension AppError {
         AppError(message, source: "Database Browser", path: path)
     }
 
-    static func extension(_ extensionId: String, _ message: String) -> AppError {
+    static func extensionError(_ extensionId: String, _ message: String) -> AppError {
         AppError(message, source: "Extension: \(extensionId)")
     }
 }

--- a/Homeboy/Core/Extensions/ExtensionManager.swift
+++ b/Homeboy/Core/Extensions/ExtensionManager.swift
@@ -273,7 +273,7 @@ class ExtensionManager: ObservableObject, ConfigurationObserving {
 
     // MARK: - Extension Lookup
 
-    func extension(withId id: String) -> LoadedExtension? {
+    func loadedExtension(withId id: String) -> LoadedExtension? {
         extensions.first { $0.id == id }
     }
 }

--- a/Homeboy/ViewModels/ExtensionViewModel.swift
+++ b/Homeboy/ViewModels/ExtensionViewModel.swift
@@ -25,8 +25,8 @@ class ExtensionViewModel: ObservableObject, ConfigurationObserving {
     private let configManager = ConfigurationManager.shared
     
     /// Current extension from manager (always up-to-date)
-    private var extension: LoadedExtension? {
-        ExtensionManager.shared.extension(withId: extensionId)
+    private var currentExtension: LoadedExtension? {
+        ExtensionManager.shared.loadedExtension(withId: extensionId)
     }
     
     /// Whether this extension is a CLI extension with subtarget support

--- a/Homeboy/Views/Extensions/ExtensionActionsBar.swift
+++ b/Homeboy/Views/Extensions/ExtensionActionsBar.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// Renders action buttons from extension manifest
 struct ExtensionActionsBar: View {
-    let extension: LoadedExtension
+    let currentExtension: LoadedExtension
     @ObservedObject var viewModel: ExtensionViewModel
     @EnvironmentObject var authManager: AuthManager
     

--- a/Homeboy/Views/Extensions/ExtensionConsoleView.swift
+++ b/Homeboy/Views/Extensions/ExtensionConsoleView.swift
@@ -6,7 +6,7 @@ struct ExtensionConsoleView: View {
     @ObservedObject var viewModel: ExtensionViewModel
     
     private var extensionName: String {
-        ExtensionManager.shared.extension(withId: viewModel.extensionId)?.name ?? viewModel.extensionId
+        ExtensionManager.shared.loadedExtension(withId: viewModel.extensionId)?.name ?? viewModel.extensionId
     }
     
     var body: some View {

--- a/Homeboy/Views/Extensions/ExtensionContainerView.swift
+++ b/Homeboy/Views/Extensions/ExtensionContainerView.swift
@@ -12,16 +12,16 @@ struct ExtensionContainerView: View {
         _viewModel = StateObject(wrappedValue: ExtensionViewModel(extensionId: extensionId))
     }
     
-    private var extension: LoadedExtension? {
-        extensionManager.extension(withId: extensionId)
+    private var currentExtension: LoadedExtension? {
+        extensionManager.loadedExtension(withId: extensionId)
     }
     
     var body: some View {
         Group {
-            if let extension = extension {
-                extensionContent(extension)
+            if let currentExtension = currentExtension {
+                extensionContent(currentExtension)
                     .onAppear {
-                        viewModel.initializeInputValues(from: extension)
+                        viewModel.initializeInputValues(from: currentExtension)
                     }
             } else {
                 VStack(spacing: 16) {
@@ -96,7 +96,7 @@ struct ExtensionContainerView: View {
 // MARK: - Platform Extension View (extensions without runtime, e.g. OpenClaw)
 
 struct PlatformExtensionView: View {
-    let extension: LoadedExtension
+    let currentExtension: LoadedExtension
     @State private var actionOutput: String = ""
     @State private var isRunning = false
     
@@ -184,7 +184,7 @@ struct PlatformExtensionView: View {
 // MARK: - Header View
 
 struct ExtensionHeaderView: View {
-    let extension: LoadedExtension
+    let currentExtension: LoadedExtension
     @ObservedObject var viewModel: ExtensionViewModel
     
     var body: some View {
@@ -217,7 +217,7 @@ struct ExtensionHeaderView: View {
 // MARK: - Ready State View
 
 struct ExtensionReadyView: View {
-    let extension: LoadedExtension
+    let currentExtension: LoadedExtension
     @ObservedObject var viewModel: ExtensionViewModel
     
     @State private var showConsole = true

--- a/Homeboy/Views/Extensions/ExtensionInputsView.swift
+++ b/Homeboy/Views/Extensions/ExtensionInputsView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// Dynamically generates input form from extension manifest
 struct ExtensionInputsView: View {
-    let extension: LoadedExtension
+    let currentExtension: LoadedExtension
     @ObservedObject var viewModel: ExtensionViewModel
     
     var body: some View {

--- a/Homeboy/Views/Extensions/ExtensionResultsView.swift
+++ b/Homeboy/Views/Extensions/ExtensionResultsView.swift
@@ -3,7 +3,7 @@ import AppKit
 
 /// Displays extension results in a dynamic table based on output schema
 struct ExtensionResultsView: View {
-    let extension: LoadedExtension
+    let currentExtension: LoadedExtension
     @ObservedObject var viewModel: ExtensionViewModel
     
     @State private var sortDescriptor: DataTableSortDescriptor<IndexedRow>?

--- a/Homeboy/Views/Extensions/ExtensionSetupView.swift
+++ b/Homeboy/Views/Extensions/ExtensionSetupView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// View shown when a extension needs dependency installation
 struct ExtensionSetupView: View {
-    let extension: LoadedExtension
+    let currentExtension: LoadedExtension
     @ObservedObject var viewModel: ExtensionViewModel
     
     var body: some View {

--- a/Homeboy/Views/SidebarView.swift
+++ b/Homeboy/Views/SidebarView.swift
@@ -81,7 +81,7 @@ struct SidebarView: View {
                                         }
                                 }
                             }
-                            .tag(NavigationItem.extension(extension.id))
+                            .tag(NavigationItem.extensionItem(extension.id))
                             .help(extension.isDisabled ? "Requires: \(extension.missingComponents.joined(separator: ", "))" : extension.name)
                         }
                     }


### PR DESCRIPTION
Adds comprehensive InitOutput types for `homeboy init --json` command.

## New Types

### Core Init Types
- **InitOutput** - Full workspace context from init command
- **InitStatus** - Component counts, config gaps, uncommitted/needs-bump/ready lists
- **InitSummary** - Breakdown by extension and status
- **ContextOutput** - CWD, git root, managed status, matched components

### Component & Extension Types
- **ComponentSummary** - Component ID, path, status, commit counts
- **ExtensionEntry** - Runtime status (ready, compatible, linked, readyReason, etc.)

### Version & Release Types
- **VersionSnapshot** - Current version info
- **GitSnapshot** - Branch, ahead/behind, clean status
- **ReleaseSnapshot** - Last release tag/date/summary
- **ChangelogSnapshot** - Changelog label and path

### Config Gap Types
- **ConfigGapDetail** - Component gaps with actionable fix commands

## New Method

```swift
func initWorkspace(path: String?) async throws -> InitOutput
```

Call `homeboy init` and parse full context with extensions.

## Benefits

This enables the desktop app to:
1. Show extension runtime status from init output
2. Display config gaps with actionable fix commands
3. Show component commit/version status
4. Access full workspace context on startup (more efficient than multiple CLI calls)

## Usage

```swift
let initOutput = try await HomeboyCLI.shared.initWorkspace()

// Access extensions with runtime status
for ext in initOutput.extensions ?? [] {
    print("\(ext.name): \(ext.ready ? "ready" : "needs setup")")
}

// Show config gaps
for gap in initOutput.status.gapDetails ?? [] {
    print("\(gap.componentId) missing \(gap.field): \(gap.command)")
}
```

Closes #6
