### PR TITLE
feat: add stack manager surface

### DIFF
--- a/Homeboy/App/ContentView.swift
+++ b/Homeboy/App/ContentView.swift
@@ -16,6 +16,7 @@ enum CoreTool: String, CaseIterable, Identifiable {
     case bench = "Bench"
     case release = "Release"
     case rigs = "Rigs"
+    case stackManager = "Stacks"
     case remoteFileEditor = "File Editor"
     case remoteLogViewer = "Log Viewer"
     case databaseBrowser = "Database"
@@ -29,6 +30,7 @@ enum CoreTool: String, CaseIterable, Identifiable {
         case .bench: return "speedometer"
         case .release: return "tag"
         case .rigs: return "shippingbox.and.arrow.backward"
+        case .stackManager: return "square.stack.3d.up"
         case .remoteFileEditor: return "doc.badge.gearshape"
         case .remoteLogViewer: return "doc.text.magnifyingglass"
         case .databaseBrowser: return "cylinder.split.1x2"
@@ -75,6 +77,8 @@ struct ContentView: View {
                 .opacity(selectedItem == .coreTool(.release) ? 1 : 0)
             RigsView()
                 .opacity(selectedItem == .coreTool(.rigs) ? 1 : 0)
+            StackManagerView()
+                .opacity(selectedItem == .coreTool(.stackManager) ? 1 : 0)
             DatabaseBrowserView()
                 .opacity(selectedItem == .coreTool(.databaseBrowser) ? 1 : 0)
             RemoteLogViewerView()
@@ -410,6 +414,367 @@ struct ReleaseWorkflowView: View {
                 .font(.system(.body, design: .monospaced))
                 .textSelection(.enabled)
         }
+    }
+}
+
+// MARK: - Stack Manager
+
+struct StackManagerView: View {
+    @State private var stacks: [StackListItem] = []
+    @State private var selectedStack: StackListItem?
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationSplitView {
+            List(selection: $selectedStack) {
+                Section("Stacks") {
+                    ForEach(stacks) { stack in
+                        StackRow(stack: stack)
+                            .tag(stack)
+                    }
+                }
+            }
+            .navigationTitle("Stacks")
+            .overlay {
+                if isLoading && stacks.isEmpty {
+                    ProgressView("Loading stacks...")
+                } else if stacks.isEmpty && errorMessage == nil {
+                    ContentUnavailableView(
+                        "No Stack Specs",
+                        systemImage: "square.stack.3d.up.slash",
+                        description: Text("Create stack specs with homeboy stack create, then refresh this view.")
+                    )
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        Task { await loadStacks() }
+                    } label: {
+                        Label("Refresh", systemImage: "arrow.clockwise")
+                    }
+                    .disabled(isLoading)
+                }
+            }
+        } detail: {
+            if let selectedStack {
+                StackDetailView(stack: selectedStack)
+                    .id(selectedStack.id)
+            } else {
+                ContentUnavailableView(
+                    "Select a Stack",
+                    systemImage: "square.stack.3d.up",
+                    description: Text("Choose a stack spec to inspect PR state and local branch status.")
+                )
+            }
+        }
+        .safeAreaInset(edge: .bottom) {
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundColor(.red)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(8)
+                    .background(Color.red.opacity(0.08))
+            }
+        }
+        .task {
+            await loadStacks()
+        }
+    }
+
+    private func loadStacks() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            let loadedStacks = try await HomeboyCLI.shared.stackList()
+            stacks = loadedStacks
+            if selectedStack == nil || !loadedStacks.contains(where: { $0.id == selectedStack?.id }) {
+                selectedStack = loadedStacks.first
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+}
+
+struct StackRow: View {
+    let stack: StackListItem
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Image(systemName: "square.stack.3d.up.fill")
+                    .foregroundColor(.purple)
+                Text(stack.id)
+                    .font(.headline)
+            }
+
+            Text(stack.description)
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .lineLimit(2)
+
+            HStack(spacing: 8) {
+                Text(stack.component)
+                Text("\(stack.prCount) PR\(stack.prCount == 1 ? "" : "s")")
+            }
+            .font(.caption2)
+            .foregroundColor(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+struct StackDetailView: View {
+    let stack: StackListItem
+
+    @State private var spec: StackSpec?
+    @State private var status: StackStatusOutput?
+    @State private var inspection: StackInspectOutput?
+    @State private var isLoading = false
+    @State private var isInspecting = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider()
+
+            if isLoading && status == nil {
+                ProgressView("Loading stack status...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        if let errorMessage {
+                            Text(errorMessage)
+                                .foregroundColor(.red)
+                                .padding(10)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background(Color.red.opacity(0.08))
+                                .cornerRadius(8)
+                        }
+
+                        summaryCards
+                        pullRequestList
+                        inspectionSection
+                    }
+                    .padding()
+                }
+            }
+        }
+        .task {
+            await loadStack()
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(stack.id)
+                    .font(.title)
+                Text(stack.description)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                Text("\(stack.base) -> \(stack.target)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            Button {
+                Task { await loadStack() }
+            } label: {
+                Label("Refresh", systemImage: "arrow.clockwise")
+            }
+            .disabled(isLoading)
+        }
+        .padding()
+    }
+
+    private var summaryCards: some View {
+        HStack(spacing: 12) {
+            StackMetricCard(title: "Pull Requests", value: "\(status?.prs.count ?? stack.prCount)")
+            StackMetricCard(title: "Merged", value: "\(status?.mergedCount ?? 0)")
+            StackMetricCard(title: "Target Ahead", value: status.map { "\($0.targetAhead)" } ?? "-")
+            StackMetricCard(title: "Target Behind", value: status.map { "\($0.targetBehind)" } ?? "-")
+        }
+    }
+
+    private var pullRequestList: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Pull Requests")
+                .font(.headline)
+
+            if let status {
+                ForEach(status.prs) { pr in
+                    StackPullRequestRow(pr: pr)
+                }
+            } else if let spec {
+                ForEach(spec.prs) { pr in
+                    HStack {
+                        Text("#\(pr.number)")
+                            .font(.headline)
+                        VStack(alignment: .leading) {
+                            Text(pr.repo)
+                            if let note = pr.note {
+                                Text(note)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        Spacer()
+                    }
+                    .padding(10)
+                    .background(Color.secondary.opacity(0.08))
+                    .cornerRadius(8)
+                }
+            }
+        }
+    }
+
+    private var inspectionSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Branch Inspection")
+                    .font(.headline)
+                Spacer()
+                Button {
+                    Task { await inspectStackBranch() }
+                } label: {
+                    Label("Inspect", systemImage: "magnifyingglass")
+                }
+                .disabled(isInspecting || status == nil)
+            }
+
+            if isInspecting {
+                ProgressView("Inspecting branch...")
+            } else if let inspection {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("\(inspection.branch): \(inspection.commits.count) commit\(inspection.commits.count == 1 ? "" : "s") over \(inspection.base)")
+                    Text("Merged PRs detected: \(inspection.mergedCount)")
+                        .foregroundColor(.secondary)
+                    ForEach(inspection.commits) { commit in
+                        Text("\(commit.shortSha)  \(commit.subject)")
+                            .font(.system(.caption, design: .monospaced))
+                    }
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.secondary.opacity(0.08))
+                .cornerRadius(8)
+            } else {
+                Text("Runs read-only `homeboy stack inspect` against the stack component path and base.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    private func loadStack() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            async let specTask = HomeboyCLI.shared.stackShow(id: stack.id)
+            async let statusTask = HomeboyCLI.shared.stackStatus(id: stack.id)
+            spec = try await specTask
+            status = try await statusTask
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    private func inspectStackBranch() async {
+        guard let status else { return }
+        isInspecting = true
+        errorMessage = nil
+        do {
+            inspection = try await HomeboyCLI.shared.stackInspect(path: status.componentPath, base: status.base, includePRs: false)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isInspecting = false
+    }
+}
+
+struct StackMetricCard: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption)
+                .foregroundColor(.secondary)
+            Text(value)
+                .font(.title2)
+                .fontWeight(.semibold)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.secondary.opacity(0.08))
+        .cornerRadius(10)
+    }
+}
+
+struct StackPullRequestRow: View {
+    let pr: StackPullRequestStatus
+
+    private var destination: URL? {
+        URL(string: pr.url ?? "https://github.com/\(pr.repo)/pull/\(pr.number)")
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                if let destination {
+                    Link("#\(pr.number) \(pr.title ?? pr.repo)", destination: destination)
+                        .font(.headline)
+                } else {
+                    Text("#\(pr.number) \(pr.title ?? pr.repo)")
+                        .font(.headline)
+                }
+                Text(pr.note ?? pr.repo)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 4) {
+                StackStateBadge(label: pr.upstreamState, color: pr.upstreamState == "MERGED" ? .purple : .blue)
+                StackStateBadge(label: pr.localState, color: pr.localState == "applied" ? .green : .orange)
+                if let reviewDecision = pr.reviewDecision {
+                    Text(reviewDecision)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .padding(10)
+        .background(Color.secondary.opacity(0.08))
+        .cornerRadius(8)
+    }
+}
+
+struct StackStateBadge: View {
+    let label: String
+    let color: Color
+
+    var body: some View {
+        Text(label)
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(color.opacity(0.16))
+            .foregroundColor(color)
+            .cornerRadius(6)
     }
 }
 

--- a/Homeboy/Core/CLI/HomeboyCLI.swift
+++ b/Homeboy/Core/CLI/HomeboyCLI.swift
@@ -1351,6 +1351,59 @@ private init() {}
         )
         return output.snapshots ?? []
     }
