### PR TITLE
feat: add benchmark workspace

### DIFF
--- a/Homeboy.xcodeproj/project.pbxproj
+++ b/Homeboy.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0B1C053B8DCA686200739C43 /* ServerEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D75CB92C4916A5B3A8DE34 /* ServerEditSheet.swift */; };
 		0BB5245A79F8709EBD8C5269 /* ModuleInstallSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA1C2F245C5FCEF82A5D2D3 /* ModuleInstallSheet.swift */; };
 		0FE6351E7C94950D6A459978 /* DeployerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F978C6E7F1C5288FF7303DF7 /* DeployerView.swift */; };
+		1162E40A1D0549D9B68608A8 /* BenchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1162E4091D0549D9B68608A8 /* BenchView.swift */; };
 		1A164D8DD4607926F6964B95 /* CopyableContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5BD1368E35CA013C4E064C8 /* CopyableContent.swift */; };
 		1D8C5CFC6CC66D4D2059241A /* CLIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0B9A725382C46F30D83C02 /* CLIError.swift */; };
 		1E0233CF5AC026C74233786E /* TableDataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EC7ED01925DBCB9195A8A4D /* TableDataView.swift */; };
@@ -107,6 +108,7 @@
 		0BBA2DD3A1B1041ACA3A049F /* RemoteFileEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileEntry.swift; sourceTree = "<group>"; };
 		0CD2C75C18D0464C6428E5EE /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
 		0DC18F8D8A50F464D296BB74 /* InlineWarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineWarningView.swift; sourceTree = "<group>"; };
+		1162E4091D0549D9B68608A8 /* BenchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchView.swift; sourceTree = "<group>"; };
 		13F8D60E3516F29F554438A0 /* VersionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionParser.swift; sourceTree = "<group>"; };
 		14349D465EC79FD6D1D8C70C /* DatabaseTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseTypes.swift; sourceTree = "<group>"; };
 		1682E9BF7F10ED915C606359 /* RemoteFileEditorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileEditorViewModel.swift; sourceTree = "<group>"; };
@@ -378,6 +380,7 @@
 				8007D7D3CCEF3F80C36AA686 /* Components */,
 				E900FE3D44D913C0F5C320A7 /* Modules */,
 				F08C0BC0AC87CDDCAA5955CF /* Settings */,
+				1162E4091D0549D9B68608A8 /* BenchView.swift */,
 				3A80F92FC849ACD9591EDEFE /* LoginView.swift */,
 				EA62EB2C6FD0532AE4CCD204 /* ProjectSwitcherView.swift */,
 				E7C2AF5C1F794564BF7DC0F4 /* RemoteFileBrowserView.swift */,
@@ -627,6 +630,7 @@
 				27D41F217F00E3A8171BEC63 /* AppWarning.swift in Sources */,
 				86C712A03FB9FC626DC46371 /* ArtifactVersionParser.swift in Sources */,
 				FE865BA85263630F8BF6A608 /* AuthManager.swift in Sources */,
+				1162E40A1D0549D9B68608A8 /* BenchView.swift in Sources */,
 				1EBFEF675F781A40A250D009 /* BackupService.swift in Sources */,
 				D067D1266FD0989BC9E07C43 /* CLIBridge.swift in Sources */,
 				1D8C5CFC6CC66D4D2059241A /* CLIError.swift in Sources */,

