### PR TITLE
chore: track desktop homeboy config

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -39,7 +39,7 @@ This document avoids duplicating CLI command docs.
 Use the CLI as the source of truth:
 - `homeboy docs`
 - `homeboy docs <topic>`
-- Markdown sources embedded into the CLI: [`homeboy/docs/`](../../homeboy/docs/index.md)
+- Markdown sources embedded into the CLI: `docs/` in the Homeboy CLI source tree
 
 ### Desktop ↔ CLI responsibilities
 
@@ -70,11 +70,11 @@ For canonical flags, output schemas, safety rules, and subtarget behavior, use `
 The desktop app relies on the CLI's mapped exit codes.
 
 Canonical mapping and error-code groups live in:
-- [`homeboy/docs/json-output/json-output-contract.md`](../../homeboy/docs/json-output/json-output-contract.md#exit-codes)
+- `homeboy docs json-output`
 
 ## Error reporting
 
 The desktop app surfaces CLI failures as `AppError` instances (see [ERROR-HANDLING](ERROR-HANDLING.md)).
 
 Canonical error codes/messages and exit code mapping live in the CLI docs:
-- [`homeboy/docs/json-output/json-output-contract.md#exit-codes`](../../homeboy/docs/json-output/json-output-contract.md#exit-codes)
+- `homeboy docs json-output`

--- a/docs/EXTENSION-SPEC.md
+++ b/docs/EXTENSION-SPEC.md
@@ -36,7 +36,7 @@ Homeboy extensions can:
 
 The manifest is a single unified `homeboy.json` file; extensions include only fields they need.
 
-For the authoritative runtime behavior, see [`homeboy/docs/commands/extension.md`](../../homeboy/docs/commands/extension.md).
+For the authoritative runtime behavior, run `homeboy docs extension`.
 
 ## Manifest Schema
 
@@ -68,7 +68,7 @@ For the authoritative runtime behavior, see [`homeboy/docs/commands/extension.md
 
 ### Runtime Object
 
-Executable extensions use the CLI runtime contract described in [`homeboy/docs/commands/extension.md`](../../homeboy/docs/commands/extension.md).
+Executable extensions use the CLI runtime contract described by `homeboy docs extension`.
 
 The manifest's `runtime` object configures shell commands that the CLI runs (for example `runCommand`, `setupCommand`, and optional `readyCheck`). The CLI injects execution context and merged settings via environment variables.
 

--- a/homeboy.json
+++ b/homeboy.json
@@ -1,0 +1,9 @@
+{
+  "auto_cleanup": false,
+  "changelog_target": "docs/CHANGELOG.md",
+  "extensions": {
+    "swift": {}
+  },
+  "id": "homeboy-desktop",
+  "remote_path": ""
+}


### PR DESCRIPTION
## Summary
- Add the portable `homeboy.json` component config for Homeboy Desktop with the Swift extension enabled.
- Replace stale/broken docs links into the Homeboy CLI source tree with current `homeboy docs` command references.

## Tests
- `swift tests/ContractTests.swift tests`
- `homeboy review /Users/chubes/Developer/homeboy-desktop@track-config-docs --summary`
- `homeboy audit /Users/chubes/Developer/homeboy-desktop@track-config-docs --json-summary` (passes with existing unrelated CLI invocation warnings; #26 doc-reference findings are gone)

Closes #17
Closes #26

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the scoped desktop config/docs cleanup; Chris to review before merge.
