### PR TITLE
feat: add API auth workspace

### DIFF
--- a/Homeboy.xcodeproj/project.pbxproj
+++ b/Homeboy.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0186B7D809C9473D9EC3F424 /* APIAuthWorkspaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0186B7D709C9473D9EC3F424 /* APIAuthWorkspaceView.swift */; };
 		023E9AE450BF036FF40C0E76 /* ProjectConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C794768AF4898995F64DB92D /* ProjectConfiguration.swift */; };
 		02AD314100925D82AE384CE8 /* GeneralSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8974EB4ED392FD3B52D70FD3 /* GeneralSettingsTab.swift */; };
 		0597F5E10CC3D748D36710F9 /* ConfigurationObserving.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6676A7C26F7EE42CD5B9E7A /* ConfigurationObserving.swift */; };
@@ -108,6 +109,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0186B7D709C9473D9EC3F424 /* APIAuthWorkspaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIAuthWorkspaceView.swift; sourceTree = "<group>"; };
 		0354F3771ED337E0EDCAC7B5 /* ModuleResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleResultsView.swift; sourceTree = "<group>"; };
 		0BBA2DD3A1B1041ACA3A049F /* RemoteFileEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileEntry.swift; sourceTree = "<group>"; };
 		0CD2C75C18D0464C6428E5EE /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
@@ -430,6 +432,7 @@
 			isa = PBXGroup;
 			children = (
 				E458125E00E4AA130D4F530D /* Table */,
+				0186B7D709C9473D9EC3F424 /* APIAuthWorkspaceView.swift */,
 				BA88D343E94C4C34E1069813 /* CodeTextView.swift */,
 				4ED098FFBF749CD6DD355B1B /* CollapsibleSplitView.swift */,
 				4406A9EEECAF8249580937A7 /* CopyableTextView.swift */,
@@ -698,6 +701,7 @@
 				58D7EB6E82E865D5736663C0 /* DeployerViewModel.swift in Sources */,
 				85F4F94606B3D49BEFDC227F /* DeploymentService.swift in Sources */,
 				AB378FCB8518F6BED6EEFB6F /* DisplayableError.swift in Sources */,
+				0186B7D809C9473D9EC3F424 /* APIAuthWorkspaceView.swift in Sources */,
 				5CA76C92A6AF0C42784FD35D /* ErrorView.swift in Sources */,
 				5B3425AA6A8A9C4C9EF5E29F /* FileBrowserSidebarView.swift in Sources */,
 				85A8C46096DE6DFF3BD11E63 /* FindableTextView.swift in Sources */,

--- a/Homeboy/App/ContentView.swift
+++ b/Homeboy/App/ContentView.swift
@@ -21,6 +21,7 @@ enum CoreTool: String, CaseIterable, Identifiable {
     case remoteFileEditor = "File Editor"
     case remoteLogViewer = "Log Viewer"
     case databaseBrowser = "Database"
+    case apiAuth = "API/Auth"
     case settings = "Settings"
     
     var id: String { rawValue }
@@ -36,6 +37,7 @@ enum CoreTool: String, CaseIterable, Identifiable {
         case .remoteFileEditor: return "doc.badge.gearshape"
         case .remoteLogViewer: return "doc.text.magnifyingglass"
         case .databaseBrowser: return "cylinder.split.1x2"
+        case .apiAuth: return "network.badge.shield.half.filled"
         case .settings: return "gear"
         }
     }
