### PR TITLE
feat: add release planning workflow

### DIFF
--- a/Homeboy/App/ContentView.swift
+++ b/Homeboy/App/ContentView.swift
@@ -1,3 +1,4 @@
+import Combine
 import SwiftUI
 
 /// Navigation items: core tools are static, extensions are dynamic
@@ -13,6 +14,7 @@ enum NavigationItem: Hashable {
 enum CoreTool: String, CaseIterable, Identifiable {
     case deployer = "Deployer"
     case bench = "Bench"
+    case release = "Release"
     case remoteFileEditor = "File Editor"
     case remoteLogViewer = "Log Viewer"
     case databaseBrowser = "Database"
@@ -24,6 +26,7 @@ enum CoreTool: String, CaseIterable, Identifiable {
         switch self {
         case .deployer: return "arrow.up.to.line"
         case .bench: return "speedometer"
+        case .release: return "tag"
         case .remoteFileEditor: return "doc.badge.gearshape"
         case .remoteLogViewer: return "doc.text.magnifyingglass"
         case .databaseBrowser: return "cylinder.split.1x2"
@@ -66,6 +69,8 @@ struct ContentView: View {
                 .opacity(selectedItem == .coreTool(.deployer) ? 1 : 0)
             BenchView()
                 .opacity(selectedItem == .coreTool(.bench) ? 1 : 0)
+            ReleaseWorkflowView()
+                .opacity(selectedItem == .coreTool(.release) ? 1 : 0)
             DatabaseBrowserView()
                 .opacity(selectedItem == .coreTool(.databaseBrowser) ? 1 : 0)
             RemoteLogViewerView()
@@ -89,6 +94,317 @@ struct ContentView: View {
                     description: Text("Choose a tool or extension from the sidebar")
                 )
             }
+        }
+    }
+}
+
+// MARK: - Release Workflow
+
+@MainActor
+final class ReleaseWorkflowViewModel: ObservableObject, ConfigurationObserving {
+    var cancellables = Set<AnyCancellable>()
+
+    @Published var components: [DeployableComponent] = []
+    @Published var selectedComponentId: String?
+    @Published var changes: ChangesOutput?
+    @Published var version: VersionShowOutput?
+    @Published var releasePlan: ReleaseOutput?
+    @Published var consoleOutput = ""
+    @Published var isLoading = false
+    @Published var error: (any DisplayableError)?
+
+    private let cli = HomeboyCLI.shared
+
+    init() {
+        loadComponents()
+        observeConfiguration()
+    }
+
+    var selectedComponent: DeployableComponent? {
+        components.first { $0.id == selectedComponentId }
+    }
+
+    func handleConfigChange(_ change: ConfigurationChangeType) {
+        switch change {
+        case .projectDidSwitch, .projectModified:
+            loadComponents()
+        default:
+            break
+        }
+    }
+
+    func loadComponents() {
+        let project = ConfigurationManager.shared.activeProject ?? ConfigurationManager.shared.safeActiveProject
+        components = ConfigurationManager.shared.loadComponentsForProject(project).map { DeployableComponent(from: $0) }
+        if selectedComponentId == nil || !components.contains(where: { $0.id == selectedComponentId }) {
+            selectedComponentId = components.first?.id
+        }
+        changes = nil
+        version = nil
+        releasePlan = nil
+    }
+
+    func refreshPlan() {
+        guard let component = selectedComponent else { return }
+        guard cli.isInstalled else {
+            error = AppError("Homeboy CLI is not installed. Install via Settings -> CLI.", source: "Release")
+            return
+        }
+
+        isLoading = true
+        error = nil
+        changes = nil
+        version = nil
+        releasePlan = nil
+        consoleOutput = "> homeboy changes \(component.id)\n"
+        consoleOutput += "> homeboy version show \(component.id) --path \(component.localPath)\n"
+        consoleOutput += "> homeboy release \(component.id) --path \(component.localPath) --dry-run\n\n"
+
+        Task {
+            do {
+                async let changesResult = cli.changes(componentId: component.id)
+                async let versionResult: VersionShowOutput? = try? cli.versionShow(componentId: component.id, path: component.localPath)
+                async let releaseResult = cli.releaseDryRun(componentId: component.id, path: component.localPath)
+
+                changes = try await changesResult
+                version = await versionResult
+                releasePlan = try await releaseResult
+                appendPlanSummary()
+            } catch {
+                self.error = AppError(error.localizedDescription, source: "Release")
+                consoleOutput += "Failed: \(error.localizedDescription)\n"
+            }
+            isLoading = false
+        }
+    }
+
+    func runBuild() {
+        guard let component = selectedComponent else { return }
+        guard cli.isInstalled else {
+            error = AppError("Homeboy CLI is not installed. Install via Settings -> CLI.", source: "Release")
+            return
+        }
+
+        isLoading = true
+        error = nil
+        consoleOutput += "\n> homeboy build \(component.id) --path \(component.localPath)\n"
+
+        Task {
+            do {
+                _ = try await cli.build(componentId: component.id, path: component.localPath)
+                consoleOutput += "Build completed. Refreshing release plan...\n"
+                isLoading = false
+                refreshPlan()
+            } catch {
+                self.error = AppError(error.localizedDescription, source: "Build")
+                consoleOutput += "Build failed: \(error.localizedDescription)\n"
+                isLoading = false
+            }
+        }
+    }
+
+    private func appendPlanSummary() {
+        if let changes {
+            consoleOutput += "Changes baseline: \(changes.baselineRef ?? "unknown")\n"
+            consoleOutput += "Commits since baseline: \(changes.commits.count)\n"
+            if changes.uncommitted?.hasChanges == true {
+                consoleOutput += "Working tree has uncommitted changes.\n"
+            }
+        }
+        if let version = version?.version {
+            consoleOutput += "Current version: \(version)\n"
+        } else {
+            consoleOutput += "Current version: unavailable. Check version target configuration.\n"
+        }
+        if let result = releasePlan?.result {
+            consoleOutput += "Release dry-run: \(result.bumpType ?? "unknown")"
+            if let next = result.nextVersion {
+                consoleOutput += " -> \(next)"
+            }
+            if let skipped = result.skippedReason {
+                consoleOutput += " (skipped: \(skipped))"
+            }
+            consoleOutput += "\n"
+        }
+    }
+}
+
+struct ReleaseWorkflowView: View {
+    @StateObject private var viewModel = ReleaseWorkflowViewModel()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            if viewModel.components.isEmpty {
+                ContentUnavailableView(
+                    "No Components",
+                    systemImage: "shippingbox",
+                    description: Text("Add components in project settings before planning a release.")
+                )
+            } else {
+                HSplitView {
+                    planningSection
+                        .frame(minWidth: 380)
+                    consoleSection
+                        .frame(minWidth: 320)
+                }
+            }
+        }
+        .frame(minWidth: 800, minHeight: 600)
+        .onAppear {
+            if viewModel.changes == nil && !viewModel.components.isEmpty {
+                viewModel.refreshPlan()
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Picker("Component", selection: $viewModel.selectedComponentId) {
+                ForEach(viewModel.components) { component in
+                    Text(component.name).tag(Optional(component.id))
+                }
+            }
+            .frame(width: 240)
+
+            Button("Refresh Plan") {
+                viewModel.refreshPlan()
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(viewModel.selectedComponentId == nil || viewModel.isLoading)
+
+            Button("Build") {
+                viewModel.runBuild()
+            }
+            .buttonStyle(.bordered)
+            .disabled(viewModel.selectedComponentId == nil || viewModel.isLoading)
+
+            Spacer()
+
+            if viewModel.isLoading {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Running CLI...")
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding()
+    }
+
+    private var planningSection: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                summaryCard
+                commitsCard
+                releaseGuardCard
+                if let error = viewModel.error {
+                    InlineErrorView(error)
+                }
+            }
+            .padding()
+        }
+    }
+
+    private var summaryCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Release Plan")
+                .font(.headline)
+            labeledValue("Component", viewModel.selectedComponent?.id ?? "-")
+            labeledValue("Baseline", viewModel.changes?.baselineRef ?? "-")
+            labeledValue("Current Version", viewModel.version?.version ?? "Unavailable")
+            labeledValue("Recommended Bump", viewModel.releasePlan?.result?.bumpType ?? "-")
+            if let skipped = viewModel.releasePlan?.result?.skippedReason {
+                labeledValue("Dry-run Result", "Skipped: \(skipped)")
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .cornerRadius(8)
+    }
+
+    private var commitsCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Changes Since Baseline")
+                .font(.headline)
+            if let commits = viewModel.changes?.commits, !commits.isEmpty {
+                ForEach(commits.prefix(12)) { commit in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(commit.subject)
+                        Text("\(commit.hash) · \(commit.category ?? "Other")")
+                            .font(.caption.monospaced())
+                            .foregroundColor(.secondary)
+                    }
+                }
+                if (viewModel.changes?.commits.count ?? 0) > 12 {
+                    Text("Showing first 12 commits. Full output is in the console.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            } else {
+                Text("No changes loaded yet.")
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .cornerRadius(8)
+    }
+
+    private var releaseGuardCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Release Execution")
+                .font(.headline)
+            Text("This view only plans releases with `homeboy release --dry-run`. Mutating release execution stays disabled until the app has an explicit confirmation flow.")
+                .foregroundColor(.secondary)
+            Button("Release Disabled") { }
+                .disabled(true)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .cornerRadius(8)
+    }
+
+    private var consoleSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("CLI Output")
+                    .font(.headline)
+                Spacer()
+                CopyButton.console(viewModel.consoleOutput, source: "Release")
+                    .disabled(viewModel.consoleOutput.isEmpty)
+                Button {
+                    viewModel.consoleOutput = ""
+                } label: {
+                    Image(systemName: "trash")
+                }
+                .buttonStyle(.borderless)
+                .disabled(viewModel.consoleOutput.isEmpty)
+            }
+            ScrollView {
+                Text(viewModel.consoleOutput.isEmpty ? "Ready to plan a release..." : viewModel.consoleOutput)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundColor(viewModel.consoleOutput.isEmpty ? .secondary : .primary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+            }
+            .background(Color(nsColor: .textBackgroundColor))
+            .cornerRadius(8)
+        }
+        .padding()
+    }
+
+    private func labeledValue(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label)
+                .foregroundColor(.secondary)
+            Spacer()
+            Text(value)
+                .font(.system(.body, design: .monospaced))
+                .textSelection(.enabled)
         }
     }
 }