--- a/Homeboy/App/ContentView.swift
+++ b/Homeboy/App/ContentView.swift
@@ -12,6 +12,7 @@ enum NavigationItem: Hashable {
 /// Settings is shown in a separate section.
 enum CoreTool: String, CaseIterable, Identifiable {
     case deployer = "Deployer"
+    case bench = "Bench"
     case remoteFileEditor = "File Editor"
     case remoteLogViewer = "Log Viewer"
     case databaseBrowser = "Database"
@@ -22,6 +23,7 @@ enum CoreTool: String, CaseIterable, Identifiable {
     var icon: String {
         switch self {
         case .deployer: return "arrow.up.to.line"
+        case .bench: return "speedometer"
         case .remoteFileEditor: return "doc.badge.gearshape"
         case .remoteLogViewer: return "doc.text.magnifyingglass"
         case .databaseBrowser: return "cylinder.split.1x2"
@@ -62,6 +64,8 @@ struct ContentView: View {
             // Core tools - kept mounted to preserve state
             DeployerView()
                 .opacity(selectedItem == .coreTool(.deployer) ? 1 : 0)
+            BenchView()
+                .opacity(selectedItem == .coreTool(.bench) ? 1 : 0)
             DatabaseBrowserView()
                 .opacity(selectedItem == .coreTool(.databaseBrowser) ? 1 : 0)
             RemoteLogViewerView()

--- a/Homeboy/Core/CLI/HomeboyCLI.swift
+++ b/Homeboy/Core/CLI/HomeboyCLI.swift
@@ -275,6 +275,64 @@ struct ComponentRecordCLI: Decodable, Identifiable {
     }
 }
 
+// MARK: - Bench CLI Output Models
+
+struct BenchCommandOutput: Decodable {
+    let passed: Bool
+    let status: String
+    let component: String
+    let exitCode: Int32
+    let iterations: Int
+    let results: BenchResults?
+    let baselineComparison: BenchBaselineComparison?
+    let hints: [String]?
+}
+
+struct BenchResults: Decodable {
+    let componentId: String
+    let iterations: Int
+    let scenarios: [BenchScenario]
+    let metricPolicies: [String: BenchMetricPolicy]?
+}
+
+struct BenchScenario: Decodable, Identifiable {
+    let id: String
+    let file: String?
+    let iterations: Int
+    let metrics: [String: Double]
+    let memory: BenchMemory?
+}
+
+struct BenchMemory: Decodable {
+    let peakBytes: UInt64
+}
+
+struct BenchMetricPolicy: Decodable {
+    let direction: String
+    let regressionThresholdPercent: Double?
+    let regressionThresholdAbsolute: Double?
+}
+
+struct BenchBaselineComparison: Decodable {
+    let thresholdPercent: Double
+    let scenarios: [BenchScenarioDelta]
+    let newScenarioIds: [String]
+    let removedScenarioIds: [String]
+    let regression: Bool
+    let hasImprovements: Bool
+    let reasons: [String]?
+}
+
+struct BenchScenarioDelta: Decodable, Identifiable {
+    let id: String
+    let baselineP95Ms: Double?
+    let currentP95Ms: Double?
+    let p95DeltaMs: Double?
+    let p95DeltaPct: Double?
+    let regression: Bool
+    let improvement: Bool
+}
+
 /// Extension configuration scoped to a component (for CLI output parsing)
 /// Settings use [String: String] for simplicity - CLI returns settings as strings
 struct ScopedExtensionConfig: Decodable {
@@ -772,6 +830,24 @@ private init() {}
             dataType: ComponentOutput.self,
             source: "Component Delete"
         )
+    }
+
+    // MARK: - Bench Commands
+
+    func benchList(componentId: String, path: String? = nil) async throws -> BenchCommandOutput {
+        var args = ["bench", "list", componentId]
+        if let path, !path.isEmpty {
+            args.append(contentsOf: ["--path", path])
+        }
+        return try await cli.executeCommand(args, dataType: BenchCommandOutput.self, source: "Bench List", timeout: 60)
+    }
+
+    func benchRun(componentId: String, path: String? = nil, iterations: Int = 10) async throws -> BenchCommandOutput {
+        var args = ["bench", componentId, "--iterations", String(iterations)]
+        if let path, !path.isEmpty {
+            args.append(contentsOf: ["--path", path])
+        }
+        return try await cli.executeCommand(args, dataType: BenchCommandOutput.self, source: "Bench", timeout: 300)
     }
 
     // MARK: - File Commands

--- a/Homeboy/Views/BenchView.swift
+++ b/Homeboy/Views/BenchView.swift
@@ -1,0 +1,364 @@
+import Combine
+import SwiftUI
+
+@MainActor
+final class BenchViewModel: ObservableObject, ConfigurationObserving {
+    var cancellables = Set<AnyCancellable>()
+
+    @Published var components: [ComponentConfiguration] = []
+    @Published var selectedComponentId: String = ""
+    @Published var iterations: Int = 10
+    @Published var scenarios: [BenchScenario] = []
+    @Published var lastRun: BenchCommandOutput?
+    @Published var isLoadingScenarios = false
+    @Published var isRunning = false
+    @Published var error: (any DisplayableError)?
+
+    private let cli = HomeboyCLI.shared
+
+    init() {
+        loadComponents()
+        observeConfiguration()
+    }
+
+    func handleConfigChange(_ change: ConfigurationChangeType) {
+        switch change {
+        case .projectDidSwitch, .projectModified:
+            loadComponents()
+        default:
+            break
+        }
+    }
+
+    func loadComponents() {
+        let project = ConfigurationManager.shared.safeActiveProject
+        components = ConfigurationManager.shared.loadComponentsForProject(project)
+            .sorted { $0.displayName.localizedStandardCompare($1.displayName) == .orderedAscending }
+
+        if !components.contains(where: { $0.id == selectedComponentId }) {
+            selectedComponentId = components.first?.id ?? ""
+            scenarios = []
+            lastRun = nil
+        }
+    }
+
+    var selectedComponent: ComponentConfiguration? {
+        components.first { $0.id == selectedComponentId }
+    }
+
+    var canRun: Bool {
+        !selectedComponentId.isEmpty && !isRunning && iterations > 0
+    }
+
+    func loadScenarios() {
+        guard let component = selectedComponent else { return }
+
+        isLoadingScenarios = true
+        error = nil
+
+        Task {
+            do {
+                let output = try await cli.benchList(componentId: component.id, path: component.localPath)
+                scenarios = output.results?.scenarios ?? []
+                lastRun = output
+            } catch {
+                scenarios = []
+                self.error = AppError(error.localizedDescription, source: "Bench List")
+            }
+            isLoadingScenarios = false
+        }
+    }
+
+    func runBench() {
+        guard let component = selectedComponent else { return }
+
+        isRunning = true
+        error = nil
+        lastRun = nil
+
+        Task {
+            do {
+                let clampedIterations = max(1, iterations)
+                let output = try await cli.benchRun(
+                    componentId: component.id,
+                    path: component.localPath,
+                    iterations: clampedIterations
+                )
+                lastRun = output
+                scenarios = output.results?.scenarios ?? scenarios
+            } catch {
+                self.error = AppError(error.localizedDescription, source: "Bench")
+            }
+            isRunning = false
+        }
+    }
+}
+
+struct BenchView: View {
+    @StateObject private var viewModel = BenchViewModel()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+
+            HSplitView {
+                configurationPanel
+                    .frame(minWidth: 300, idealWidth: 360)
+                resultsPanel
+                    .frame(minWidth: 420)
+            }
+        }
+        .frame(minWidth: 800, minHeight: 600)
+        .onAppear {
+            viewModel.loadComponents()
+        }
+        .onChange(of: viewModel.selectedComponentId) { _, _ in
+            viewModel.scenarios = []
+            viewModel.lastRun = nil
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 16) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Benchmarks")
+                    .font(.title2.weight(.semibold))
+                Text("Run `homeboy bench` without writing baselines or ratchets.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            if viewModel.isLoadingScenarios || viewModel.isRunning {
+                ProgressView()
+                    .controlSize(.small)
+            }
+
+            Button("List Scenarios") {
+                viewModel.loadScenarios()
+            }
+            .disabled(viewModel.selectedComponentId.isEmpty || viewModel.isLoadingScenarios || viewModel.isRunning)
+
+            Button("Run Bench") {
+                viewModel.runBench()
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(!viewModel.canRun)
+        }
+        .padding()
+    }
+
+    private var configurationPanel: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            GroupBox("Component") {
+                VStack(alignment: .leading, spacing: 10) {
+                    if viewModel.components.isEmpty {
+                        Text("No components are configured for this project.")
+                            .foregroundColor(.secondary)
+                    } else {
+                        Picker("Component", selection: $viewModel.selectedComponentId) {
+                            ForEach(viewModel.components) { component in
+                                Text(component.displayName).tag(component.id)
+                            }
+                        }
+
+                        if let component = viewModel.selectedComponent {
+                            Text(component.localPath)
+                                .font(.caption.monospaced())
+                                .foregroundColor(.secondary)
+                                .textSelection(.enabled)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 4)
+            }
+
+            GroupBox("Run Settings") {
+                Stepper(value: $viewModel.iterations, in: 1...1_000) {
+                    Text("Iterations: \(viewModel.iterations)")
+                }
+                .padding(.vertical, 4)
+            }
+
+            GroupBox("Scenarios") {
+                if viewModel.scenarios.isEmpty {
+                    Text("List scenarios to preview what this component can benchmark.")
+                        .foregroundColor(.secondary)
+                } else {
+                    List(viewModel.scenarios) { scenario in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(scenario.id)
+                                .font(.body.weight(.medium))
+                            if let file = scenario.file {
+                                Text(file)
+                                    .font(.caption.monospaced())
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        .padding(.vertical, 2)
+                    }
+                    .frame(minHeight: 180)
+                }
+            }
+
+            Spacer()
+        }
+        .padding()
+    }
+
+    private var resultsPanel: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            if let error = viewModel.error {
+                InlineErrorView(error)
+            }
+
+            if let run = viewModel.lastRun {
+                runSummary(run)
+
+                if let results = run.results {
+                    scenarioResults(results.scenarios)
+                }
+
+                if let comparison = run.baselineComparison {
+                    baselineSummary(comparison)
+                }
+            } else {
+                ContentUnavailableView(
+                    "No Benchmark Results",
+                    systemImage: "speedometer",
+                    description: Text("Choose a component, list scenarios, or run a benchmark to see timing summaries.")
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .padding()
+    }
+
+    private func runSummary(_ run: BenchCommandOutput) -> some View {
+        GroupBox("Summary") {
+            Grid(alignment: .leading, horizontalSpacing: 18, verticalSpacing: 8) {
+                summaryRow("Component", run.component)
+                summaryRow("Status", run.status.capitalized)
+                summaryRow("Iterations", String(run.iterations))
+                summaryRow("Exit Code", String(run.exitCode))
+                summaryRow("Passed", run.passed ? "Yes" : "No")
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func scenarioResults(_ scenarios: [BenchScenario]) -> some View {
+        GroupBox("Scenario Results") {
+            if scenarios.isEmpty {
+                Text("No scenario results were returned.")
+                    .foregroundColor(.secondary)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 12) {
+                        ForEach(scenarios) { scenario in
+                            scenarioResultRow(scenario)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+    }
+
+    private func scenarioResultRow(_ scenario: BenchScenario) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(scenario.id)
+                    .font(.headline)
+                Spacer()
+                if let p95 = scenario.metrics["p95_ms"] {
+                    Text(formatMetric(p95, name: "p95_ms"))
+                        .font(.system(.body, design: .monospaced))
+                }
+            }
+
+            if let file = scenario.file {
+                Text(file)
+                    .font(.caption.monospaced())
+                    .foregroundColor(.secondary)
+            }
+
+            metricChips(for: scenario)
+        }
+        .padding(10)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .cornerRadius(8)
+    }
+
+    private func metricChips(for scenario: BenchScenario) -> some View {
+        let metrics = scenario.metrics.sorted { $0.key < $1.key }
+        return VStack(alignment: .leading, spacing: 6) {
+            ForEach(metrics, id: \.key) { metric in
+                Text("\(metric.key): \(formatMetric(metric.value, name: metric.key))")
+                    .font(.caption.monospaced())
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color(nsColor: .quaternaryLabelColor).opacity(0.18))
+                    .cornerRadius(5)
+            }
+
+            if let memory = scenario.memory {
+                Text("peak: \(formatBytes(memory.peakBytes))")
+                    .font(.caption.monospaced())
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color(nsColor: .quaternaryLabelColor).opacity(0.18))
+                    .cornerRadius(5)
+            }
+        }
+    }
+
+    private func baselineSummary(_ comparison: BenchBaselineComparison) -> some View {
+        GroupBox("Baseline Comparison") {
+            VStack(alignment: .leading, spacing: 8) {
+                Label(
+                    comparison.regression ? "Regression detected" : "No regression detected",
+                    systemImage: comparison.regression ? "exclamationmark.triangle.fill" : "checkmark.circle.fill"
+                )
+                .foregroundColor(comparison.regression ? .orange : .green)
+
+                Text("Threshold: \(formatNumber(comparison.thresholdPercent))%")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                ForEach(comparison.reasons ?? [], id: \.self) { reason in
+                    Text(reason)
+                        .font(.caption)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func summaryRow(_ label: String, _ value: String) -> some View {
+        GridRow {
+            Text(label)
+                .foregroundColor(.secondary)
+            Text(value)
+                .font(.system(.body, design: .monospaced))
+        }
+    }
+
+    private func formatMetric(_ value: Double, name: String) -> String {
+        if name.hasSuffix("_ms") {
+            return "\(formatNumber(value)) ms"
+        }
+        return formatNumber(value)
+    }
+
+    private func formatNumber(_ value: Double) -> String {
+        value.formatted(.number.precision(.fractionLength(0...2)))
+    }
+
+    private func formatBytes(_ bytes: UInt64) -> String {
+        ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .memory)
+    }
+}

--- a/tests/ContractTests.swift
+++ b/tests/ContractTests.swift
@@ -135,6 +135,64 @@ struct ComponentConfigurationTest: Decodable {
     }
 }
 
+// MARK: - Bench Output Types (mirror HomeboyCLI.swift)
+
+struct BenchCommandOutputTest: Decodable {
+    let passed: Bool
+    let status: String
+    let component: String
+    let exitCode: Int32
+    let iterations: Int
+    let results: BenchResultsTest?
+    let baselineComparison: BenchBaselineComparisonTest?
+    let hints: [String]?
+}
+
+struct BenchResultsTest: Decodable {
+    let componentId: String
+    let iterations: Int
+    let scenarios: [BenchScenarioTest]
+    let metricPolicies: [String: BenchMetricPolicyTest]?
+}
+
+struct BenchScenarioTest: Decodable {
+    let id: String
+    let file: String?
+    let iterations: Int
+    let metrics: [String: Double]
+    let memory: BenchMemoryTest?
+}
+
+struct BenchMemoryTest: Decodable {
+    let peakBytes: UInt64
+}
+
+struct BenchMetricPolicyTest: Decodable {
+    let direction: String
+    let regressionThresholdPercent: Double?
+    let regressionThresholdAbsolute: Double?
+}
+
+struct BenchBaselineComparisonTest: Decodable {
+    let thresholdPercent: Double
+    let scenarios: [BenchScenarioDeltaTest]
+    let newScenarioIds: [String]
+    let removedScenarioIds: [String]
+    let regression: Bool
+    let hasImprovements: Bool
+    let reasons: [String]?
+}
+
+struct BenchScenarioDeltaTest: Decodable {
+    let id: String
+    let baselineP95Ms: Double?
+    let currentP95Ms: Double?
+    let p95DeltaMs: Double?
+    let p95DeltaPct: Double?
+    let regression: Bool
+    let improvement: Bool
+}
+
 // MARK: - Test Runner
 
 func runTests(testDir: String) throws {
@@ -182,6 +240,9 @@ func runTests(testDir: String) throws {
 
     // Test 12: CLI command construction uses current Homeboy surface
     try testCurrentCLICommandSurface(testDir: testDir)
+
+    // Test 13: bench result parsing
+    try testBenchResult(fixturesDir: fixturesDir, decoder: decoder)
 
     print("")
     print("All contract tests passed")
@@ -812,6 +873,67 @@ func testCurrentCLICommandSurface(testDir: String) throws {
         }
     }
     print("[PASS] Audit filters and help-surface probe are present")
+    print("")
+}
+
+func testBenchResult(fixturesDir: String, decoder: JSONDecoder) throws {
+    print("Test: bench-result.json")
+    print("-----------------------")
+
+    let fixture = URL(fileURLWithPath: "\(fixturesDir)/bench-result.json")
+
+    guard FileManager.default.fileExists(atPath: fixture.path) else {
+        throw NSError(domain: "ContractTest", code: 80,
+            userInfo: [NSLocalizedDescriptionKey: "Fixture not found: bench-result.json"])
+    }
+
+    let data = try Data(contentsOf: fixture)
+    let result = try decoder.decode(CLIResponse<BenchCommandOutputTest>.self, from: data)
+
+    guard result.success else {
+        throw NSError(domain: "ContractTest", code: 81,
+            userInfo: [NSLocalizedDescriptionKey: "bench-result.json: success=false"])
+    }
+
+    guard let output = result.data else {
+        throw NSError(domain: "ContractTest", code: 82,
+            userInfo: [NSLocalizedDescriptionKey: "bench-result.json: data field is nil"])
+    }
+
+    guard output.component == "homeboy" else {
+        throw NSError(domain: "ContractTest", code: 83,
+            userInfo: [NSLocalizedDescriptionKey: "Unexpected bench component: \(output.component)"])
+    }
+    print("[PASS] Parsed bench command output")
+
+    guard let results = output.results else {
+        throw NSError(domain: "ContractTest", code: 84,
+            userInfo: [NSLocalizedDescriptionKey: "bench-result.json: results is nil"])
+    }
+
+    guard results.scenarios.count == 2 else {
+        throw NSError(domain: "ContractTest", code: 85,
+            userInfo: [NSLocalizedDescriptionKey: "Expected 2 scenarios, got \(results.scenarios.count)"])
+    }
+    print("[PASS] Parsed \(results.scenarios.count) bench scenarios")
+
+    guard let p95 = results.scenarios.first?.metrics["p95_ms"], p95 > 0 else {
+        throw NSError(domain: "ContractTest", code: 86,
+            userInfo: [NSLocalizedDescriptionKey: "First scenario missing positive p95_ms"])
+    }
+    print("[PASS] Scenario metrics decode as numeric values")
+
+    guard results.scenarios.first?.memory?.peakBytes == 41943040 else {
+        throw NSError(domain: "ContractTest", code: 87,
+            userInfo: [NSLocalizedDescriptionKey: "First scenario memory peak did not decode"])
+    }
+    print("[PASS] Scenario memory decodes from peak_bytes")
+
+    guard output.baselineComparison?.regression == false else {
+        throw NSError(domain: "ContractTest", code: 88,
+            userInfo: [NSLocalizedDescriptionKey: "Baseline comparison regression flag mismatch"])
+    }
+    print("[PASS] Baseline comparison decodes")
     print("")
 }
 

--- a/tests/fixtures/bench-result.json
+++ b/tests/fixtures/bench-result.json
@@ -1,0 +1,64 @@
+{
+  "success": true,
+  "data": {
+    "passed": true,
+    "status": "passed",
+    "component": "homeboy",
+    "exit_code": 0,
+    "iterations": 10,
+    "results": {
+      "component_id": "homeboy",
+      "iterations": 10,
+      "metric_policies": {
+        "p95_ms": {
+          "direction": "lower_is_better",
+          "regression_threshold_percent": 5
+        }
+      },
+      "scenarios": [
+        {
+          "id": "audit_self",
+          "file": "src/bin/bench-audit-self.rs",
+          "iterations": 10,
+          "metrics": {
+            "p50_ms": 59700,
+            "p95_ms": 62900,
+            "min_ms": 59500,
+            "max_ms": 63300
+          },
+          "memory": {
+            "peak_bytes": 41943040
+          }
+        },
+        {
+          "id": "noop",
+          "iterations": 10,
+          "metrics": {
+            "p50_ms": 1.2,
+            "p95_ms": 1.8,
+            "requests_per_second": 180.5
+          }
+        }
+      ]
+    },
+    "baseline_comparison": {
+      "threshold_percent": 5,
+      "scenarios": [
+        {
+          "id": "audit_self",
+          "baseline_p95_ms": 64000,
+          "current_p95_ms": 62900,
+          "p95_delta_ms": -1100,
+          "p95_delta_pct": -1.71875,
+          "metric_deltas": [],
+          "regression": false,
+          "improvement": true
+        }
+      ],
+      "new_scenario_ids": ["noop"],
+      "removed_scenario_ids": [],
+      "regression": false,
+      "has_improvements": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a Bench workspace to the desktop sidebar for selecting a component, listing scenarios, setting iterations, and running `homeboy bench` without baseline writes.
- Add Swift CLI models/wrappers for `homeboy bench list` and basic `homeboy bench <component>` output.
- Add contract fixture coverage for the bench JSON envelope and baseline comparison fields.

## Tests
- `swift tests/ContractTests.swift tests`
- `homeboy bench --help`
- `homeboy bench list --help`
- `homeboy bench list homeboy-desktop --path /Users/chubes/Developer/homeboy-desktop@feat-bench-workspace` *(parser accepted; returns structured validation because `homeboy-desktop` has no linked bench-capable extension)*
- `homeboy lint homeboy-desktop --path /Users/chubes/Developer/homeboy-desktop@feat-bench-workspace`

Note: `xcodebuild` could not run on this host because the active developer directory is Command Line Tools, not full Xcode.

Closes #34

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the desktop benchmark workspace; Chris to review before merge.