+
+    // MARK: - Stack Commands
+
+    func stackList() async throws -> [StackListItem] {
+        let output: StackListOutput = try await cli.executeCommand(
+            ["stack", "list"],
+            dataType: StackListOutput.self,
+            source: "Stack List",
+            timeout: 30
+        )
+        return output.stacks ?? []
+    }
+
+    func stackShow(id: String) async throws -> StackSpec {
+        let output: StackShowOutput = try await cli.executeCommand(
+            ["stack", "show", id],
+            dataType: StackShowOutput.self,
+            source: "Stack Show",
+            timeout: 30
+        )
+        guard let stack = output.stack else {
+            throw CLIBridgeError.invalidResponse("Stack not found: \(id)")
+        }
+        return stack
+    }
+
+    func stackStatus(id: String) async throws -> StackStatusOutput {
+        try await cli.executeCommand(
+            ["stack", "status", id],
+            dataType: StackStatusOutput.self,
+            source: "Stack Status",
+            timeout: 120
+        )
+    }
+
+    func stackInspect(path: String? = nil, base: String? = nil, includePRs: Bool = true) async throws -> StackInspectOutput {
+        var args = ["stack", "inspect"]
+        if let path {
+            args.append(contentsOf: ["--path", path])
+        }
+        if let base {
+            args.append(contentsOf: ["--base", base])
+        }
+        if !includePRs {
+            args.append("--no-pr")
+        }
+        return try await cli.executeCommand(
+            args,
+            dataType: StackInspectOutput.self,
+            source: "Stack Inspect",
+            timeout: 120
+        )
+    }
 }
 
 // MARK: - New Command Output Types
