### PR TITLE
fix: modernize extension manager CLI commands

### DIFF
--- a/Homeboy/Core/CLI/CLIExtensionTypes.swift
+++ b/Homeboy/Core/CLI/CLIExtensionTypes.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Extension entry from `homeboy extension list --json`
+/// Extension entry from `homeboy extension list`
 /// Matches the CLI's ExtensionEntry struct output
 struct CLIExtensionEntry: Decodable, Identifiable {
     let id: String
@@ -10,10 +10,15 @@ struct CLIExtensionEntry: Decodable, Identifiable {
     let runtime: String  // "executable" or "platform"
     let compatible: Bool
     let ready: Bool
-    let configured: Bool
+    let configured: Bool?
     let linked: Bool
     let path: String  // Extension directory path for manifest reading
     let actions: [CLIExtensionAction]?  // Present when extension defines actions
+    let hasReadyCheck: Bool?
+    let hasSetup: Bool?
+    let cliDisplayName: String?
+    let cliTool: String?
+    let sourceRevision: String?
 }
 
 struct CLIExtensionAction: Decodable {
@@ -22,7 +27,7 @@ struct CLIExtensionAction: Decodable {
     let type: String
 }
 
-/// Response wrapper for `homeboy extension list --json`
+/// Response wrapper for `homeboy extension list`
 struct CLIExtensionListResponse: Decodable {
     let success: Bool
     let data: CLIExtensionListData?
@@ -30,6 +35,7 @@ struct CLIExtensionListResponse: Decodable {
 }
 
 struct CLIExtensionListData: Decodable {
+    let command: String?
     let projectId: String?
     let extensions: [CLIExtensionEntry]
 }

--- a/Homeboy/Core/Extensions/ExtensionManager.swift
+++ b/Homeboy/Core/Extensions/ExtensionManager.swift
@@ -98,13 +98,7 @@ class ExtensionManager: ObservableObject, ConfigurationObserving {
         error = nil
 
         do {
-            let projectId = ConfigurationManager.shared.activeProject?.id
-            var args = ["extension", "list", "--json"]
-            if let project = projectId {
-                args += ["--project", project]
-            }
-
-            let response = try await CLIBridge.shared.execute(args)
+            let response = try await CLIBridge.shared.execute(["extension", "list"])
             let result = try response.decodeResponse(CLIExtensionListData.self)
 
             guard result.success, let data = result.data else {
@@ -208,7 +202,7 @@ class ExtensionManager: ObservableObject, ConfigurationObserving {
 
     /// Unlinks a linked extension (uses uninstall which handles symlinks)
     func unlinkExtension(extensionId: String) async throws {
-        let args = ["extension", "uninstall", extensionId, "--force"]
+        let args = ["extension", "uninstall", extensionId]
         let response = try await CLIBridge.shared.execute(args)
 
         guard response.success else {
@@ -220,7 +214,7 @@ class ExtensionManager: ObservableObject, ConfigurationObserving {
 
     /// Uninstalls a extension via CLI
     func uninstallExtension(extensionId: String) async throws {
-        let args = ["extension", "uninstall", extensionId, "--force"]
+        let args = ["extension", "uninstall", extensionId]
         let response = try await CLIBridge.shared.execute(args)
 
         guard response.success else {
@@ -248,15 +242,11 @@ class ExtensionManager: ObservableObject, ConfigurationObserving {
     func runExtension(
         extensionId: String,
         inputs: [String: String],
-        projectId: String?,
         onOutput: @escaping (String) -> Void
     ) async {
         var args = ["extension", "run", extensionId]
-        if let project = projectId {
-            args += ["--project", project]
-        }
-        for (key, value) in inputs {
-            args += ["--input", "\(key)=\(value)"]
+        for (key, value) in inputs.sorted(by: { $0.key < $1.key }) {
+            args.append("\(key)=\(value)")
         }
 
         let stream = await CLIBridge.shared.executeStreaming(args)

--- a/Homeboy/ViewModels/ExtensionViewModel.swift
+++ b/Homeboy/ViewModels/ExtensionViewModel.swift
@@ -99,12 +99,9 @@ class ExtensionViewModel: ObservableObject, ConfigurationObserving {
         isRunning = true
         
         Task {
-            let projectId = configManager.activeProject?.id
-
             await ExtensionManager.shared.runExtension(
                 extensionId: extension.id,
                 inputs: inputValues,
-                projectId: projectId,
                 onOutput: { [weak self] line in
                     Task { @MainActor in
                         self?.consoleOutput += line

--- a/tests/ContractTests.swift
+++ b/tests/ContractTests.swift
@@ -52,6 +52,39 @@ struct ComponentListItemCLI: Decodable {
     let buildArtifact: String?
 }
 
+// MARK: - Extension List Types (mirror CLIExtensionTypes.swift)
+
+struct ExtensionListOutput: Decodable {
+    let command: String?
+    let projectId: String?
+    let extensions: [ExtensionListItemCLI]
+}
+
+struct ExtensionListItemCLI: Decodable {
+    let id: String
+    let name: String
+    let version: String
+    let description: String
+    let runtime: String
+    let compatible: Bool
+    let ready: Bool
+    let configured: Bool?
+    let linked: Bool
+    let path: String
+    let actions: [ExtensionActionCLI]?
+    let hasReadyCheck: Bool?
+    let hasSetup: Bool?
+    let cliDisplayName: String?
+    let cliTool: String?
+    let sourceRevision: String?
+}
+
+struct ExtensionActionCLI: Decodable {
+    let id: String
+    let label: String
+    let type: String
+}
+
 // MARK: - Database Output Types (mirror HomeboyCLI.swift)
 
 struct DbOutput: Decodable {
@@ -140,6 +173,9 @@ func runTests(testDir: String) throws {
 
     // Test 9: HomeboyCLI helper command shapes
     try testHomeboyCLIHelperCommandShapes()
+
+    // Test 10: extension-list.json parsing
+    try testExtensionList(fixturesDir: fixturesDir, decoder: decoder)
 
     print("")
     print("All contract tests passed")
@@ -599,6 +635,71 @@ func testHomeboyCLIHelperCommandShapes() throws {
     try requireNotContains(#"\(context)"#,
         "helper commands do not pass literal context interpolation templates", code: 91)
 
+    print("")
+}
+
+func testExtensionList(fixturesDir: String, decoder: JSONDecoder) throws {
+    print("Test: extension-list.json")
+    print("-------------------------")
+
+    let fixture = URL(fileURLWithPath: "\(fixturesDir)/extension-list.json")
+
+    guard FileManager.default.fileExists(atPath: fixture.path) else {
+        throw NSError(domain: "ContractTest", code: 70,
+            userInfo: [NSLocalizedDescriptionKey: "Fixture not found: extension-list.json"])
+    }
+
+    let data = try Data(contentsOf: fixture)
+    let result = try decoder.decode(CLIResponse<ExtensionListOutput>.self, from: data)
+
+    guard result.success else {
+        throw NSError(domain: "ContractTest", code: 71,
+            userInfo: [NSLocalizedDescriptionKey: "extension-list.json: success=false"])
+    }
+    print("[PASS] Parsed CLIResponse wrapper")
+
+    guard let output = result.data else {
+        throw NSError(domain: "ContractTest", code: 72,
+            userInfo: [NSLocalizedDescriptionKey: "extension-list.json: data field is nil"])
+    }
+
+    guard output.command == "extension.list" else {
+        throw NSError(domain: "ContractTest", code: 73,
+            userInfo: [NSLocalizedDescriptionKey: "extension-list.json: command mismatch"])
+    }
+    print("[PASS] Parsed extension.list command")
+
+    guard output.projectId == nil else {
+        throw NSError(domain: "ContractTest", code: 74,
+            userInfo: [NSLocalizedDescriptionKey: "extension-list.json should not be project-scoped"])
+    }
+    print("[PASS] Extension list is not project-scoped")
+
+    guard output.extensions.count == 2 else {
+        throw NSError(domain: "ContractTest", code: 75,
+            userInfo: [NSLocalizedDescriptionKey: "Expected 2 extensions, got \(output.extensions.count)"])
+    }
+    print("[PASS] Parsed \(output.extensions.count) extensions")
+
+    let node = output.extensions[0]
+    guard node.configured == nil else {
+        throw NSError(domain: "ContractTest", code: 76,
+            userInfo: [NSLocalizedDescriptionKey: "Current extension list output should not require configured"])
+    }
+    print("[PASS] Optional configured field may be absent")
+
+    guard node.actions?.first?.id == "release.package" else {
+        throw NSError(domain: "ContractTest", code: 77,
+            userInfo: [NSLocalizedDescriptionKey: "Platform extension action did not decode"])
+    }
+    print("[PASS] Platform extension actions decoded")
+
+    let swift = output.extensions[1]
+    guard swift.hasSetup == true && swift.hasReadyCheck == true else {
+        throw NSError(domain: "ContractTest", code: 78,
+            userInfo: [NSLocalizedDescriptionKey: "Executable extension readiness flags did not decode"])
+    }
+    print("[PASS] Executable extension readiness flags decoded")
     print("")
 }
 

--- a/tests/fixtures/extension-list.json
+++ b/tests/fixtures/extension-list.json
@@ -1,0 +1,41 @@
+{
+  "success": true,
+  "data": {
+    "command": "extension.list",
+    "extensions": [
+      {
+        "actions": [
+          {
+            "id": "release.package",
+            "label": "Package release artifacts",
+            "type": "command"
+          }
+        ],
+        "compatible": true,
+        "description": "Node.js project type",
+        "id": "nodejs",
+        "linked": true,
+        "name": "Node.js",
+        "path": "/Users/example/.config/homeboy/extensions/nodejs",
+        "ready": true,
+        "runtime": "platform",
+        "source_revision": "0a1e566",
+        "version": "3.0.0"
+      },
+      {
+        "compatible": true,
+        "description": "Swift testing infrastructure",
+        "has_ready_check": true,
+        "has_setup": true,
+        "id": "swift",
+        "linked": true,
+        "name": "Swift",
+        "path": "/Users/example/.config/homeboy/extensions/swift",
+        "ready": true,
+        "runtime": "executable",
+        "source_revision": "5ae07a3",
+        "version": "2.4.1"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Modernizes ExtensionManager shell-outs for the current Homeboy extension command surface.
- Updates extension-list decoding to match current CLI output and adds a contract fixture for the shape.
- Keeps uninstall confirmation in the app while removing the removed force flag.

## Tests
- swift tests/ContractTests.swift tests
- homeboy extension list >/dev/null
- homeboy extension uninstall __homeboy_desktop_missing_extension_probe__ >/dev/null
- homeboy extension setup __homeboy_desktop_missing_extension_probe__ >/dev/null
- homeboy extension run __homeboy_desktop_missing_extension_probe__ sample=value >/dev/null
- homeboy audit --json-summary /Users/chubes/Developer/homeboy-desktop@fix-extension-manager-cli

Closes #23

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the CLI command updates, adding the extension-list contract fixture, and running verification.