### PR TITLE
Add desktop rig management workflow

### DIFF
--- a/Homeboy.xcodeproj/project.pbxproj
+++ b/Homeboy.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		0BB5245A79F8709EBD8C5269 /* ModuleInstallSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA1C2F245C5FCEF82A5D2D3 /* ModuleInstallSheet.swift */; };
 		0FE6351E7C94950D6A459978 /* DeployerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F978C6E7F1C5288FF7303DF7 /* DeployerView.swift */; };
 		1162E40A1D0549D9B68608A8 /* BenchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1162E4091D0549D9B68608A8 /* BenchView.swift */; };
+		102A2F3B4C5D6E7F8091A2B3 /* RigsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3B4C5D6E7F8091A2B3102A /* RigsView.swift */; };
+		1A2B3102F3B4C5D6E7F8091A /* RigsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4C5D6E7F8091A2B3102A2F /* RigsViewModel.swift */; };
 		1A164D8DD4607926F6964B95 /* CopyableContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5BD1368E35CA013C4E064C8 /* CopyableContent.swift */; };
 		1D8C5CFC6CC66D4D2059241A /* CLIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0B9A725382C46F30D83C02 /* CLIError.swift */; };
 		1E0233CF5AC026C74233786E /* TableDataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EC7ED01925DBCB9195A8A4D /* TableDataView.swift */; };
@@ -118,9 +120,11 @@
 		21BD4D2024772E1CFC5F01C2 /* ModuleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleViewModel.swift; sourceTree = "<group>"; };
 		267B4789567169ABFC9AAD53 /* ModuleManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleManifest.swift; sourceTree = "<group>"; };
 		29EDC4F278327A663263D4A7 /* DatabaseBrowserViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseBrowserViewModel.swift; sourceTree = "<group>"; };
+		2F3B4C5D6E7F8091A2B3102A /* RigsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RigsView.swift; sourceTree = "<group>"; };
 		2DA1C2F245C5FCEF82A5D2D3 /* ModuleInstallSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleInstallSheet.swift; sourceTree = "<group>"; };
 		2E7289F91C0EA517A3DE5DB9 /* RemoteFileBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileBrowser.swift; sourceTree = "<group>"; };
 		2EC7ED01925DBCB9195A8A4D /* TableDataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableDataView.swift; sourceTree = "<group>"; };
+		3B4C5D6E7F8091A2B3102A2F /* RigsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RigsViewModel.swift; sourceTree = "<group>"; };
 		385944CD36C9E1B61CE23EDE /* FindableTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindableTextView.swift; sourceTree = "<group>"; };
 		3A6FE3DEAD139D529B6724D8 /* APITypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITypes.swift; sourceTree = "<group>"; };
 		3A80F92FC849ACD9591EDEFE /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
@@ -379,6 +383,7 @@
 			children = (
 				8007D7D3CCEF3F80C36AA686 /* Components */,
 				E900FE3D44D913C0F5C320A7 /* Modules */,
+				4C5D6E7F8091A2B3102A2F3B /* Rigs */,
 				F08C0BC0AC87CDDCAA5955CF /* Settings */,
 				1162E4091D0549D9B68608A8 /* BenchView.swift */,
 				3A80F92FC849ACD9591EDEFE /* LoginView.swift */,