@@ -89,6 +91,8 @@ struct ContentView: View {
                 .opacity(selectedItem == .coreTool(.remoteLogViewer) ? 1 : 0)
             RemoteFileEditorView()
                 .opacity(selectedItem == .coreTool(.remoteFileEditor) ? 1 : 0)
+            APIAuthWorkspaceView()
+                .opacity(selectedItem == .coreTool(.apiAuth) ? 1 : 0)
             SettingsView()
                 .opacity(selectedItem == .coreTool(.settings) ? 1 : 0)
             

--- a/Homeboy/Core/CLI/HomeboyCLI.swift
+++ b/Homeboy/Core/CLI/HomeboyCLI.swift
@@ -87,6 +87,21 @@ struct ApiConfigCLI: Decodable {
     let enabled: Bool
 }
 
+// MARK: - API/Auth CLI Output Models
+
+struct HomeboyAuthOutput: Decodable {
+    let projectId: String
+    let authenticated: Bool?
+    let success: Bool?
+}
+
+struct HomeboyAPIGetOutput: Decodable {
+    let projectId: String
+    let method: String
+    let endpoint: String
+    let response: JSONValue
+}
+
 struct SubTargetCLI: Decodable, Identifiable {
     let name: String
     let domain: String
@@ -601,6 +616,42 @@ private init() {}
             ["project", "delete", id],
             dataType: ProjectMutationOutput.self,
             source: "Project Delete"
+        )
+    }
+
+    // MARK: - API/Auth Commands
+
+    func authStatus(projectId: String) async throws -> HomeboyAuthOutput {
+        try await cli.executeCommand(
+            ["auth", "status", "--project", projectId],
+            dataType: HomeboyAuthOutput.self,
+            source: "API Auth Status"
+        )
+    }
+
+    func authLogin(projectId: String, identifier: String, password: String) async throws -> HomeboyAuthOutput {
+        try await cli.executeCommand(
+            ["auth", "login", "--project", projectId, "--identifier", identifier, "--password", password],
+            dataType: HomeboyAuthOutput.self,
+            source: "API Auth Login",
+            timeout: 60
+        )
+    }
+
+    func authLogout(projectId: String) async throws -> HomeboyAuthOutput {
+        try await cli.executeCommand(
+            ["auth", "logout", "--project", projectId],
+            dataType: HomeboyAuthOutput.self,
+            source: "API Auth Logout"
+        )
+    }
+
+    func apiGet(projectId: String, endpoint: String) async throws -> HomeboyAPIGetOutput {
+        try await cli.executeCommand(
+            ["api", projectId, "get", endpoint],
+            dataType: HomeboyAPIGetOutput.self,
+            source: "API GET",
+            timeout: 60
         )
     }
 

--- a/Homeboy/Core/Copyable/JSONValue.swift
+++ b/Homeboy/Core/Copyable/JSONValue.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Type-erased JSON value for parsing CLI error details.
 /// Preserves the structure of arbitrary JSON while allowing string representation for display.
-enum JSONValue: Decodable, Sendable, Equatable {
+enum JSONValue: Codable, Sendable, Equatable {
     case string(String)
     case int(Int)
     case double(Double)
@@ -58,6 +58,27 @@ enum JSONValue: Decodable, Sendable, Equatable {
         )
     }
 
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .string(let value):
+            try container.encode(value)
+        case .int(let value):
+            try container.encode(value)
+        case .double(let value):
+            try container.encode(value)
+        case .bool(let value):
+            try container.encode(value)
+        case .null:
+            try container.encodeNil()
+        case .array(let values):
+            try container.encode(values)
+        case .object(let dict):
+            try container.encode(dict)
+        }
+    }
+
     /// Flatten value to string for display in error context
     var stringValue: String {
         switch self {
@@ -78,6 +99,18 @@ enum JSONValue: Decodable, Sendable, Equatable {
             let pairs = dict.map { "\($0.key): \($0.value.stringValue)" }
             return "{\(pairs.joined(separator: ", "))}"
         }
+    }
+
+    var prettyPrintedJSONString: String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        guard let data = try? encoder.encode(self),
+              let json = String(data: data, encoding: .utf8) else {
+            return stringValue
+        }
+
+        return json
     }
 
     /// Flatten nested object to key-value pairs with dotted keys for error context.

