### PR TITLE
feat: add Git operations workspace

### DIFF
--- a/Homeboy.xcodeproj/project.pbxproj
+++ b/Homeboy.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		1EBFEF675F781A40A250D009 /* BackupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2026B5BAE550AC7BD82744DA /* BackupService.swift */; };
 		22221233AC86561D48490886 /* RemoteFileBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C2AF5C1F794564BF7DC0F4 /* RemoteFileBrowserView.swift */; };
 		278021F9D228BBDA95267231 /* HomeboyCLI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D870E69E9C29278BC862CD04 /* HomeboyCLI.swift */; };
+		2846F25C9D6A4E7BB401AA01 /* GitOperationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3C5E2D1F7B4C9A9002DD11 /* GitOperationsView.swift */; };
 		27D41F217F00E3A8171BEC63 /* AppWarning.swift in Sources */ = {isa = PBXBuildFile; fileRef = C489D03946456721B73D70EA /* AppWarning.swift */; };
 		27FA9FFDA56F6C7BCAFE0296 /* ModulesSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C398F35F8687FF75D86A408 /* ModulesSettingsTab.swift */; };
 		29AC5918A42B81DE1D250360 /* ContentContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC77F3DE919D687C5088735B /* ContentContext.swift */; };
@@ -43,6 +44,7 @@
 		58782E3C2B83E467318758D3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E134C3E1AFDFB8B9C3BFA989 /* Assets.xcassets */; };
 		58C9903BC07607162259D792 /* SSHKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9B567AD7EF6AEAFF4650E3 /* SSHKeyManager.swift */; };
 		58D7EB6E82E865D5736663C0 /* DeployerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C206F8FCC7B57F9E68E99A08 /* DeployerViewModel.swift */; };
+		5A7D2C4E91B8406DA0E3FB22 /* GitOperationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C1D9F4B2A6E438FA112CC33 /* GitOperationsViewModel.swift */; };
 		5A9B1A9B7984F57035A97D82 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D06A62D2DDC840DC6A12CC7 /* KeychainService.swift */; };
 		5AAC8C88082027144361696A /* ModuleManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267B4789567169ABFC9AAD53 /* ModuleManifest.swift */; };
 		5B3425AA6A8A9C4C9EF5E29F /* FileBrowserSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD70F8136E9691D7528CB581 /* FileBrowserSidebarView.swift */; };
@@ -152,12 +154,14 @@
 		6C195A8A1462489E882BC187 /* DisplayableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayableError.swift; sourceTree = "<group>"; };
 		75262FFB3BBC6BC33A8AC4F3 /* bandcamp_scraper.cpython-314.pyc */ = {isa = PBXFileReference; path = "bandcamp_scraper.cpython-314.pyc"; sourceTree = "<group>"; };
 		7BFAEBF8AA9E2BEC2A55EF0D /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
+		7C1D9F4B2A6E438FA112CC33 /* GitOperationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitOperationsViewModel.swift; sourceTree = "<group>"; };
 		7E6E41FFC96012F3C390C094 /* JSONValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValue.swift; sourceTree = "<group>"; };
 		811079398986364AA0E0542A /* CLIVersionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIVersionChecker.swift; sourceTree = "<group>"; };
 		830D15DCC64EB9AF17F822E0 /* ComponentsSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentsSettingsTab.swift; sourceTree = "<group>"; };
 		833BBA3138BAD0CFB3557D6B /* Homeboy.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Homeboy.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		83B2C9499D9E9A17D32109EF /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		8974EB4ED392FD3B52D70FD3 /* GeneralSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsTab.swift; sourceTree = "<group>"; };
+		8A3C5E2D1F7B4C9A9002DD11 /* GitOperationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitOperationsView.swift; sourceTree = "<group>"; };
 		8F7BEDC81C87152DCED825A3 /* SiteListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteListView.swift; sourceTree = "<group>"; };
 		9172819247F48893F5F20EA2 /* WordPressSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSettingsTab.swift; sourceTree = "<group>"; };
 		91949A849E1F8F3490BBEC6A /* CreateProjectSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateProjectSheet.swift; sourceTree = "<group>"; };
@@ -297,6 +301,7 @@
 			children = (
 				9FEB0F1E3E336D290DB4C2DE /* App */,
 				905C0DD32197709B0759C486 /* Core */,