@@ -396,6 +401,15 @@
 				21BD4D2024772E1CFC5F01C2 /* ModuleViewModel.swift */,
 			);
 			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		4C5D6E7F8091A2B3102A2F3B /* Rigs */ = {
+			isa = PBXGroup;
+			children = (
+				2F3B4C5D6E7F8091A2B3102A /* RigsView.swift */,
+				3B4C5D6E7F8091A2B3102A2F /* RigsViewModel.swift */,
+			);
+			path = Rigs;
 			sourceTree = "<group>";
 		};
 		8007D7D3CCEF3F80C36AA686 /* Components */ = {
@@ -700,6 +714,8 @@
 				80D12DD221BE19316CB0BDCA /* RemoteLogViewerViewModel.swift in Sources */,
 				C24FBE4BE4FE4BA046D565C3 /* RemotePathResolver+WordPress.swift in Sources */,
 				465D0E037B7E2705A578EAF2 /* RemotePathResolver.swift in Sources */,
+				102A2F3B4C5D6E7F8091A2B3 /* RigsView.swift in Sources */,
+				1A2B3102F3B4C5D6E7F8091A /* RigsViewModel.swift in Sources */,
 				58C9903BC07607162259D792 /* SSHKeyManager.swift in Sources */,
 				71419F89166E98CC7C4A3A98 /* SSHService.swift in Sources */,
 				E8A0E0A1E7364CFEB6EB48AF /* SchemaResolver.swift in Sources */,

--- a/Homeboy/App/ContentView.swift
+++ b/Homeboy/App/ContentView.swift
@@ -15,6 +15,7 @@ enum CoreTool: String, CaseIterable, Identifiable {
     case deployer = "Deployer"
     case bench = "Bench"
     case release = "Release"
+    case rigs = "Rigs"
     case remoteFileEditor = "File Editor"
     case remoteLogViewer = "Log Viewer"
     case databaseBrowser = "Database"
@@ -27,6 +28,7 @@ enum CoreTool: String, CaseIterable, Identifiable {
         case .deployer: return "arrow.up.to.line"
         case .bench: return "speedometer"
         case .release: return "tag"
+        case .rigs: return "shippingbox.and.arrow.backward"
         case .remoteFileEditor: return "doc.badge.gearshape"
         case .remoteLogViewer: return "doc.text.magnifyingglass"
         case .databaseBrowser: return "cylinder.split.1x2"
@@ -71,6 +73,8 @@ struct ContentView: View {
                 .opacity(selectedItem == .coreTool(.bench) ? 1 : 0)
             ReleaseWorkflowView()
                 .opacity(selectedItem == .coreTool(.release) ? 1 : 0)
+            RigsView()
+                .opacity(selectedItem == .coreTool(.rigs) ? 1 : 0)
             DatabaseBrowserView()
                 .opacity(selectedItem == .coreTool(.databaseBrowser) ? 1 : 0)
             RemoteLogViewerView()

--- a/Homeboy/Core/CLI/HomeboyCLI.swift
+++ b/Homeboy/Core/CLI/HomeboyCLI.swift
@@ -765,6 +765,94 @@ private init() {}
         )
     }
 
+    // MARK: - Rig Commands
+
+    func rigList() async throws -> [RigListItem] {
+        let output: RigListOutput = try await cli.executeCommand(
+            ["rig", "list"],
+            dataType: RigListOutput.self,
+            source: "Rig List"
+        )
+        return output.rigs ?? []
+    }
+
+    func rigShow(id: String) async throws -> RigSpec {
+        let output: RigShowOutput = try await cli.executeCommand(
+            ["rig", "show", id],
+            dataType: RigShowOutput.self,
+            source: "Rig Show"
+        )
+        guard let rig = output.rig else {
+            throw CLIBridgeError.invalidResponse("Rig not found: \(id)")
+        }
+        return rig
+    }
+
+    func rigStatus(id: String) async throws -> RigStatusOutput {
+        try await cli.executeCommand(
+            ["rig", "status", id],
+            dataType: RigStatusOutput.self,
+            source: "Rig Status",
+            timeout: 60
+        )
+    }
+
+    func rigCheck(id: String) async throws -> RigCommandResult<RigCheckOutput> {
+        try await runRigCommand(["rig", "check", id], dataType: RigCheckOutput.self, source: "Rig Check", timeout: 180)
+    }
+
+    func rigUp(id: String) async throws -> RigCommandResult<RigLifecycleOutput> {
+        try await runRigCommand(["rig", "up", id], dataType: RigLifecycleOutput.self, source: "Rig Up", timeout: 900)
+    }
+
+    func rigDown(id: String) async throws -> RigCommandResult<RigLifecycleOutput> {
+        try await runRigCommand(["rig", "down", id], dataType: RigLifecycleOutput.self, source: "Rig Down", timeout: 300)
+    }
+
+    private func runRigCommand<T: Decodable>(
+        _ args: [String],
+        dataType: T.Type,
+        source: String,
+        timeout: TimeInterval
+    ) async throws -> RigCommandResult<T> {
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("homeboy-rig-\(UUID().uuidString).json")
+        var commandArgs = args
+        if commandArgs.first == "rig" {
+            commandArgs.insert(contentsOf: ["--output", outputURL.path], at: 1)
+        }
+
+        let response = try await cli.execute(commandArgs, timeout: timeout)
+        let structuredOutput = (try? String(contentsOf: outputURL, encoding: .utf8)).flatMap { value in
+            value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : value
+        } ?? response.output
+        try? FileManager.default.removeItem(at: outputURL)
+
+        guard let data = structuredOutput.data(using: .utf8) else {
+            throw CLIBridgeError.invalidResponse("\(source) output is not valid UTF-8")
+        }
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let result = try decoder.decode(CLIBridgeResult<T>.self, from: data)
+
+        if let data = result.data {
+            return RigCommandResult(
+                success: result.success,
+                data: data,
+                rawOutput: response.output.isEmpty ? structuredOutput : response.output,
+                errorOutput: response.errorOutput,
+                exitCode: response.exitCode
+            )
+        }
+
+        if let errorDetail = result.error {
+            throw CLIBridgeError.cliError(errorDetail.toCLIError(source: source))
+        }
+
+        throw CLIBridgeError.invalidResponse("\(source) response missing data")
+    }
+
 // MARK: - Component Commands
 
     func componentList() async throws -> [ComponentListItemCLI] {
@@ -1528,4 +1616,128 @@ struct FleetExecResult: Decodable, Identifiable {
     let error: String?
 
     var id: String { projectId }
+}
+
+// MARK: - Rig Output Types
+
+struct RigCommandResult<T: Decodable> {
+    let success: Bool
+    let data: T
+    let rawOutput: String
+    let errorOutput: String
+    let exitCode: Int32
+}
+
+struct RigListOutput: Decodable {
+    let command: String
+    let rigs: [RigListItem]?
+}
+
+struct RigListItem: Decodable, Identifiable {
+    let id: String
+    let declaredId: String?
+    let description: String?
+    let pipelines: [String]
+    let componentCount: Int
+    let serviceCount: Int
+    let source: RigSource?
+}
+
+struct RigSource: Decodable {
+    let source: String?
+    let packagePath: String?
+    let rigPath: String?
+    let linked: Bool?
+}
+
+struct RigShowOutput: Decodable {
+    let command: String
+    let rig: RigSpec?
+}
+
+struct RigSpec: Decodable, Identifiable {
+    let id: String
+    let description: String?
+    let components: [String: RigComponent]
+    let services: [String: JSONValue]?
+    let symlinks: [JSONValue]?
+    let pipeline: [String: [RigStep]]?
+}
+
+struct RigComponent: Decodable, Identifiable {
+    let path: String
+    let branch: String?
+    let stack: String?
+
+    var id: String { path }
+}
+
+struct RigStep: Decodable, Identifiable {
+    let kind: String
+    let label: String?
+    let idValue: String?
+    let op: String?
+    let component: String?
+    let command: String?
+
+    var id: String { [kind, label, idValue, op, component, command].compactMap { $0 }.joined(separator: ":") }
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case label
+        case idValue = "id"
+        case op
+        case component
+        case command
+    }
+}
+
+struct RigStatusOutput: Decodable {
+    let command: String
+    let rigId: String
+    let description: String?
+    let lastUp: String?
+    let lastCheck: String?
+    let lastCheckResult: String?
+    let services: [RigServiceStatus]
+}
+
+struct RigServiceStatus: Decodable, Identifiable {
+    let id: String
+    let kind: String
+    let status: String
+    let port: Int?
+    let pid: Int?
+    let startedAt: String?
+    let logPath: String?
+}
+
+struct RigCheckOutput: Decodable {
+    let command: String
+    let rigId: String
+    let success: Bool
+    let pipeline: RigPipelineResult
+}
+
+struct RigLifecycleOutput: Decodable {
+    let command: String
+    let rigId: String?
+    let success: Bool?
+    let pipeline: RigPipelineResult?
+}
+
+struct RigPipelineResult: Decodable {
+    let name: String
+    let passed: Int?
+    let failed: Int?
+    let steps: [RigPipelineStep]
+}
+
+struct RigPipelineStep: Decodable, Identifiable {
+    let kind: String
+    let label: String
+    let status: String
+    let error: String?
+
+    var id: String { "\(kind):\(label)" }
 }

--- a/Homeboy/Views/Rigs/RigsView.swift
+++ b/Homeboy/Views/Rigs/RigsView.swift
@@ -1,0 +1,386 @@
+import SwiftUI
+
+struct RigsView: View {
+    @StateObject private var viewModel = RigsViewModel()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+
+            if viewModel.isLoading && viewModel.rigs.isEmpty {
+                ProgressView("Loading rigs...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if viewModel.rigs.isEmpty {
+                emptyState
+            } else {
+                HSplitView {
+                    rigList
+                        .frame(minWidth: 280, idealWidth: 340, maxWidth: 420)
+                    rigDetail
+                        .frame(minWidth: 520)
+                }
+            }
+        }
+        .frame(minWidth: 900, minHeight: 620)
+        .onAppear {
+            if viewModel.rigs.isEmpty {
+                viewModel.load()
+            }
+        }
+        .alert(item: $viewModel.pendingMutatingAction) { action in
+            Alert(
+                title: Text(action.title),
+                message: Text("This runs `homeboy rig \(action.rawValue) \(viewModel.selectedRigID ?? "")`. It may start or stop local services and modify development checkouts."),
+                primaryButton: .destructive(Text("Run \(action.rawValue)")) {
+                    viewModel.runPendingMutatingAction()
+                },
+                secondaryButton: .cancel()
+            )
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Rigs")
+                    .font(.title2.bold())
+                Text("Inspect and check reproducible Homeboy development environments")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            if let running = viewModel.runningCommand {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Running \(running)...")
+                    .foregroundColor(.secondary)
+            }
+
+            Button {
+                viewModel.load()
+            } label: {
+                Label("Refresh", systemImage: "arrow.clockwise")
+            }
+            .buttonStyle(.bordered)
+            .disabled(viewModel.isRunningCommand)
+        }
+        .padding()
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "shippingbox")
+                .font(.system(size: 48))
+                .foregroundColor(.secondary)
+            Text("No Rigs Found")
+                .font(.headline)
+            Text("Create rigs with the Homeboy CLI, then return here to inspect and check them.")
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var rigList: some View {
+        List(selection: $viewModel.selectedRigID) {
+            ForEach(viewModel.rigs) { rig in
+                Button {
+                    viewModel.selectRig(rig.id)
+                } label: {
+                    RigRow(rig: rig)
+                }
+                .buttonStyle(.plain)
+                .tag(rig.id)
+            }
+        }
+        .listStyle(.sidebar)
+    }
+
+    private var rigDetail: some View {
+        VStack(spacing: 0) {
+            if let rig = viewModel.selectedRig {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        selectedRigHeader(rig)
+
+                        if let error = viewModel.error {
+                            InlineErrorView(error)
+                        }
+
+                        actionBar
+                        statusSection
+                        checkSection
+                        specSection(rig)
+                        consoleSection
+                    }
+                    .padding()
+                }
+            } else {
+                ContentUnavailableView(
+                    "Select a Rig",
+                    systemImage: "shippingbox",
+                    description: Text("Choose a rig from the sidebar to inspect it")
+                )
+            }
+        }
+    }
+
+    private func selectedRigHeader(_ rig: RigSpec) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(rig.id)
+                .font(.title.bold())
+                .textSelection(.enabled)
+            if let description = rig.description, !description.isEmpty {
+                Text(description)
+                    .foregroundColor(.secondary)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+
+    private var actionBar: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Read-only")
+                .font(.caption.bold())
+                .foregroundColor(.secondary)
+            HStack {
+                Button {
+                    viewModel.runStatus()
+                } label: {
+                    Label("Status", systemImage: "list.bullet.rectangle")
+                }
+                .buttonStyle(.bordered)
+
+                Button {
+                    viewModel.runCheck()
+                } label: {
+                    Label("Check", systemImage: "checkmark.seal")
+                }
+                .buttonStyle(.borderedProminent)
+
+                Divider()
+
+                Text("Lifecycle")
+                    .font(.caption.bold())
+                    .foregroundColor(.secondary)
+
+                Button("Up") {
+                    viewModel.confirmMutatingAction(.up)
+                }
+                .buttonStyle(.bordered)
+
+                Button("Down") {
+                    viewModel.confirmMutatingAction(.down)
+                }
+                .buttonStyle(.bordered)
+
+                Spacer()
+
+                Button("Clear Output") {
+                    viewModel.clearConsole()
+                }
+                .buttonStyle(.borderless)
+                .disabled(viewModel.consoleOutput.isEmpty)
+            }
+            .disabled(viewModel.isRunningCommand)
+        }
+        .padding()
+        .background(Color(nsColor: .controlBackgroundColor))
+        .cornerRadius(8)
+    }
+
+    private var statusSection: some View {
+        GroupBox("Status") {
+            if let status = viewModel.status {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 12) {
+                        infoPill(label: "Last check", value: status.lastCheckResult ?? "unknown")
+                        infoPill(label: "Checked", value: status.lastCheck ?? "never")
+                        infoPill(label: "Last up", value: status.lastUp ?? "never")
+                    }
+
+                    if status.services.isEmpty {
+                        Text("No services declared")
+                            .foregroundColor(.secondary)
+                    } else {
+                        ForEach(status.services) { service in
+                            HStack {
+                                Image(systemName: service.status == "running" ? "checkmark.circle.fill" : "circle")
+                                    .foregroundColor(service.status == "running" ? .green : .secondary)
+                                Text(service.id)
+                                    .font(.body.monospaced())
+                                Text(service.kind)
+                                    .foregroundColor(.secondary)
+                                Spacer()
+                                Text(service.status)
+                                    .font(.caption.bold())
+                                if let port = service.port {
+                                    Text(":\(port)")
+                                        .font(.caption.monospaced())
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                Text("Run Status to load service state.")
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private var checkSection: some View {
+        GroupBox("Latest Check") {
+            if let check = viewModel.checkResult {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Image(systemName: check.success ? "checkmark.circle.fill" : "xmark.octagon.fill")
+                            .foregroundColor(check.success ? .green : .red)
+                        Text(check.success ? "Passed" : "Failed")
+                            .font(.headline)
+                        Spacer()
+                        Text("\(check.pipeline.passed ?? 0) passed / \(check.pipeline.failed ?? 0) failed")
+                            .foregroundColor(.secondary)
+                    }
+
+                    ForEach(check.pipeline.steps) { step in
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Image(systemName: step.status == "pass" ? "checkmark.circle" : "xmark.circle")
+                                    .foregroundColor(step.status == "pass" ? .green : .red)
+                                Text(step.label)
+                                Spacer()
+                                Text(step.kind)
+                                    .font(.caption.monospaced())
+                                    .foregroundColor(.secondary)
+                            }
+                            if let error = step.error {
+                                Text(error)
+                                    .font(.caption.monospaced())
+                                    .foregroundColor(.red)
+                                    .textSelection(.enabled)
+                            }
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                Text("Run Check to validate this rig.")
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private func specSection(_ rig: RigSpec) -> some View {
+        GroupBox("Spec") {
+            VStack(alignment: .leading, spacing: 12) {
+                specSummary(rig)
+
+                if !rig.components.isEmpty {
+                    Text("Components")
+                        .font(.headline)
+                    ForEach(rig.components.keys.sorted(), id: \.self) { id in
+                        if let component = rig.components[id] {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(id)
+                                    .font(.body.monospaced().bold())
+                                Text(component.path)
+                                    .font(.caption.monospaced())
+                                    .foregroundColor(.secondary)
+                                    .textSelection(.enabled)
+                                if let branch = component.branch {
+                                    Text("branch: \(branch)")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func specSummary(_ rig: RigSpec) -> some View {
+        HStack(spacing: 12) {
+            infoPill(label: "Components", value: "\(rig.components.count)")
+            infoPill(label: "Services", value: "\(rig.services?.count ?? 0)")
+            infoPill(label: "Symlinks", value: "\(rig.symlinks?.count ?? 0)")
+            infoPill(label: "Pipelines", value: rig.pipeline?.keys.sorted().joined(separator: ", ") ?? "none")
+        }
+    }
+
+    private var consoleSection: some View {
+        GroupBox("Command Output") {
+            if viewModel.consoleOutput.isEmpty {
+                Text("Command output will appear here and can be copied.")
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                CopyableTextView(console: viewModel.consoleOutput, source: "Rigs", maxHeight: 280)
+            }
+        }
+    }
+
+    private func infoPill(label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.caption2.bold())
+                .foregroundColor(.secondary)
+            Text(value)
+                .font(.caption.monospaced())
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(Color(nsColor: .textBackgroundColor))
+        .cornerRadius(6)
+    }
+}
+
+private struct RigRow: View {
+    let rig: RigListItem
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(rig.id)
+                    .font(.headline)
+                Spacer()
+                if rig.source?.linked == true {
+                    Image(systemName: "link")
+                        .foregroundColor(.secondary)
+                        .help("Installed from linked source")
+                }
+            }
+
+            if let description = rig.description, !description.isEmpty {
+                Text(description)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
+            }
+
+            HStack(spacing: 8) {
+                Text("\(rig.componentCount) components")
+                Text("\(rig.serviceCount) services")
+                Text(rig.pipelines.joined(separator: ", "))
+            }
+            .font(.caption2)
+            .foregroundColor(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+#Preview {
+    RigsView()
+}

--- a/Homeboy/Views/Rigs/RigsViewModel.swift
+++ b/Homeboy/Views/Rigs/RigsViewModel.swift
@@ -1,0 +1,185 @@
+import Foundation
+
+@MainActor
+final class RigsViewModel: ObservableObject {
+    enum MutatingAction: String, Identifiable {
+        case up = "up"
+        case down = "down"
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .up: return "Run Rig Up"
+            case .down: return "Run Rig Down"
+            }
+        }
+    }
+
+    @Published var rigs: [RigListItem] = []
+    @Published var selectedRigID: String?
+    @Published var selectedRig: RigSpec?
+    @Published var status: RigStatusOutput?
+    @Published var checkResult: RigCheckOutput?
+    @Published var consoleOutput = ""
+    @Published var isLoading = false
+    @Published var runningCommand: String?
+    @Published var error: (any DisplayableError)?
+    @Published var pendingMutatingAction: MutatingAction?
+
+    var selectedRigListItem: RigListItem? {
+        rigs.first { $0.id == selectedRigID }
+    }
+
+    var isRunningCommand: Bool {
+        runningCommand != nil
+    }
+
+    func load() {
+        guard HomeboyCLI.shared.isInstalled else {
+            error = AppError("Homeboy CLI is not installed. Install via Settings → CLI.", source: "Rigs")
+            return
+        }
+
+        isLoading = true
+        error = nil
+
+        Task {
+            do {
+                let loaded = try await HomeboyCLI.shared.rigList()
+                rigs = loaded
+                isLoading = false
+
+                if selectedRigID == nil || !loaded.contains(where: { $0.id == selectedRigID }) {
+                    selectedRigID = loaded.first?.id
+                }
+
+                if let id = selectedRigID {
+                    await loadRig(id: id)
+                }
+            } catch {
+                isLoading = false
+                self.error = error.toDisplayableError(source: "Rigs")
+                appendConsole("> Error: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func selectRig(_ id: String) {
+        guard selectedRigID != id else { return }
+        selectedRigID = id
+        selectedRig = nil
+        status = nil
+        checkResult = nil
+
+        Task {
+            await loadRig(id: id)
+        }
+    }
+
+    func refreshSelectedRig() {
+        guard let id = selectedRigID else { return }
+        Task {
+            await loadRig(id: id)
+        }
+    }
+
+    func runStatus() {
+        guard let id = selectedRigID else { return }
+        runReadOnlyCommand(name: "status", id: id) {
+            let output = try await HomeboyCLI.shared.rigStatus(id: id)
+            self.status = output
+            self.appendConsole("\(output.services.count) service(s) reported")
+        }
+    }
+
+    func runCheck() {
+        guard let id = selectedRigID else { return }
+        runCommand(name: "check", id: id) {
+            let result = try await HomeboyCLI.shared.rigCheck(id: id)
+            self.checkResult = result.data
+            self.appendConsole(result.rawOutput)
+
+            if !result.errorOutput.isEmpty {
+                self.appendConsole(result.errorOutput)
+            }
+        }
+    }
+
+    func confirmMutatingAction(_ action: MutatingAction) {
+        pendingMutatingAction = action
+    }
+
+    func runPendingMutatingAction() {
+        guard let action = pendingMutatingAction, let id = selectedRigID else { return }
+        pendingMutatingAction = nil
+
+        runCommand(name: action.rawValue, id: id) {
+            let result: RigCommandResult<RigLifecycleOutput>
+            switch action {
+            case .up:
+                result = try await HomeboyCLI.shared.rigUp(id: id)
+            case .down:
+                result = try await HomeboyCLI.shared.rigDown(id: id)
+            }
+
+            self.appendConsole(result.rawOutput)
+
+            if !result.errorOutput.isEmpty {
+                self.appendConsole(result.errorOutput)
+            }
+
+            await self.loadRig(id: id)
+        }
+    }
+
+    func clearConsole() {
+        consoleOutput = ""
+    }
+
+    private func loadRig(id: String) async {
+        do {
+            async let specTask = HomeboyCLI.shared.rigShow(id: id)
+            async let statusTask = HomeboyCLI.shared.rigStatus(id: id)
+            selectedRig = try await specTask
+            status = try await statusTask
+        } catch {
+            self.error = error.toDisplayableError(source: "Rigs")
+            appendConsole("> Error loading \(id): \(error.localizedDescription)")
+        }
+    }
+
+    private func runReadOnlyCommand(name: String, id: String, operation: @escaping () async throws -> Void) {
+        runCommand(name: name, id: id, operation: operation)
+    }
+
+    private func runCommand(name: String, id: String, operation: @escaping () async throws -> Void) {
+        guard runningCommand == nil else { return }
+
+        runningCommand = name
+        error = nil
+        appendConsole("> homeboy rig \(name) \(id)")
+
+        Task {
+            do {
+                try await operation()
+            } catch {
+                self.error = error.toDisplayableError(source: "Rigs")
+                appendConsole("> Error: \(error.localizedDescription)")
+            }
+
+            runningCommand = nil
+        }
+    }
+
+    private func appendConsole(_ text: String) {
+        guard !text.isEmpty else { return }
+        if !consoleOutput.isEmpty && !consoleOutput.hasSuffix("\n") {
+            consoleOutput += "\n"
+        }
+        consoleOutput += text
+        if !consoleOutput.hasSuffix("\n") {
+            consoleOutput += "\n"
+        }
+    }
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -59,7 +59,7 @@ The desktop app expects servers to be editable in Settings, and uses the CLI for
 
 For canonical server command docs and JSON output, run `homeboy docs server`.
 
-### wp / pm2 / db / deploy / ssh / logs / file / extension
+### wp / pm2 / db / deploy / ssh / logs / file / extension / rig
 
 These areas are implemented by the CLI and surfaced by the desktop app via `CLIBridge`.
 

--- a/tests/ContractTests.swift
+++ b/tests/ContractTests.swift
@@ -99,6 +99,97 @@ struct DbOutput: Decodable {
     let sql: String?
 }
 
+// MARK: - Rig Output Types (mirror HomeboyCLI.swift)
+
+enum JSONValueTest: Decodable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+    case null
+    case array([JSONValueTest])
+    case object([String: JSONValueTest])
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode([JSONValueTest].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: JSONValueTest].self) {
+            self = .object(value)
+        } else {
+            throw DecodingError.typeMismatch(JSONValueTest.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Unable to decode JSON value"))
+        }
+    }
+}
+
+struct RigListOutputTest: Decodable {
+    let command: String
+    let rigs: [RigListItemTest]?
+}
+
+struct RigListItemTest: Decodable {
+    let id: String
+    let description: String?
+    let pipelines: [String]
+    let componentCount: Int
+    let serviceCount: Int
+}
+
+struct RigShowOutputTest: Decodable {
+    let command: String
+    let rig: RigSpecTest?
+}
+
+struct RigSpecTest: Decodable {
+    let id: String
+    let description: String?
+    let components: [String: RigComponentTest]
+    let services: [String: JSONValueTest]?
+    let symlinks: [JSONValueTest]?
+    let pipeline: [String: [RigStepTest]]?
+}
+
+struct RigComponentTest: Decodable {
+    let path: String
+    let branch: String?
+}
+
+struct RigStepTest: Decodable {
+    let kind: String
+    let label: String?
+}
+
+struct RigCheckOutputTest: Decodable {
+    let command: String
+    let rigId: String
+    let success: Bool
+    let pipeline: RigPipelineResultTest
+}
+
+struct RigPipelineResultTest: Decodable {
+    let name: String
+    let passed: Int?
+    let failed: Int?
+    let steps: [RigPipelineStepTest]
+}
+
+struct RigPipelineStepTest: Decodable {
+    let kind: String
+    let label: String
+    let status: String
+    let error: String?
+}
+
 struct WPTable: Decodable {
     let Name: String
     let Rows: String?
@@ -303,6 +394,9 @@ func runTests(testDir: String) throws {
 
     // Test 15: release/build planning command shapes
     try testReleaseBuildPlanningCommandShapes()
+
+    // Test 16: Rig command JSON contracts
+    try testRigContracts(fixturesDir: fixturesDir, decoder: decoder)
 
     print("")
     print("All contract tests passed")
@@ -1072,6 +1166,61 @@ func testBenchResult(fixturesDir: String, decoder: JSONDecoder) throws {
             userInfo: [NSLocalizedDescriptionKey: "Baseline comparison regression flag mismatch"])
     }
     print("[PASS] Baseline comparison decodes")
+    print("")
+}
+
+func testRigContracts(fixturesDir: String, decoder: JSONDecoder) throws {
+    print("Test: rig command contracts")
+    print("---------------------------")
+
+    let listFixture = URL(fileURLWithPath: "\(fixturesDir)/rig-list.json")
+    let showFixture = URL(fileURLWithPath: "\(fixturesDir)/rig-show.json")
+    let checkFixture = URL(fileURLWithPath: "\(fixturesDir)/rig-check-failed.json")
+
+    let listData = try Data(contentsOf: listFixture)
+    let listResult = try decoder.decode(CLIResponse<RigListOutputTest>.self, from: listData)
+    guard listResult.success, let list = listResult.data, let rigs = list.rigs, !rigs.isEmpty else {
+        throw NSError(domain: "ContractTest", code: 80,
+            userInfo: [NSLocalizedDescriptionKey: "rig-list.json did not decode rigs"])
+    }
+    print("[PASS] Decoded rig list with \(rigs.count) rig(s)")
+
+    let firstRig = rigs[0]
+    guard firstRig.componentCount == 2, firstRig.serviceCount == 1 else {
+        throw NSError(domain: "ContractTest", code: 81,
+            userInfo: [NSLocalizedDescriptionKey: "rig-list.json counts did not decode"])
+    }
+    print("[PASS] Rig list counts decode")
+
+    let showData = try Data(contentsOf: showFixture)
+    let showResult = try decoder.decode(CLIResponse<RigShowOutputTest>.self, from: showData)
+    guard showResult.success, let spec = showResult.data?.rig else {
+        throw NSError(domain: "ContractTest", code: 82,
+            userInfo: [NSLocalizedDescriptionKey: "rig-show.json did not decode rig spec"])
+    }
+    guard spec.components.keys.sorted() == ["studio", "wordpress-playground"] else {
+        throw NSError(domain: "ContractTest", code: 83,
+            userInfo: [NSLocalizedDescriptionKey: "rig-show.json component map did not decode"])
+    }
+    print("[PASS] Rig spec component map decodes")
+
+    guard spec.pipeline?["check"]?.count == 2 else {
+        throw NSError(domain: "ContractTest", code: 84,
+            userInfo: [NSLocalizedDescriptionKey: "rig-show.json check pipeline did not decode"])
+    }
+    print("[PASS] Rig spec pipeline steps decode")
+
+    let checkData = try Data(contentsOf: checkFixture)
+    let checkResult = try decoder.decode(CLIResponse<RigCheckOutputTest>.self, from: checkData)
+    guard checkResult.success == false, let check = checkResult.data else {
+        throw NSError(domain: "ContractTest", code: 85,
+            userInfo: [NSLocalizedDescriptionKey: "rig-check-failed.json should decode failed envelope with data"])
+    }
+    guard check.success == false, check.pipeline.failed == 1 else {
+        throw NSError(domain: "ContractTest", code: 86,
+            userInfo: [NSLocalizedDescriptionKey: "rig-check-failed.json failed check details did not decode"])
+    }
+    print("[PASS] Failed rig check data decodes without requiring success=true")
     print("")
 }
 

--- a/tests/fixtures/rig-check-failed.json
+++ b/tests/fixtures/rig-check-failed.json
@@ -1,0 +1,26 @@
+{
+  "success": false,
+  "data": {
+    "command": "rig.check",
+    "pipeline": {
+      "failed": 1,
+      "name": "check",
+      "passed": 1,
+      "steps": [
+        {
+          "kind": "check",
+          "label": "Docker daemon running",
+          "status": "pass"
+        },
+        {
+          "error": "Command exited 1 (expected 0)",
+          "kind": "check",
+          "label": "Live proc_open end-to-end",
+          "status": "fail"
+        }
+      ]
+    },
+    "rig_id": "studio",
+    "success": false
+  }
+}

--- a/tests/fixtures/rig-list.json
+++ b/tests/fixtures/rig-list.json
@@ -1,0 +1,15 @@
+{
+  "success": true,
+  "data": {
+    "command": "rig.list",
+    "rigs": [
+      {
+        "component_count": 2,
+        "description": "Studio dev rig",
+        "id": "studio",
+        "pipelines": ["check", "down", "up"],
+        "service_count": 1
+      }
+    ]
+  }
+}

--- a/tests/fixtures/rig-show.json
+++ b/tests/fixtures/rig-show.json
@@ -1,0 +1,58 @@
+{
+  "success": true,
+  "data": {
+    "command": "rig.show",
+    "rig": {
+      "components": {
+        "studio": {
+          "branch": "dev/combined-fixes",
+          "path": "~/Developer/studio"
+        },
+        "wordpress-playground": {
+          "branch": "dev/combined-fixes",
+          "path": "~/Developer/wordpress-playground"
+        }
+      },
+      "description": "Studio dev rig",
+      "id": "studio",
+      "pipeline": {
+        "check": [
+          {
+            "command": "docker info >/dev/null 2>&1",
+            "expect_exit": 0,
+            "kind": "check",
+            "label": "Docker daemon running"
+          },
+          {
+            "id": "tarball-server",
+            "kind": "service",
+            "op": "health"
+          }
+        ],
+        "up": [
+          {
+            "id": "tarball-server",
+            "kind": "service",
+            "op": "start"
+          }
+        ]
+      },
+      "services": {
+        "tarball-server": {
+          "health": {
+            "expect_status": 200,
+            "http": "http://127.0.0.1:9724/"
+          },
+          "kind": "http-static",
+          "port": 9724
+        }
+      },
+      "symlinks": [
+        {
+          "link": "~/.local/bin/studio",
+          "target": "~/.local/bin/studio-dev"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a dedicated Rigs core navigation screen for listing, inspecting, and checking Homeboy rigs.
- Add HomeboyCLI rig wrappers/models for list, show, status, check, up, and down, with structured output separated from visible command logs.
- Add contract fixtures covering rig list/show/check JSON, including failed check envelopes that still carry data.

## Tests
- swift tests/ContractTests.swift tests
- homeboy test homeboy-desktop --path /Users/chubes/Developer/homeboy-desktop@feat-rig-management
- homeboy lint homeboy-desktop --path /Users/chubes/Developer/homeboy-desktop@feat-rig-management
- plutil -lint Homeboy.xcodeproj/project.pbxproj
- homeboy rig --help
- homeboy rig list

Note: xcodebuild could not run in this environment because the active developer directory is Command Line Tools, not full Xcode.

Closes #32

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the desktop rig workflow; Chris to review before merge.