--- a/Homeboy/Core/CLI/CLIBridge.swift
+++ b/Homeboy/Core/CLI/CLIBridge.swift
@@ -233,6 +233,7 @@ private struct CLIBridgeComponentEntity: Decodable {
     let localPath: String
     let remotePath: String
     let buildArtifact: String?
+    let buildCommand: String?
     let versionTargets: [VersionTarget]?
     let changelogTarget: String?
     let hooks: [String: [String]]?
@@ -244,6 +245,7 @@ private struct CLIBridgeComponentEntity: Decodable {
             localPath: localPath,
             remotePath: remotePath,
             buildArtifact: buildArtifact,
+            buildCommand: buildCommand,
             extensions: nil,
             versionTargets: versionTargets,
             changelogTarget: changelogTarget,

--- a/Homeboy/Core/CLI/HomeboyCLI.swift
+++ b/Homeboy/Core/CLI/HomeboyCLI.swift
@@ -264,6 +264,7 @@ struct ComponentRecordCLI: Decodable, Identifiable {
     let localPath: String
     let remotePath: String
     let buildArtifact: String?
+    let buildCommand: String?
     let extensions: [String: ScopedExtensionConfig]?  // NEW: Extension configs by ID
     let versionTargets: [VersionTargetCLI]?
     let changelogTarget: String?       // NEW: Dedicated changelog file path
@@ -1202,6 +1203,45 @@ private init() {}
         return response.output.contains(option) || response.errorOutput.contains(option)
     }
 
+    // MARK: - Release / Build Planning Commands
+
+    /// Inspect changes since the release baseline for a component.
+    func changes(componentId: String) async throws -> ChangesOutput {
+        try await cli.executeCommand(
+            ["changes", componentId],
+            dataType: ChangesOutput.self,
+            source: "Release Changes",
+            timeout: 60
+        )
+    }
+
+    /// Show the current version for a component. Path is optional and only used for local override workflows.
+    func versionShow(componentId: String, path: String? = nil) async throws -> VersionShowOutput {
+        var args = ["version", "show", componentId]
+        if let path {
+            args.append(contentsOf: ["--path", path])
+        }
+        return try await cli.executeCommand(args, dataType: VersionShowOutput.self, source: "Version Show", timeout: 30)
+    }
+
+    /// Execute a component build through the CLI. This is intentionally separate from release execution.
+    func build(componentId: String, path: String? = nil) async throws -> BuildOutput {
+        var args = ["build", componentId]
+        if let path {
+            args.append(contentsOf: ["--path", path])
+        }
+        return try await cli.executeCommand(args, dataType: BuildOutput.self, source: "Build", timeout: 300)
+    }
+
+    /// Preview a release plan without mutating the repository.
+    func releaseDryRun(componentId: String, path: String? = nil) async throws -> ReleaseOutput {
+        var args = ["release", componentId, "--dry-run"]
+        if let path {
+            args.append(contentsOf: ["--path", path])
+        }
+        return try await cli.executeCommand(args, dataType: ReleaseOutput.self, source: "Release Dry Run", timeout: 120)
+    }
+
     // MARK: - Undo Command
 
     /// Undo the last write operation
@@ -1293,6 +1333,91 @@ struct RefactorResult: Decodable {
     let changesApplied: Int?
     let filesModified: [String]?
     let errors: [String]?
+}
+
+/// Output from `homeboy changes <component>`.
+struct ChangesOutput: Decodable {
+    let componentId: String?
+    let baselineRef: String?
+    let baselineSource: String?
+    let latestTag: String?
+    let path: String?
+    let commits: [ChangeCommit]
+    let uncommitted: UncommittedChanges?
+    let changelog: ChangeChangelog?
+}
+
+struct ChangeCommit: Decodable, Identifiable {
+    let hash: String
+    let subject: String
+    let category: String?
+
+    var id: String { hash }
+}
+
+struct UncommittedChanges: Decodable {
+    let hasChanges: Bool
+    let staged: [String]?
+    let unstaged: [String]?
+    let untracked: [String]?
+}
+
+struct ChangeChangelog: Decodable {
+    let path: String?
+    let unreleasedEntries: Int?
+}
+
+/// Output from `homeboy version show <component>`.
+struct VersionShowOutput: Decodable {
+    let command: String?
+    let componentId: String?
+    let version: String?
+    let path: String?
+    let targets: [ComponentRecordCLI.VersionTargetCLI]?
+}
+
+/// Output from `homeboy build <component>`.
+struct BuildOutput: Decodable {
+    let command: String?
+    let componentId: String?
+    let success: Bool?
+    let results: [BuildResult]?
+    let summary: BuildSummary?
+    let artifactPath: String?
+    let message: String?
+}
+
+struct BuildResult: Decodable, Identifiable {
+    let componentId: String?
+    let id: String?
+    let success: Bool?
+    let artifactPath: String?
+    let message: String?
+
+    var stableId: String { componentId ?? id ?? artifactPath ?? message ?? UUID().uuidString }
+}
+
+struct BuildSummary: Decodable {
+    let succeeded: Int?
+    let failed: Int?
+    let skipped: Int?
+    let total: Int?
+}
+
+/// Output from `homeboy release <component> --dry-run`.
+struct ReleaseOutput: Decodable {
+    let command: String?
+    let result: ReleaseResult?
+}
+
+struct ReleaseResult: Decodable {
+    let componentId: String?
+    let dryRun: Bool?
+    let bumpType: String?
+    let currentVersion: String?
+    let nextVersion: String?
+    let releasableCommits: Int?
+    let skippedReason: String?
 }
 
 /// Output from undo command

--- a/Homeboy/Core/Config/ComponentConfiguration.swift
+++ b/Homeboy/Core/Config/ComponentConfiguration.swift
@@ -23,10 +23,35 @@ struct ComponentConfiguration: Codable, Identifiable {
     var localPath: String
     var remotePath: String
     var buildArtifact: String?
+    var buildCommand: String?
     var extensions: [String: ScopedExtensionConfig]?  // NEW: Extension configs by ID
     var versionTargets: [VersionTarget]?
     var changelogTarget: String?       // NEW: Dedicated changelog file path
     var hooks: [String: [String]]?     // NEW: Lifecycle hooks
+
+    init(
+        id: String,
+        aliases: [String] = [],
+        localPath: String,
+        remotePath: String,
+        buildArtifact: String? = nil,
+        buildCommand: String? = nil,
+        extensions: [String: ScopedExtensionConfig]? = nil,
+        versionTargets: [VersionTarget]? = nil,
+        changelogTarget: String? = nil,
+        hooks: [String: [String]]? = nil
+    ) {
+        self.id = id
+        self.aliases = aliases
+        self.localPath = localPath
+        self.remotePath = remotePath
+        self.buildArtifact = buildArtifact
+        self.buildCommand = buildCommand
+        self.extensions = extensions
+        self.versionTargets = versionTargets
+        self.changelogTarget = changelogTarget
+        self.hooks = hooks
+    }
 
     /// Display name computed from id (e.g., "chubes-theme" -> "Chubes Theme")
     var displayName: String {

--- a/tests/ContractTests.swift
+++ b/tests/ContractTests.swift
@@ -193,6 +193,60 @@ struct BenchScenarioDeltaTest: Decodable {
     let improvement: Bool
 }
 
+// MARK: - Release / Build Output Types (mirror HomeboyCLI.swift)
+
+struct ChangesOutputTest: Decodable {
+    let componentId: String?
+    let baselineRef: String?
+    let baselineSource: String?
+    let latestTag: String?
+    let path: String?
+    let commits: [ChangeCommitTest]
+    let uncommitted: UncommittedChangesTest?
+    let changelog: ChangeChangelogTest?
+}
+
+struct ChangeCommitTest: Decodable {
+    let hash: String
+    let subject: String
+    let category: String?
+}
+
+struct UncommittedChangesTest: Decodable {
+    let hasChanges: Bool
+    let staged: [String]?
+    let unstaged: [String]?
+    let untracked: [String]?
+}
+
+struct ChangeChangelogTest: Decodable {
+    let path: String?
+    let unreleasedEntries: Int?
+}
+
+struct VersionShowOutputTest: Decodable {
+    let command: String?
+    let componentId: String?
+    let version: String?
+    let path: String?
+    let targets: [VersionTargetTest]?
+}
+
+struct ReleaseOutputTest: Decodable {
+    let command: String?
+    let result: ReleaseResultTest?
+}
+
+struct ReleaseResultTest: Decodable {
+    let componentId: String?
+    let dryRun: Bool?
+    let bumpType: String?
+    let currentVersion: String?
+    let nextVersion: String?
+    let releasableCommits: Int?
+    let skippedReason: String?
+}
+
 // MARK: - Test Runner
 
 func runTests(testDir: String) throws {
@@ -244,8 +298,92 @@ func runTests(testDir: String) throws {
     // Test 13: bench result parsing
     try testBenchResult(fixturesDir: fixturesDir, decoder: decoder)
 
+    // Test 14: release/build planning model parsing
+    try testReleaseBuildPlanningFixtures(fixturesDir: fixturesDir, decoder: decoder)
+
+    // Test 15: release/build planning command shapes
+    try testReleaseBuildPlanningCommandShapes()
+
     print("")
     print("All contract tests passed")
+}
+
+func testReleaseBuildPlanningFixtures(fixturesDir: String, decoder: JSONDecoder) throws {
+    print("Test: release/build planning fixtures")
+    print("-------------------------------------")
+
+    let changesData = try Data(contentsOf: URL(fileURLWithPath: "\(fixturesDir)/changes.json"))
+    let changes = try decoder.decode(CLIResponse<ChangesOutputTest>.self, from: changesData)
+    guard changes.success, let changesOutput = changes.data else {
+        throw NSError(domain: "ContractTest", code: 92,
+            userInfo: [NSLocalizedDescriptionKey: "changes.json did not decode as a successful response"])
+    }
+    guard changesOutput.componentId == "homeboy-desktop" else {
+        throw NSError(domain: "ContractTest", code: 93,
+            userInfo: [NSLocalizedDescriptionKey: "changes.json component_id mismatch"])
+    }
+    guard changesOutput.commits.count == 2 else {
+        throw NSError(domain: "ContractTest", code: 94,
+            userInfo: [NSLocalizedDescriptionKey: "changes.json expected 2 commits"])
+    }
+    print("[PASS] changes output decodes with commits and baseline")
+
+    let versionData = try Data(contentsOf: URL(fileURLWithPath: "\(fixturesDir)/version-show.json"))
+    let version = try decoder.decode(CLIResponse<VersionShowOutputTest>.self, from: versionData)
+    guard version.success, version.data?.version == "0.11.3" else {
+        throw NSError(domain: "ContractTest", code: 95,
+            userInfo: [NSLocalizedDescriptionKey: "version-show.json did not decode expected version"])
+    }
+    print("[PASS] version show output decodes")
+
+    let releaseData = try Data(contentsOf: URL(fileURLWithPath: "\(fixturesDir)/release-dry-run.json"))
+    let release = try decoder.decode(CLIResponse<ReleaseOutputTest>.self, from: releaseData)
+    guard release.success, release.data?.result?.dryRun == true else {
+        throw NSError(domain: "ContractTest", code: 96,
+            userInfo: [NSLocalizedDescriptionKey: "release-dry-run.json did not decode dry_run=true"])
+    }
+    guard release.data?.result?.skippedReason == "major-requires-flag" else {
+        throw NSError(domain: "ContractTest", code: 97,
+            userInfo: [NSLocalizedDescriptionKey: "release-dry-run.json skipped_reason mismatch"])
+    }
+    print("[PASS] release dry-run output decodes")
+
+    print("")
+}
+
+func testReleaseBuildPlanningCommandShapes() throws {
+    print("Test: release/build planning command shapes")
+    print("-------------------------------------------")
+
+    let source = try String(contentsOf: URL(fileURLWithPath: "Homeboy/Core/CLI/HomeboyCLI.swift"), encoding: .utf8)
+    let contentView = try String(contentsOf: URL(fileURLWithPath: "Homeboy/App/ContentView.swift"), encoding: .utf8)
+
+    func requireContains(_ haystack: String, _ needle: String, _ message: String, code: Int) throws {
+        guard haystack.contains(needle) else {
+            throw NSError(domain: "ContractTest", code: code,
+                userInfo: [NSLocalizedDescriptionKey: message])
+        }
+        print("[PASS] \(message)")
+    }
+
+    func requireNotContains(_ haystack: String, _ needle: String, _ message: String, code: Int) throws {
+        guard !haystack.contains(needle) else {
+            throw NSError(domain: "ContractTest", code: code,
+                userInfo: [NSLocalizedDescriptionKey: message])
+        }
+        print("[PASS] \(message)")
+    }
+
+    try requireContains(source, "[\"changes\", componentId]", "changes helper uses current command shape", code: 98)
+    try requireContains(source, "[\"version\", \"show\", componentId]", "version show helper uses current command shape", code: 99)
+    try requireContains(source, "[\"build\", componentId]", "build helper uses current command shape", code: 100)
+    try requireContains(source, "[\"release\", componentId, \"--dry-run\"]", "release helper is dry-run only", code: 101)
+    try requireContains(contentView, "case release = \"Release\"", "release is a separate core tool", code: 102)
+    try requireContains(contentView, "ReleaseWorkflowView()", "release view is mounted separately from deployer", code: 103)
+    try requireContains(contentView, "Release Disabled", "mutating release action remains disabled", code: 104)
+    try requireNotContains(contentView, "cli.release(", "release view does not call a mutating release helper", code: 105)
+
+    print("")
 }
 
 func testDeployDryRun(fixturesDir: String, decoder: JSONDecoder) throws {

--- a/tests/fixtures/changes.json
+++ b/tests/fixtures/changes.json
@@ -1,0 +1,32 @@
+{
+  "success": true,
+  "data": {
+    "baseline_ref": "v0.11.3",
+    "baseline_source": "tag",
+    "changelog": {
+      "path": "/Users/chubes/Developer/homeboy-desktop/docs/CHANGELOG.md",
+      "unreleased_entries": 0
+    },
+    "commits": [
+      {
+        "category": "Fix",
+        "hash": "488c310",
+        "subject": "fix: modernize CLI helper command shapes (#40)"
+      },
+      {
+        "category": "Feature",
+        "hash": "00b472e",
+        "subject": "feat: add fleet management support (Closes #12)"
+      }
+    ],
+    "component_id": "homeboy-desktop",
+    "latest_tag": "v0.11.3",
+    "path": "/Users/chubes/Developer/homeboy-desktop",
+    "uncommitted": {
+      "has_changes": false,
+      "staged": [],
+      "unstaged": [],
+      "untracked": []
+    }
+  }
+}

--- a/tests/fixtures/release-dry-run.json
+++ b/tests/fixtures/release-dry-run.json
@@ -1,0 +1,13 @@
+{
+  "success": true,
+  "data": {
+    "command": "release",
+    "result": {
+      "bump_type": "major",
+      "component_id": "homeboy-desktop",
+      "dry_run": true,
+      "releasable_commits": 12,
+      "skipped_reason": "major-requires-flag"
+    }
+  }
+}

--- a/tests/fixtures/version-show.json
+++ b/tests/fixtures/version-show.json
@@ -1,0 +1,15 @@
+{
+  "success": true,
+  "data": {
+    "command": "version show",
+    "component_id": "homeboy-desktop",
+    "version": "0.11.3",
+    "path": "/Users/chubes/Developer/homeboy-desktop",
+    "targets": [
+      {
+        "file": "Homeboy/Core/Config/AppConfiguration.swift",
+        "pattern": "version = \\\"([0-9.]+)\\\""
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add a separate Release core tool for inspecting changes, version info, and `homeboy release --dry-run` plans without mixing release planning into deploy.
- Add CLI helpers and decode models for changes/version/build/release planning, plus fixture coverage for the new output contracts.
- Keep mutating release execution disabled while allowing `homeboy build` to run independently from deploy.

## Tests
- `swift tests/ContractTests.swift tests`
- `homeboy changes --help`
- `homeboy version --help`
- `homeboy build --help`
- `homeboy release --help`
- `homeboy release homeboy-desktop --path /Users/chubes/Developer/homeboy-desktop@feat-release-build-workflow --dry-run`
- `homeboy lint homeboy-desktop --path /Users/chubes/Developer/homeboy-desktop@feat-release-build-workflow` (Swift lint skipped because SwiftLint/SwiftFormat are not installed)

Closes #36

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the desktop release/build workflow; Chris to review before merge.