+				6D8B13E4C9A74F91B205EE44 /* GitOperations */,
 				E51666A5CA18CBF6D75EBA87 /* Modules */,
 				48A84FF4933780B2CA668D49 /* Resources */,
 				7D4D938EF07D7C67EC4BFAEF /* ViewModels */,
@@ -328,6 +333,15 @@
 				F978C6E7F1C5288FF7303DF7 /* DeployerView.swift */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		6D8B13E4C9A74F91B205EE44 /* GitOperations */ = {
+			isa = PBXGroup;
+			children = (
+				94F1C7A8D3E24B55A609EE66 /* Views */,
+				7C1D9F4B2A6E438FA112CC33 /* GitOperationsViewModel.swift */,
+			);
+			path = Extensions/GitOperations;
 			sourceTree = "<group>";
 		};
 		73DE024E75BCEEAB05E11E1A /* Views */ = {
@@ -462,6 +476,14 @@
 				7E6E41FFC96012F3C390C094 /* JSONValue.swift */,
 			);
 			path = Copyable;
+			sourceTree = "<group>";
+		};
+		94F1C7A8D3E24B55A609EE66 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				8A3C5E2D1F7B4C9A9002DD11 /* GitOperationsView.swift */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 		9FEB0F1E3E336D290DB4C2DE /* App */ = {
@@ -682,6 +704,8 @@
 				02AD314100925D82AE384CE8 /* GeneralSettingsTab.swift in Sources */,
 				57C3AE0D20A591DEE69B0FF0 /* HomeboyApp.swift in Sources */,
 				278021F9D228BBDA95267231 /* HomeboyCLI.swift in Sources */,
+				2846F25C9D6A4E7BB401AA01 /* GitOperationsView.swift in Sources */,
+				5A7D2C4E91B8406DA0E3FB22 /* GitOperationsViewModel.swift in Sources */,
 				E832787BA1F926FB3A085E09 /* InlineErrorView.swift in Sources */,
 				EEA581470DC8B48027F54228 /* InlineWarningView.swift in Sources */,
 				5BDE52F8E2A18B1F50AD060A /* JSONValue.swift in Sources */,

--- a/Homeboy/App/ContentView.swift
+++ b/Homeboy/App/ContentView.swift
@@ -17,6 +17,7 @@ enum CoreTool: String, CaseIterable, Identifiable {
     case release = "Release"
     case rigs = "Rigs"
     case stackManager = "Stacks"
+    case git = "Git"
     case remoteFileEditor = "File Editor"
     case remoteLogViewer = "Log Viewer"
     case databaseBrowser = "Database"
@@ -31,6 +32,7 @@ enum CoreTool: String, CaseIterable, Identifiable {
         case .release: return "tag"
         case .rigs: return "shippingbox.and.arrow.backward"
         case .stackManager: return "square.stack.3d.up"
+        case .git: return "point.3.connected.trianglepath.dotted"
         case .remoteFileEditor: return "doc.badge.gearshape"
         case .remoteLogViewer: return "doc.text.magnifyingglass"
         case .databaseBrowser: return "cylinder.split.1x2"
@@ -79,6 +81,8 @@ struct ContentView: View {
                 .opacity(selectedItem == .coreTool(.rigs) ? 1 : 0)
             StackManagerView()
                 .opacity(selectedItem == .coreTool(.stackManager) ? 1 : 0)
+            GitOperationsView()
+                .opacity(selectedItem == .coreTool(.git) ? 1 : 0)
             DatabaseBrowserView()
                 .opacity(selectedItem == .coreTool(.databaseBrowser) ? 1 : 0)
             RemoteLogViewerView()

--- a/Homeboy/Core/CLI/HomeboyCLI.swift
+++ b/Homeboy/Core/CLI/HomeboyCLI.swift
@@ -433,6 +433,18 @@ struct GitSnapshot: Decodable {
     let baselineRef: String?
 }
 
+// MARK: - Git CLI Output Models
+
+struct GitStatusOutput: Decodable {
+    let action: String
+    let componentId: String
+    let exitCode: Int32
+    let path: String
+    let stderr: String
+    let stdout: String
+    let success: Bool
+}
+
 struct ReleaseSnapshot: Decodable {
     let tag: String?
     let date: String?
@@ -476,6 +488,23 @@ private init() {}
             args.append(contentsOf: ["--path", p])
         }
         return try await cli.executeCommand(args, dataType: InitOutput.self, source: "Init", timeout: 30)
+    }
+
+    // MARK: - Git Commands
+
+    /// Read-only wrapper for `homeboy git status`.
+    func gitStatus(componentId: String, path: String? = nil) async throws -> GitStatusOutput {
+        var args = ["git", "status", componentId]
+        if let path, !path.isEmpty {
+            args.append(contentsOf: ["--path", path])
+        }
+
+        return try await cli.executeCommand(
+            args,
+            dataType: GitStatusOutput.self,
+            source: "Git Status",
+            timeout: 30
+        )
     }
 
     // MARK: - Config Gap Commands

--- a/Homeboy/Extensions/GitOperations/GitOperationsViewModel.swift
+++ b/Homeboy/Extensions/GitOperations/GitOperationsViewModel.swift
@@ -1,0 +1,171 @@
+import AppKit
+import Combine
+import Foundation
+
+struct GitComponentState: Identifiable {
+    let component: ComponentConfiguration
+    var status: GitStatusOutput?
+    var remoteURL: URL?
+    var error: AppError?
+
+    var id: String { component.id }
+
+    var displayName: String { component.displayName }
+
+    var path: String { component.localPath }
+
+    var stateLabel: String {
+        if let error { return error.body }
+        guard let status else { return "Not loaded" }
+        guard status.success else { return "Status failed" }
+        return status.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "Clean" : "Changes"
+    }
+
+    var stateIcon: String {
+        if error != nil { return "exclamationmark.triangle.fill" }
+        guard let status else { return "circle" }
+        guard status.success else { return "xmark.circle.fill" }
+        return status.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "checkmark.circle.fill" : "circle.fill"
+    }
+
+    var stateColor: NSColor {
+        if error != nil { return .systemOrange }
+        guard let status else { return .secondaryLabelColor }
+        guard status.success else { return .systemRed }
+        return status.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? .systemGreen : .systemOrange
+    }
+
+    var githubIssuesURL: URL? {
+        remoteURL?.appendingPathComponent("issues")
+    }
+
+    var githubPullRequestsURL: URL? {
+        remoteURL?.appendingPathComponent("pulls")
+    }
+}
+
+@MainActor
+final class GitOperationsViewModel: ObservableObject, ConfigurationObserving {
+    @Published var components: [GitComponentState] = []
+    @Published var selectedComponentId: String?
+    @Published var isLoading = false
+    @Published var error: AppError?
+
+    var cancellables = Set<AnyCancellable>()
+
+    private let cli = HomeboyCLI.shared
+
+    init() {
+        loadComponents()
+        observeConfiguration()
+    }
+
+    var selectedComponent: GitComponentState? {
+        guard let selectedComponentId else { return components.first }
+        return components.first { $0.id == selectedComponentId }
+    }
+
+    func handleConfigChange(_ change: ConfigurationChangeType) {
+        switch change {
+        case .projectDidSwitch, .projectModified:
+            loadComponents()
+        default:
+            break
+        }
+    }
+
+    func refresh() {
+        guard HomeboyCLI.shared.isInstalled else {
+            error = AppError("Homeboy CLI is not installed. Install via Settings → CLI.", source: "Git")
+            return
+        }
+
+        isLoading = true
+        error = nil
+
+        Task {
+            var refreshed: [GitComponentState] = []
+
+            for state in components {
+                var next = state
+
+                do {
+                    async let status = cli.gitStatus(componentId: state.id, path: state.path)
+                    async let remote = githubRemoteURL(path: state.path)
+                    next.status = try await status
+                    next.remoteURL = await remote
+                    next.error = nil
+                } catch {
+                    next.error = AppError(error.localizedDescription, source: "Git Status: \(state.id)")
+                }
+
+                refreshed.append(next)
+            }
+
+            components = refreshed
+            isLoading = false
+        }
+    }
+
+    func open(_ url: URL?) {
+        guard let url else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    private func loadComponents() {
+        let project = ConfigurationManager.shared.safeActiveProject
+        let loaded = ConfigurationManager.shared.loadComponentsForProject(project)
+        components = loaded.map { GitComponentState(component: $0, status: nil, remoteURL: nil, error: nil) }
+
+        if selectedComponentId == nil || !components.contains(where: { $0.id == selectedComponentId }) {
+            selectedComponentId = components.first?.id
+        }
+    }
+
+    private nonisolated func githubRemoteURL(path: String) async -> URL? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git", "-C", path, "remote", "get-url", "origin"]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+
+        guard process.terminationStatus == 0 else { return nil }
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        guard let remote = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !remote.isEmpty else {
+            return nil
+        }
+
+        return normalizeGitHubURL(remote)
+    }
+
+    private nonisolated func normalizeGitHubURL(_ remote: String) -> URL? {
+        if remote.hasPrefix("git@github.com:") {
+            var path = remote.replacingOccurrences(of: "git@github.com:", with: "")
+            if path.hasSuffix(".git") {
+                path.removeLast(4)
+            }
+            return URL(string: "https://github.com/\(path)")
+        }
+
+        if remote.hasPrefix("https://github.com/") {
+            var url = remote
+            if url.hasSuffix(".git") {
+                url.removeLast(4)
+            }
+            return URL(string: url)
+        }
+
+        return nil
+    }
+}

--- a/Homeboy/Extensions/GitOperations/Views/GitOperationsView.swift
+++ b/Homeboy/Extensions/GitOperations/Views/GitOperationsView.swift
@@ -1,0 +1,245 @@
+import AppKit
+import SwiftUI
+
+struct GitOperationsView: View {
+    @StateObject private var viewModel = GitOperationsViewModel()
+    @State private var sortDescriptor: DataTableSortDescriptor<GitComponentState>?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            headerSection
+            Divider()
+
+            if viewModel.components.isEmpty {
+                emptyState
+            } else {
+                HSplitView {
+                    componentListSection
+                        .frame(minWidth: 420)
+
+                    detailSection
+                        .frame(minWidth: 360)
+                }
+            }
+        }
+        .frame(minWidth: 800, minHeight: 600)
+        .onAppear {
+            viewModel.refresh()
+        }
+    }
+
+    private var headerSection: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Git")
+                    .font(.title2.bold())
+                Text("Read-only component status and GitHub navigation")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            if viewModel.isLoading {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Refreshing...")
+                    .foregroundColor(.secondary)
+            }
+
+            Button {
+                viewModel.refresh()
+            } label: {
+                Image(systemName: "arrow.clockwise")
+            }
+            .buttonStyle(.borderless)
+            .help("Refresh git status")
+            .disabled(viewModel.isLoading)
+        }
+        .padding()
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "point.3.connected.trianglepath.dotted")
+                .font(.system(size: 56))
+                .foregroundColor(.secondary)
+
+            Text("No Components")
+                .font(.title)
+
+            Text("Add components in Settings to inspect their Git state.")
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var componentListSection: some View {
+        VStack(spacing: 0) {
+            NativeDataTable(
+                items: sortedComponents(viewModel.components),
+                columns: makeColumns(),
+                selection: Binding(
+                    get: { viewModel.selectedComponentId.map { Set([$0]) } ?? [] },
+                    set: { viewModel.selectedComponentId = $0.first }
+                ),
+                sortDescriptor: $sortDescriptor,
+                onDoubleClick: { component in
+                    viewModel.selectedComponentId = component.id
+                }
+            )
+
+            Divider()
+
+            HStack {
+                Text("\(viewModel.components.count) components")
+                    .foregroundColor(.secondary)
+                    .font(.caption)
+                Spacer()
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+        }
+    }
+
+    private var detailSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            if let component = viewModel.selectedComponent {
+                selectedComponentDetails(component)
+            } else {
+                ContentUnavailableView(
+                    "Select a Component",
+                    systemImage: "point.3.connected.trianglepath.dotted",
+                    description: Text("Choose a component to inspect its status output and GitHub links.")
+                )
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private func selectedComponentDetails(_ component: GitComponentState) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(component.displayName)
+                    .font(.title2.bold())
+                Text(component.path)
+                    .font(.caption.monospaced())
+                    .foregroundColor(.secondary)
+                    .textSelection(.enabled)
+            }
+
+            HStack(spacing: 8) {
+                Image(systemName: component.stateIcon)
+                    .foregroundColor(Color(component.stateColor))
+                Text(component.stateLabel)
+                    .font(.headline)
+            }
+
+            if let error = component.error {
+                InlineErrorView(error)
+            }
+
+            GroupBox("homeboy git status") {
+                VStack(alignment: .leading, spacing: 8) {
+                    if let status = component.status {
+                        LabeledContent("Exit code", value: String(status.exitCode))
+                        LabeledContent("Path", value: status.path)
+
+                        if !status.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                            Text(status.stdout)
+                                .font(.system(.caption, design: .monospaced))
+                                .textSelection(.enabled)
+                        } else if status.success {
+                            Text("No status output. The component is clean.")
+                                .foregroundColor(.secondary)
+                        }
+
+                        if !status.stderr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                            Text(status.stderr)
+                                .font(.system(.caption, design: .monospaced))
+                                .foregroundColor(.red)
+                                .textSelection(.enabled)
+                        }
+                    } else {
+                        Text("Status has not been loaded yet.")
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 4)
+            }
+
+            GroupBox("GitHub") {
+                HStack {
+                    Button("Issues") {
+                        viewModel.open(component.githubIssuesURL)
+                    }
+                    .disabled(component.githubIssuesURL == nil)
+
+                    Button("Pull Requests") {
+                        viewModel.open(component.githubPullRequestsURL)
+                    }
+                    .disabled(component.githubPullRequestsURL == nil)
+
+                    Spacer()
+                }
+                .padding(.vertical, 4)
+            }
+
+            Spacer()
+        }
+    }
+
+    private func sortedComponents(_ components: [GitComponentState]) -> [GitComponentState] {
+        guard let descriptor = sortDescriptor else {
+            return components.sorted { $0.displayName.localizedStandardCompare($1.displayName) == .orderedAscending }
+        }
+        return components.sorted { lhs, rhs in
+            descriptor.compare(lhs, rhs) == .orderedAscending
+        }
+    }
+
+    private func makeColumns() -> [DataTableColumn<GitComponentState>] {
+        [
+            .text(
+                id: "component",
+                title: "Component",
+                width: .auto(min: 140, ideal: 180, max: 300),
+                keyPath: \.displayName
+            ),
+            .custom(
+                id: "state",
+                title: "State",
+                width: .fixed(120),
+                sortable: true,
+                sortComparator: { lhs, rhs in lhs.stateLabel.localizedStandardCompare(rhs.stateLabel) },
+                cellProvider: { component in
+                    makeIconTextCell(
+                        text: component.stateLabel,
+                        iconName: component.stateIcon,
+                        iconColor: component.stateColor
+                    )
+                }
+            ),
+            .custom(
+                id: "path",
+                title: "Path",
+                width: .auto(min: 180, ideal: 280, max: 500),
+                sortComparator: { lhs, rhs in lhs.path.localizedStandardCompare(rhs.path) },
+                cellProvider: { component in
+                    makeTextCell(
+                        text: component.path,
+                        font: DataTableConstants.monospaceFont,
+                        color: DataTableConstants.secondaryTextColor,
+                        alignment: .left
+                    )
+                }
+            )
+        ]
+    }
+}
+
+#Preview {
+    GitOperationsView()
+}