--- a/Homeboy/Views/Components/APIAuthWorkspaceView.swift
+++ b/Homeboy/Views/Components/APIAuthWorkspaceView.swift
@@ -1,0 +1,317 @@
+import AppKit
+import SwiftUI
+
+struct APIAuthWorkspaceView: View {
+    @ObservedObject private var config = ConfigurationManager.shared
+
+    @State private var selectedProjectId: String = ""
+    @State private var authStatus: HomeboyAuthOutput?
+    @State private var endpoint = "/wp/v2/types"
+    @State private var identifier = ""
+    @State private var password = ""
+    @State private var apiResult: HomeboyAPIGetOutput?
+    @State private var isLoadingStatus = false
+    @State private var isRunningRequest = false
+    @State private var isLoggingIn = false
+    @State private var errorMessage: String?
+
+    private var projects: [ProjectConfiguration] {
+        config.availableProjects.isEmpty ? [config.safeActiveProject] : config.availableProjects
+    }
+
+    private var selectedProject: ProjectConfiguration? {
+        projects.first { $0.id == selectedProjectId } ?? config.activeProject
+    }
+
+    private var selectedProjectAPIConfig: APIConfig? {
+        selectedProject?.api
+    }
+
+    private var canRunGet: Bool {
+        !selectedProjectId.isEmpty && !endpoint.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isRunningRequest
+    }
+
+    private var canLogin: Bool {
+        !selectedProjectId.isEmpty && !identifier.isEmpty && !password.isEmpty && !isLoggingIn
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    projectPicker
+                    authPanel
+                    getExplorer
+                }
+                .padding(24)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .task {
+            initializeSelection()
+            await refreshStatus()
+        }
+        .onChange(of: config.activeProject?.id) { _, _ in
+            initializeSelection()
+            Task { await refreshStatus() }
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("API/Auth")
+                    .font(.largeTitle)
+                    .fontWeight(.semibold)
+                Text("Homeboy project API authentication and safe read-only requests")
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            Button {
+                Task { await refreshStatus() }
+            } label: {
+                Label("Refresh", systemImage: "arrow.clockwise")
+            }
+            .disabled(isLoadingStatus || selectedProjectId.isEmpty)
+        }
+        .padding(24)
+    }
+
+    private var projectPicker: some View {
+        GroupBox("Project") {
+            VStack(alignment: .leading, spacing: 12) {
+                Picker("Project", selection: $selectedProjectId) {
+                    ForEach(projects) { project in
+                        Text(project.id).tag(project.id)
+                    }
+                }
+                .pickerStyle(.menu)
+                .onChange(of: selectedProjectId) { _, _ in
+                    authStatus = nil
+                    apiResult = nil
+                    errorMessage = nil
+                    Task { await refreshStatus() }
+                }
+
+                if let api = selectedProjectAPIConfig {
+                    LabeledContent("API enabled") {
+                        Text(api.enabled ? "Yes" : "No")
+                            .foregroundStyle(api.enabled ? .green : .secondary)
+                    }
+                    LabeledContent("Base URL") {
+                        Text(api.baseURL.isEmpty ? "Not configured" : api.baseURL)
+                            .textSelection(.enabled)
+                            .foregroundStyle(api.baseURL.isEmpty ? .secondary : .primary)
+                    }
+                }
+
+                if let errorMessage {
+                    InlineErrorView(errorMessage, source: "API/Auth")
+                }
+            }
+            .frame(maxWidth: 640, alignment: .leading)
+        }
+    }
+
+    private var authPanel: some View {
+        GroupBox("Project API Auth") {
+            VStack(alignment: .leading, spacing: 16) {
+                HStack(spacing: 12) {
+                    statusBadge
+                    Spacer()
+                    Button("Check Status") {
+                        Task { await refreshStatus() }
+                    }
+                    .disabled(isLoadingStatus || selectedProjectId.isEmpty)
+
+                    Button("Logout") {
+                        Task { await logout() }
+                    }
+                    .disabled(selectedProjectId.isEmpty || isLoadingStatus)
+                }
+
+                Text("This uses `homeboy auth`, which stores credentials in Homeboy's project-scoped auth workspace. It does not use the desktop app login session.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                VStack(alignment: .leading, spacing: 10) {
+                    TextField("Username or email", text: $identifier)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: 360)
+                    SecureField("Password", text: $password)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: 360)
+                    Button {
+                        Task { await login() }
+                    } label: {
+                        if isLoggingIn {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Label("Login with Homeboy", systemImage: "key")
+                        }
+                    }
+                    .disabled(!canLogin)
+                }
+            }
+            .frame(maxWidth: 640, alignment: .leading)
+        }
+    }
+
+    private var statusBadge: some View {
+        HStack(spacing: 8) {
+            if isLoadingStatus {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Checking auth status")
+            } else if authStatus?.authenticated == true {
+                Image(systemName: "checkmark.seal.fill")
+                    .foregroundStyle(.green)
+                Text("Authenticated")
+            } else if authStatus != nil {
+                Image(systemName: "person.crop.circle.badge.xmark")
+                    .foregroundStyle(.secondary)
+                Text("Not authenticated")
+            } else {
+                Image(systemName: "questionmark.circle")
+                    .foregroundStyle(.secondary)
+                Text("Status unknown")
+            }
+        }
+    }
+
+    private var getExplorer: some View {
+        GroupBox("Safe GET Explorer") {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack {
+                    TextField("Endpoint", text: $endpoint)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(.body, design: .monospaced))
+                    Button {
+                        Task { await runGet() }
+                    } label: {
+                        if isRunningRequest {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Label("Run GET", systemImage: "play.fill")
+                        }
+                    }
+                    .disabled(!canRunGet)
+                }
+
+                Text("Only `homeboy api <project> get <endpoint>` is exposed here. Mutating verbs stay out of the desktop UI until preview and confirmation are designed.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                if let apiResult {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("Response")
+                                .font(.headline)
+                            Spacer()
+                            Button("Copy JSON") {
+                                copyToClipboard(apiResult.response.prettyPrintedJSONString)
+                            }
+                        }
+                        Text(apiResult.response.prettyPrintedJSONString)
+                            .font(.system(.body, design: .monospaced))
+                            .textSelection(.enabled)
+                            .padding(12)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Color(nsColor: .textBackgroundColor))
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                    }
+                } else {
+                    ContentUnavailableView(
+                        "No API Response",
+                        systemImage: "curlybraces",
+                        description: Text("Run a GET request to inspect the project's configured API.")
+                    )
+                    .frame(maxWidth: .infinity, minHeight: 180)
+                }
+            }
+        }
+    }
+
+    private func initializeSelection() {
+        if selectedProjectId.isEmpty || !projects.contains(where: { $0.id == selectedProjectId }) {
+            selectedProjectId = config.activeProject?.id ?? projects.first?.id ?? ""
+        }
+    }
+
+    private func refreshStatus() async {
+        guard !selectedProjectId.isEmpty else { return }
+        isLoadingStatus = true
+        errorMessage = nil
+        defer { isLoadingStatus = false }
+
+        do {
+            authStatus = try await HomeboyCLI.shared.authStatus(projectId: selectedProjectId)
+        } catch {
+            authStatus = nil
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func login() async {
+        guard canLogin else { return }
+        isLoggingIn = true
+        errorMessage = nil
+        defer { isLoggingIn = false }
+
+        do {
+            authStatus = try await HomeboyCLI.shared.authLogin(
+                projectId: selectedProjectId,
+                identifier: identifier,
+                password: password
+            )
+            password = ""
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func logout() async {
+        guard !selectedProjectId.isEmpty else { return }
+        isLoadingStatus = true
+        errorMessage = nil
+        defer { isLoadingStatus = false }
+
+        do {
+            _ = try await HomeboyCLI.shared.authLogout(projectId: selectedProjectId)
+            authStatus = try? await HomeboyCLI.shared.authStatus(projectId: selectedProjectId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func runGet() async {
+        guard canRunGet else { return }
+        isRunningRequest = true
+        errorMessage = nil
+        apiResult = nil
+        defer { isRunningRequest = false }
+
+        let normalizedEndpoint = endpoint.hasPrefix("/") ? endpoint : "/\(endpoint)"
+
+        do {
+            apiResult = try await HomeboyCLI.shared.apiGet(projectId: selectedProjectId, endpoint: normalizedEndpoint)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func copyToClipboard(_ value: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(value, forType: .string)
+    }
+}
+
+#Preview {
+    APIAuthWorkspaceView()
+}

--- a/tests/ContractTests.swift
+++ b/tests/ContractTests.swift
@@ -231,6 +231,21 @@ struct RigPipelineStepTest: Decodable {
     let error: String?
 }
 
+// MARK: - API/Auth Output Types (mirror HomeboyCLI.swift)
+
+struct HomeboyAuthOutputTest: Decodable {
+    let projectId: String
+    let authenticated: Bool?
+    let success: Bool?
+}
+
+struct HomeboyAPIGetOutputTest: Decodable {
+    let projectId: String
+    let method: String
+    let endpoint: String
+    let response: JSONValueTest
+}
+
 struct WPTable: Decodable {
     let Name: String
     let Rows: String?
@@ -460,8 +475,59 @@ func runTests(testDir: String) throws {
     // Test 19: Git workspace command shapes
     try testGitWorkspaceCommandShapes(testDir: testDir)
 
+    // Test 20: API/Auth model decoding and command shapes
+    try testAPIAuthContracts(decoder: decoder)
+
     print("")
     print("All contract tests passed")
+}
+
+func testAPIAuthContracts(decoder: JSONDecoder) throws {
+    print("Test: API/Auth workspace contracts")
+    print("----------------------------------")
+
+    let authJSON = #"{"success":true,"data":{"project_id":"example","authenticated":true}}"#.data(using: .utf8)!
+    let auth = try decoder.decode(CLIResponse<HomeboyAuthOutputTest>.self, from: authJSON)
+    guard auth.data?.projectId == "example", auth.data?.authenticated == true else {
+        throw NSError(domain: "ContractTest", code: 120,
+            userInfo: [NSLocalizedDescriptionKey: "auth status output does not decode snake_case project_id/authenticated fields"])
+    }
+    print("[PASS] Auth status output decodes")
+
+    let apiJSON = #"{"success":true,"data":{"project_id":"example","method":"GET","endpoint":"/wp/v2/types","response":{"ok":true,"count":2}}}"#.data(using: .utf8)!
+    let api = try decoder.decode(CLIResponse<HomeboyAPIGetOutputTest>.self, from: apiJSON)
+    guard api.data?.projectId == "example", api.data?.method == "GET", api.data?.endpoint == "/wp/v2/types" else {
+        throw NSError(domain: "ContractTest", code: 121,
+            userInfo: [NSLocalizedDescriptionKey: "api GET output does not decode expected metadata fields"])
+    }
+    guard case .object(let responseObject) = api.data?.response,
+          case .bool(true) = responseObject["ok"],
+          case .int(2) = responseObject["count"] else {
+        throw NSError(domain: "ContractTest", code: 122,
+            userInfo: [NSLocalizedDescriptionKey: "api GET response does not preserve arbitrary JSON"])
+    }
+    print("[PASS] API GET output decodes arbitrary response JSON")
+
+    let source = try String(contentsOf: URL(fileURLWithPath: "Homeboy/Core/CLI/HomeboyCLI.swift"), encoding: .utf8)
+
+    func requireContains(_ needle: String, _ message: String, code: Int) throws {
+        guard source.contains(needle) else {
+            throw NSError(domain: "ContractTest", code: code,
+                userInfo: [NSLocalizedDescriptionKey: message])
+        }
+        print("[PASS] \(message)")
+    }
+
+    try requireContains("[\"auth\", \"status\", \"--project\", projectId]",
+        "auth status wrapper uses current CLI shape", code: 123)
+    try requireContains("[\"auth\", \"login\", \"--project\", projectId, \"--identifier\", identifier, \"--password\", password]",
+        "auth login wrapper uses non-interactive CLI flags", code: 124)
+    try requireContains("[\"auth\", \"logout\", \"--project\", projectId]",
+        "auth logout wrapper uses current CLI shape", code: 125)
+    try requireContains("[\"api\", projectId, \"get\", endpoint]",
+        "api GET wrapper exposes only read-only API command", code: 126)
+
+    print("")
 }
 
 func testReleaseBuildPlanningFixtures(fixturesDir: String, decoder: JSONDecoder) throws {


### PR DESCRIPTION
## Summary
- Adds a new API/Auth core workspace separate from the desktop app's own AuthManager login state.
- Adds CLI-backed models/wrappers for `homeboy auth status`, `login`, `logout`, and read-only `homeboy api <project> get`.
- Adds a safe GET explorer UI with project API config/status display and arbitrary JSON response rendering/copying; mutating verbs remain intentionally out of scope.

## Tests
- `swift tests/ContractTests.swift tests`
- `homeboy auth --help`
- `homeboy api --help`
- `homeboy auth status --project intelligence-chubes4` returns `config.invalid_value` because API is not enabled for the local fixture project.
- `homeboy api intelligence-chubes4 get /wp/v2/types` is blocked by the current Homeboy CLI serializing `projectId` while the API parser expects `project_id`.
- `homeboy lint homeboy-desktop --path /Users/chubes/Developer/homeboy-desktop@feat-api-auth-workspace` passes; Swift lint is skipped because SwiftLint/SwiftFormat are not installed.
- `xcodebuild -project Homeboy.xcodeproj -scheme Homeboy -destination 'platform=macOS' build` could not run because this machine's active developer directory is CommandLineTools, not full Xcode.

Closes #38

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the desktop API/Auth workspace; Chris to review before merge.
