### PR TITLE
fix: update remote log pin command

### DIFF
--- a/Homeboy/Extensions/RemoteLogViewer/RemoteLogViewerViewModel.swift
+++ b/Homeboy/Extensions/RemoteLogViewer/RemoteLogViewerViewModel.swift
@@ -269,7 +269,7 @@ class RemoteLogViewerViewModel: ObservableObject, ConfigurationObserving {
 
                     if removeResponse.success {
                         // Re-add with new tail lines
-                        let addArgs = ["project", "pin", "add", projectId, log.path, "--type", "log", "--tail", String(lines)]
+                        let addArgs = ["project", "pin", "add", "--type", "log", "--tail", String(lines), projectId, log.path]
                         let addResponse = try await cli.execute(addArgs, timeout: 30)
 
                         if !addResponse.success {
@@ -310,8 +310,8 @@ class RemoteLogViewerViewModel: ObservableObject, ConfigurationObserving {
 
         Task {
             do {
-                // homeboy project pin add <project> <path> --type log --tail <lines> --json
-                let args = ["project", "pin", "add", projectId, log.path, "--type", "log", "--tail", String(log.tailLines)]
+                // homeboy project pin add --type log --tail <lines> <project> <path>
+                let args = ["project", "pin", "add", "--type", "log", "--tail", String(log.tailLines), projectId, log.path]
                 let response = try await cli.execute(args, timeout: 30)
 
                 if response.success {

--- a/tests/ContractTests.swift
+++ b/tests/ContractTests.swift
@@ -135,6 +135,9 @@ func runTests(testDir: String) throws {
     // Test 7: versionTargets parsing
     try testVersionTargetsParsing(fixturesDir: fixturesDir, decoder: decoder)
 
+    // Test 8: Remote Log Viewer pin command shape
+    try testRemoteLogViewerPinCommandShape(testDir: testDir)
+
     print("")
     print("All contract tests passed")
 }
@@ -504,6 +507,39 @@ func testVersionTargetsParsing(fixturesDir: String, decoder: JSONDecoder) throws
             userInfo: [NSLocalizedDescriptionKey: "versionPattern computed property should not be nil"])
     }
     print("[PASS] versionPattern computed property: present")
+    print("")
+}
+
+func testRemoteLogViewerPinCommandShape(testDir: String) throws {
+    print("Test: Remote Log Viewer pin command shape")
+    print("-----------------------------------------")
+
+    let sourcePath = URL(fileURLWithPath: testDir)
+        .deletingLastPathComponent()
+        .appendingPathComponent("Homeboy/Extensions/RemoteLogViewer/RemoteLogViewerViewModel.swift")
+
+    let source = try String(contentsOf: sourcePath, encoding: .utf8)
+    let currentPinCommand = #"["project", "pin", "add", "--type", "log", "--tail", String(log.tailLines), projectId, log.path]"#
+    let currentTailUpdateCommand = #"["project", "pin", "add", "--type", "log", "--tail", String(lines), projectId, log.path]"#
+    let oldPositionalFirstCommand = #"["project", "pin", "add", projectId, log.path, "--type", "log", "--tail"#
+
+    guard source.contains(currentPinCommand) else {
+        throw NSError(domain: "ContractTest", code: 70,
+            userInfo: [NSLocalizedDescriptionKey: "RemoteLogViewer pin command does not use current homeboy project pin add syntax"])
+    }
+    print("[PASS] Pin command puts --type/--tail before project/path")
+
+    guard source.contains(currentTailUpdateCommand) else {
+        throw NSError(domain: "ContractTest", code: 71,
+            userInfo: [NSLocalizedDescriptionKey: "RemoteLogViewer tail update command does not preserve current pin syntax"])
+    }
+    print("[PASS] Tail-line update command preserves --tail before project/path")
+
+    guard !source.contains(oldPositionalFirstCommand) else {
+        throw NSError(domain: "ContractTest", code: 72,
+            userInfo: [NSLocalizedDescriptionKey: "RemoteLogViewer still contains old positional-first project pin add syntax"])
+    }
+    print("[PASS] Old positional-first log pin syntax is absent")
     print("")
 }
 


### PR DESCRIPTION
## Summary
- Updates Remote Log Viewer log pin and tail-line re-pin calls to use the current `homeboy project pin add --type log --tail <lines> <project> <path>` syntax.
- Adds a contract test that pins the current command shape and rejects the old positional-first form.

## Tests
- `swift tests/ContractTests.swift tests`
- `homeboy project pin add --type log --tail 50 __homeboy_desktop_parser_check__ logs/app.log` (parser accepted shape; failed semantically with `project.not_found`)
- `homeboy audit --json-summary /Users/chubes/Developer/homeboy-desktop@fix-remote-log-pin` (issue #24 finding absent; unrelated stale CLI warnings remain)

Closes #24

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the command-shape update, added the contract assertion, and ran the requested verification; Chris remains responsible for review and merge.