@@ -1528,6 +1581,106 @@ struct UndoSnapshot: Decodable, Identifiable {
     let timestamp: String
     let componentId: String?
     let description: String?
+}
+
+// MARK: - Stack Output Types
+
+struct StackListOutput: Decodable {
+    let command: String
+    let stacks: [StackListItem]?
+}
+
+struct StackListItem: Decodable, Identifiable, Hashable {
+    let id: String
+    let description: String
+    let component: String
+    let componentPath: String
+    let base: String
+    let target: String
+    let prCount: Int
+}
+
+struct StackShowOutput: Decodable {
+    let command: String
+    let stack: StackSpec?
+}
+
+struct StackSpec: Decodable, Identifiable {
+    let id: String
+    let description: String
+    let component: String
+    let componentPath: String
+    let base: StackRef
+    let target: StackRef
+    let prs: [StackPullRequestSpec]
+}
+
+struct StackRef: Decodable {
+    let remote: String
+    let branch: String
+
+    var displayName: String { "\(remote)/\(branch)" }
+}
+
+struct StackPullRequestSpec: Decodable, Identifiable {
+    let repo: String
+    let number: Int
+    let note: String?
+
+    var id: String { "\(repo)#\(number)" }
+}
+
+struct StackStatusOutput: Decodable {
+    let command: String
+    let success: Bool?
+    let stackId: String
+    let componentPath: String
+    let base: String
+    let target: String
+    let targetAhead: Int
+    let targetBehind: Int
+    let mergedCount: Int
+    let prs: [StackPullRequestStatus]
+}
+
+struct StackPullRequestStatus: Decodable, Identifiable {
+    let repo: String
+    let number: Int
+    let note: String?
+    let title: String?
+    let url: String?
+    let upstreamState: String
+    let localState: String
+    let reviewDecision: String?
+
+    var id: String { "\(repo)#\(number)" }
+}
+
+struct StackInspectOutput: Decodable {
+    let command: String
+    let success: Bool?
+    let componentId: String?
+    let path: String
+    let branch: String
+    let base: String
+    let baseAutoDetected: Bool?
+    let mergedCount: Int
+    let commits: [StackInspectedCommit]
+}
+
+struct StackInspectedCommit: Decodable, Identifiable {
+    let sha: String
+    let subject: String
+    let author: String?
+    let date: String?
+    let prNumber: Int?
+    let prTitle: String?
+    let prUrl: String?
+    let prState: String?
+    let prLookupNote: String?
+
+    var id: String { sha }
+    var shortSha: String { String(sha.prefix(8)) }
 }
 
 // MARK: - Fleet Output Types