--- a/Homeboy/Views/Components/Table/DataTableColumn.swift
+++ b/Homeboy/Views/Components/Table/DataTableColumn.swift
@@ -205,7 +205,7 @@ func makeTextCell(
     return textField
 }
 
-private func makeIconTextCell(
+func makeIconTextCell(
     text: String,
     iconName: String,
     iconColor: NSColor

--- a/tests/ContractTests.swift
+++ b/tests/ContractTests.swift
@@ -379,6 +379,18 @@ struct ReleaseResultTest: Decodable {
     let skippedReason: String?
 }
 
+// MARK: - Git Output Types (mirror HomeboyCLI.swift)
+
+struct GitStatusOutputTest: Decodable {
+    let action: String
+    let componentId: String
+    let exitCode: Int32
+    let path: String
+    let stderr: String
+    let stdout: String
+    let success: Bool
+}
+
 // MARK: - Test Runner
 
 func runTests(testDir: String) throws {
@@ -441,6 +453,12 @@ func runTests(testDir: String) throws {
 
     // Test 17: Stack command JSON contracts
     try testStackContracts(fixturesDir: fixturesDir, decoder: decoder)
+
+    // Test 18: git-status.json parsing
+    try testGitStatus(fixturesDir: fixturesDir, decoder: decoder)
+
+    // Test 19: Git workspace command shapes
+    try testGitWorkspaceCommandShapes(testDir: testDir)
 
     print("")
     print("All contract tests passed")
@@ -521,6 +539,50 @@ func testReleaseBuildPlanningCommandShapes() throws {
     try requireContains(contentView, "Release Disabled", "mutating release action remains disabled", code: 104)
     try requireNotContains(contentView, "cli.release(", "release view does not call a mutating release helper", code: 105)
 
+    print("")
+}
+
+func testGitStatus(fixturesDir: String, decoder: JSONDecoder) throws {
+    print("Test: git-status.json")
+    print("---------------------")
+
+    let fixture = URL(fileURLWithPath: "\(fixturesDir)/git-status.json")
+
+    guard FileManager.default.fileExists(atPath: fixture.path) else {
+        throw NSError(domain: "ContractTest", code: 100,
+            userInfo: [NSLocalizedDescriptionKey: "Fixture not found: git-status.json"])
+    }
+
+    let data = try Data(contentsOf: fixture)
+    let result = try decoder.decode(CLIResponse<GitStatusOutputTest>.self, from: data)
+
+    guard result.success else {
+        throw NSError(domain: "ContractTest", code: 101,
+            userInfo: [NSLocalizedDescriptionKey: "git-status.json: success=false"])
+    }
+
+    guard let status = result.data else {
+        throw NSError(domain: "ContractTest", code: 102,
+            userInfo: [NSLocalizedDescriptionKey: "git-status.json: data field is nil"])
+    }
+
+    guard status.action == "status" else {
+        throw NSError(domain: "ContractTest", code: 103,
+            userInfo: [NSLocalizedDescriptionKey: "git-status.json: action mismatch"])
+    }
+    print("[PASS] action is status")
+
+    guard status.componentId == "homeboy-desktop" else {
+        throw NSError(domain: "ContractTest", code: 104,
+            userInfo: [NSLocalizedDescriptionKey: "git-status.json: componentId mismatch"])
+    }
+    print("[PASS] componentId decoded")
+
+    guard status.exitCode == 0 && status.success else {
+        throw NSError(domain: "ContractTest", code: 105,
+            userInfo: [NSLocalizedDescriptionKey: "git-status.json: status should be successful"])
+    }
+    print("[PASS] status success fields decoded")
     print("")
 }
 
@@ -1149,6 +1211,55 @@ func testCurrentCLICommandSurface(testDir: String) throws {
         }
     }
     print("[PASS] Audit filters and help-surface probe are present")
+
+    print("")
+}
+
+func testGitWorkspaceCommandShapes(testDir: String) throws {
+    print("Test: Git workspace command shapes")
+    print("----------------------------------")
+
+    let cliSource = try String(contentsOf: URL(fileURLWithPath: "Homeboy/Core/CLI/HomeboyCLI.swift"), encoding: .utf8)
+    let viewModelSource = try String(
+        contentsOf: URL(fileURLWithPath: "Homeboy/Extensions/GitOperations/GitOperationsViewModel.swift"),
+        encoding: .utf8
+    )
+    let viewSource = try String(
+        contentsOf: URL(fileURLWithPath: "Homeboy/Extensions/GitOperations/Views/GitOperationsView.swift"),
+        encoding: .utf8
+    )
+
+    func requireContains(_ source: String, _ needle: String, _ message: String, code: Int) throws {
+        guard source.contains(needle) else {
+            throw NSError(domain: "ContractTest", code: code,
+                userInfo: [NSLocalizedDescriptionKey: message])
+        }
+        print("[PASS] \(message)")
+    }
+
+    func requireNotContains(_ source: String, _ needle: String, _ message: String, code: Int) throws {
+        guard !source.contains(needle) else {
+            throw NSError(domain: "ContractTest", code: code,
+                userInfo: [NSLocalizedDescriptionKey: message])
+        }
+        print("[PASS] \(message)")
+    }
+
+    try requireContains(cliSource, #"var args = ["git", "status", componentId]"#,
+        "Git status wrapper uses homeboy git status", code: 110)
+    try requireContains(cliSource, #"args.append(contentsOf: ["--path", path])"#,
+        "Git status wrapper supports --path", code: 111)
+    try requireContains(viewModelSource, #"process.arguments = ["git", "-C", path, "remote", "get-url", "origin"]"#,
+        "GitHub navigation reads origin URL without mutation", code: 112)
+    try requireContains(viewSource, #"Button("Issues")"#,
+        "Git view exposes Issues navigation", code: 113)
+    try requireContains(viewSource, #"Button("Pull Requests")"#,
+        "Git view exposes Pull Requests navigation", code: 114)
+
+    for forbidden in ["commit", "push", "rebase", "cherry-pick", "tag", "issues reconcile"] {
+        try requireNotContains(viewSource, forbidden, "Git workspace does not expose mutating \(forbidden) operation", code: 120)
+    }
+
     print("")
 }
 

--- a/tests/fixtures/git-status.json
+++ b/tests/fixtures/git-status.json
@@ -1,0 +1,12 @@
+{
+  "success": true,
+  "data": {
+    "action": "status",
+    "component_id": "homeboy-desktop",
+    "exit_code": 0,
+    "path": "/Users/chubes/Developer/homeboy-desktop@feat-git-github-workspace",
+    "stderr": "",
+    "stdout": "",
+    "success": true
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a read-only Git core workspace that lists configured components and refreshes each component through `homeboy git status`.
- Shows selected-component status output plus GitHub Issues and Pull Requests links derived from the component's `origin` remote.
- Keeps mutating Git operations and `homeboy issues reconcile` out of this first slice.

## Tests
- `swift tests/ContractTests.swift tests`
- `homeboy git --help`
- `homeboy issues --help`
- `homeboy git status homeboy-desktop --path /Users/chubes/Developer/homeboy-desktop@feat-git-github-workspace`
- `swiftc -parse Homeboy/Core/CLI/HomeboyCLI.swift Homeboy/Extensions/GitOperations/GitOperationsViewModel.swift Homeboy/Extensions/GitOperations/Views/GitOperationsView.swift Homeboy/App/ContentView.swift Homeboy/Views/Components/Table/DataTableColumn.swift`
- `homeboy lint homeboy-desktop --path /Users/chubes/Developer/homeboy-desktop@feat-git-github-workspace`

`xcodebuild` was not available because the active developer directory is Command Line Tools, not Xcode.

Closes #37

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the desktop Git/GitHub workspace; Chris to review before merge.