--- a/tests/ContractTests.swift
+++ b/tests/ContractTests.swift
@@ -99,6 +99,47 @@ struct DbOutput: Decodable {
     let sql: String?
 }
 
+// MARK: - Stack Output Types (mirror HomeboyCLI.swift)
+
+struct StackListOutput: Decodable {
+    let command: String
+    let stacks: [StackListItem]?
+}
+
+struct StackListItem: Decodable {
+    let id: String
+    let description: String
+    let component: String
+    let componentPath: String
+    let base: String
+    let target: String
+    let prCount: Int
+}
+
+struct StackStatusOutput: Decodable {
+    let command: String
+    let success: Bool?
+    let stackId: String
+    let componentPath: String
+    let base: String
+    let target: String
+    let targetAhead: Int
+    let targetBehind: Int
+    let mergedCount: Int
+    let prs: [StackPullRequestStatus]
+}
+
+struct StackPullRequestStatus: Decodable {
+    let repo: String
+    let number: Int
+    let note: String?
+    let title: String?
+    let url: String?
+    let upstreamState: String
+    let localState: String
+    let reviewDecision: String?
+}
+
 // MARK: - Rig Output Types (mirror HomeboyCLI.swift)
 
 enum JSONValueTest: Decodable {
@@ -397,6 +438,9 @@ func runTests(testDir: String) throws {
 
     // Test 16: Rig command JSON contracts
     try testRigContracts(fixturesDir: fixturesDir, decoder: decoder)
+
+    // Test 17: Stack command JSON contracts
+    try testStackContracts(fixturesDir: fixturesDir, decoder: decoder)
 
     print("")
     print("All contract tests passed")
@@ -1221,6 +1265,40 @@ func testRigContracts(fixturesDir: String, decoder: JSONDecoder) throws {
             userInfo: [NSLocalizedDescriptionKey: "rig-check-failed.json failed check details did not decode"])
     }
     print("[PASS] Failed rig check data decodes without requiring success=true")
+    print("")
+}
+
+func testStackContracts(fixturesDir: String, decoder: JSONDecoder) throws {
+    print("Test: stack command contracts")
+    print("-----------------------------")
+
+    let listData = try Data(contentsOf: URL(fileURLWithPath: "\(fixturesDir)/stack-list.json"))
+    let listResult = try decoder.decode(CLIResponse<StackListOutput>.self, from: listData)
+    guard listResult.success, let stacks = listResult.data?.stacks, stacks.count == 1 else {
+        throw NSError(domain: "ContractTest", code: 90,
+            userInfo: [NSLocalizedDescriptionKey: "stack-list.json did not decode one stack"])
+    }
+    guard stacks[0].id == "studio-combined", stacks[0].prCount == 5 else {
+        throw NSError(domain: "ContractTest", code: 91,
+            userInfo: [NSLocalizedDescriptionKey: "stack-list.json summary fields did not decode"])
+    }
+    print("[PASS] Stack list summary decodes")
+
+    let statusData = try Data(contentsOf: URL(fileURLWithPath: "\(fixturesDir)/stack-status.json"))
+    let statusResult = try decoder.decode(CLIResponse<StackStatusOutput>.self, from: statusData)
+    guard statusResult.success, let status = statusResult.data else {
+        throw NSError(domain: "ContractTest", code: 92,
+            userInfo: [NSLocalizedDescriptionKey: "stack-status.json did not decode status data"])
+    }
+    guard status.stackId == "studio-combined", status.targetAhead == 7, status.targetBehind == 8 else {
+        throw NSError(domain: "ContractTest", code: 93,
+            userInfo: [NSLocalizedDescriptionKey: "stack-status.json target state did not decode"])
+    }
+    guard status.prs.first?.localState == "missing", status.prs.first?.reviewDecision == "REVIEW_REQUIRED" else {
+        throw NSError(domain: "ContractTest", code: 94,
+            userInfo: [NSLocalizedDescriptionKey: "stack-status.json PR state did not decode"])
+    }
+    print("[PASS] Stack status PR state decodes")
     print("")
 }
 

--- a/tests/fixtures/stack-list.json
+++ b/tests/fixtures/stack-list.json
@@ -1,0 +1,17 @@
+{
+  "success": true,
+  "data": {
+    "command": "stack.list",
+    "stacks": [
+      {
+        "base": "origin/trunk",
+        "component": "studio",
+        "component_path": "~/Developer/studio",
+        "description": "Studio dev/combined-fixes stack",
+        "id": "studio-combined",
+        "pr_count": 5,
+        "target": "fork/dev/combined-fixes"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/stack-status.json
+++ b/tests/fixtures/stack-status.json
@@ -1,0 +1,26 @@
+{
+  "success": true,
+  "data": {
+    "base": "origin/trunk",
+    "command": "stack.status",
+    "component_path": "/Users/chubes/Developer/studio",
+    "merged_count": 1,
+    "prs": [
+      {
+        "local_state": "missing",
+        "note": "Forward host stdin to wp-cli through the server daemon",
+        "number": 3211,
+        "repo": "Automattic/studio",
+        "review_decision": "REVIEW_REQUIRED",
+        "title": "Forward host stdin to wp-cli through the server daemon",
+        "upstream_state": "OPEN",
+        "url": "https://github.com/Automattic/studio/pull/3211"
+      }
+    ],
+    "stack_id": "studio-combined",
+    "success": true,
+    "target": "fork/dev/combined-fixes",
+    "target_ahead": 7,
+    "target_behind": 8
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a read-only Stack Manager screen for configured `homeboy stack` specs.
- Adds CLI models/wrappers for `stack list`, `show`, `status`, and read-only `inspect`.
- Adds contract fixtures for stack list/status JSON decoding.

## Tests
- `swift tests/ContractTests.swift tests`
- `swiftc -parse Homeboy/App/ContentView.swift Homeboy/Core/CLI/HomeboyCLI.swift Homeboy/Core/CLI/CLIBridge.swift`
- `homeboy stack --help`
- `homeboy stack list`

Full app build not run locally: `xcodebuild` requires Xcode, but this host is currently selected to Command Line Tools only.

Closes #33

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the desktop stack manager; Chris to review before merge.
