### PR TITLE
feat: add component quality workspace

### DIFF
--- a/Homeboy.xcodeproj/project.pbxproj
+++ b/Homeboy.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		0597F5E10CC3D748D36710F9 /* ConfigurationObserving.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6676A7C26F7EE42CD5B9E7A /* ConfigurationObserving.swift */; };
 		0B1C053B8DCA686200739C43 /* ServerEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D75CB92C4916A5B3A8DE34 /* ServerEditSheet.swift */; };
 		0BB5245A79F8709EBD8C5269 /* ModuleInstallSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA1C2F245C5FCEF82A5D2D3 /* ModuleInstallSheet.swift */; };
+		0D4D7E7A5AB24A1D85E8A001 /* QualityModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4D7E7A5AB24A1D85E8A101 /* QualityModels.swift */; };
+		0D4D7E7A5AB24A1D85E8A002 /* QualityViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4D7E7A5AB24A1D85E8A102 /* QualityViewModel.swift */; };
+		0D4D7E7A5AB24A1D85E8A003 /* QualityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4D7E7A5AB24A1D85E8A103 /* QualityView.swift */; };
 		0FE6351E7C94950D6A459978 /* DeployerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F978C6E7F1C5288FF7303DF7 /* DeployerView.swift */; };
 		1162E40A1D0549D9B68608A8 /* BenchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1162E4091D0549D9B68608A8 /* BenchView.swift */; };
 		102A2F3B4C5D6E7F8091A2B3 /* RigsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3B4C5D6E7F8091A2B3102A /* RigsView.swift */; };
@@ -113,6 +116,9 @@
 		0354F3771ED337E0EDCAC7B5 /* ModuleResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleResultsView.swift; sourceTree = "<group>"; };
 		0BBA2DD3A1B1041ACA3A049F /* RemoteFileEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileEntry.swift; sourceTree = "<group>"; };
 		0CD2C75C18D0464C6428E5EE /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
+		0D4D7E7A5AB24A1D85E8A101 /* QualityModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QualityModels.swift; sourceTree = "<group>"; };
+		0D4D7E7A5AB24A1D85E8A102 /* QualityViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QualityViewModel.swift; sourceTree = "<group>"; };
+		0D4D7E7A5AB24A1D85E8A103 /* QualityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QualityView.swift; sourceTree = "<group>"; };
 		0DC18F8D8A50F464D296BB74 /* InlineWarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineWarningView.swift; sourceTree = "<group>"; };
 		1162E4091D0549D9B68608A8 /* BenchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchView.swift; sourceTree = "<group>"; };
 		13F8D60E3516F29F554438A0 /* VersionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionParser.swift; sourceTree = "<group>"; };
@@ -271,6 +277,24 @@
 				29EDC4F278327A663263D4A7 /* DatabaseBrowserViewModel.swift */,
 			);
 			path = DatabaseBrowser;
+			sourceTree = "<group>";
+		};
+		47D4D7E7A5AB24A1D85E8A00 /* Quality */ = {
+			isa = PBXGroup;
+			children = (
+				48D4D7E7A5AB24A1D85E8A00 /* Views */,
+				0D4D7E7A5AB24A1D85E8A101 /* QualityModels.swift */,
+				0D4D7E7A5AB24A1D85E8A102 /* QualityViewModel.swift */,
+			);
+			path = Quality;
+			sourceTree = "<group>";
+		};
+		48D4D7E7A5AB24A1D85E8A00 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				0D4D7E7A5AB24A1D85E8A103 /* QualityView.swift */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 		48A84FF4933780B2CA668D49 /* Resources */ = {
@@ -529,10 +553,11 @@
 			children = (
 				46F743648D562B5D67158FFF /* DatabaseBrowser */,
 				26C9D5C3477F3537E1BB713A /* Deployer */,
+				47D4D7E7A5AB24A1D85E8A00 /* Quality */,
 				2E61F67D3432F0D875C83574 /* RemoteFileEditor */,
 				426FE25E9CC2781D94562CE8 /* RemoteLogViewer */,
 			);
-			path = Modules;
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		E900FE3D44D913C0F5C320A7 /* Modules */ = {
@@ -732,6 +757,9 @@
 				76A91937D9017A5B0D9B0BA5 /* PinnableTabBar.swift in Sources */,
 				023E9AE450BF036FF40C0E76 /* ProjectConfiguration.swift in Sources */,
 				7EE844A0691D39F31A685114 /* ProjectSwitcherView.swift in Sources */,
+				0D4D7E7A5AB24A1D85E8A001 /* QualityModels.swift in Sources */,
+				0D4D7E7A5AB24A1D85E8A003 /* QualityView.swift in Sources */,
+				0D4D7E7A5AB24A1D85E8A002 /* QualityViewModel.swift in Sources */,
 				9ACBEB5DF2D256960184C815 /* QueryEditorView.swift in Sources */,
 				38D566E59E85DF4E4D14C48F /* RemoteFileBrowser.swift in Sources */,
 				22221233AC86561D48490886 /* RemoteFileBrowserView.swift in Sources */,

--- a/Homeboy/App/ContentView.swift
+++ b/Homeboy/App/ContentView.swift
@@ -18,6 +18,7 @@ enum CoreTool: String, CaseIterable, Identifiable {
     case rigs = "Rigs"
     case stackManager = "Stacks"
     case git = "Git"
+    case quality = "Quality"
     case remoteFileEditor = "File Editor"
     case remoteLogViewer = "Log Viewer"
     case databaseBrowser = "Database"
@@ -34,6 +35,7 @@ enum CoreTool: String, CaseIterable, Identifiable {
         case .rigs: return "shippingbox.and.arrow.backward"
         case .stackManager: return "square.stack.3d.up"
         case .git: return "point.3.connected.trianglepath.dotted"
+        case .quality: return "checkmark.seal"
         case .remoteFileEditor: return "doc.badge.gearshape"
         case .remoteLogViewer: return "doc.text.magnifyingglass"
         case .databaseBrowser: return "cylinder.split.1x2"
@@ -85,6 +87,8 @@ struct ContentView: View {
                 .opacity(selectedItem == .coreTool(.stackManager) ? 1 : 0)
             GitOperationsView()
                 .opacity(selectedItem == .coreTool(.git) ? 1 : 0)
+            QualityView()
+                .opacity(selectedItem == .coreTool(.quality) ? 1 : 0)
             DatabaseBrowserView()
                 .opacity(selectedItem == .coreTool(.databaseBrowser) ? 1 : 0)
             RemoteLogViewerView()

--- a/Homeboy/Core/CLI/HomeboyCLI.swift
+++ b/Homeboy/Core/CLI/HomeboyCLI.swift
@@ -493,6 +493,48 @@ final class HomeboyCLI {
 
 private init() {}
 
+    private static var decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }()
+
+    private func executeCommandWithOutputFile<T: Decodable>(
+        _ args: [String],
+        dataType: T.Type,
+        source: String,
+        timeout: TimeInterval = 120
+    ) async throws -> T {
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("homeboy-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        var outputArgs = args
+        outputArgs.append(contentsOf: ["--output", outputURL.path])
+
+        let response = try await cli.execute(outputArgs, timeout: timeout)
+        guard FileManager.default.fileExists(atPath: outputURL.path) else {
+            if response.success {
+                throw CLIBridgeError.invalidResponse("Missing output file for \(source)")
+            }
+            throw CLIBridgeError.executionFailed(exitCode: response.exitCode, message: response.errorOutput)
+        }
+
+        let data = try Data(contentsOf: outputURL)
+        let result = try Self.decoder.decode(CLIBridgeResult<T>.self, from: data)
+        guard result.success else {
+            if let errorDetail = result.error {
+                throw CLIBridgeError.cliError(errorDetail.toCLIError(source: source))
+            }
+            throw CLIBridgeError.executionFailed(exitCode: response.exitCode, message: response.errorOutput)
+        }
+        guard let decoded = result.data else {
+            throw CLIBridgeError.invalidResponse("Success response missing data")
+        }
+
+        return decoded
+    }
+
     // MARK: - Init Command
 
     /// Run `homeboy init` to get full context including extensions and components
@@ -1246,7 +1288,7 @@ private init() {}
         return try await cli.executeCommand(args, dataType: LogsOutput.self, source: "Logs Search", timeout: 60)
     }
 
-    // MARK: - Audit Commands
+    // MARK: - Quality Commands
 
     private enum AuditSlice {
         static let code = [
@@ -1310,6 +1352,67 @@ private init() {}
     /// Run structural audit on a component
     func auditStructure(componentId: String) async throws -> AuditOutput {
         try await audit(componentId: componentId, only: AuditSlice.structure, source: "Audit Structure", timeout: 60)
+    }
+
+    func qualityReviewSummary(
+        componentId: String,
+        path: String? = nil,
+        scope: QualityScope = .full,
+        changedSince: String? = nil
+    ) async throws -> QualityReviewOutput {
+        var args = ["review", componentId, "--summary"]
+        appendQualityScope(&args, path: path, scope: scope, changedSince: changedSince)
+        return try await executeCommandWithOutputFile(args, dataType: QualityReviewOutput.self, source: "Quality Review", timeout: 180)
+    }
+
+    func qualityTriage(componentId: String) async throws -> QualityTriageOutput {
+        try await executeCommandWithOutputFile(
+            ["triage", "component", componentId],
+            dataType: QualityTriageOutput.self,
+            source: "Quality Triage",
+            timeout: 60
+        )
+    }
+
+    func qualityStage(
+        _ stage: QualityStage,
+        componentId: String,
+        path: String? = nil,
+        scope: QualityScope = .full,
+        changedSince: String? = nil
+    ) async throws -> CLIBridgeResponse {
+        var args = [stage.rawValue, componentId]
+        switch stage {
+        case .audit, .lint, .test:
+            appendQualityScope(&args, path: path, scope: scope, changedSince: changedSince)
+        case .validate:
+            if let path, !path.isEmpty {
+                args.append(contentsOf: ["--path", path])
+            }
+        }
+        return try await cli.execute(args, timeout: 180)
+    }
+
+    private func appendQualityScope(
+        _ args: inout [String],
+        path: String?,
+        scope: QualityScope,
+        changedSince: String?
+    ) {
+        if let path, !path.isEmpty {
+            args.append(contentsOf: ["--path", path])
+        }
+
+        switch scope {
+        case .full:
+            break
+        case .changedSince:
+            if let changedSince, !changedSince.isEmpty {
+                args.append(contentsOf: ["--changed-since", changedSince])
+            }
+        case .changedOnly:
+            args.append("--changed-only")
+        }
     }
 
     // MARK: - Refactor Commands

--- a/Homeboy/Extensions/Quality/QualityModels.swift
+++ b/Homeboy/Extensions/Quality/QualityModels.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+enum QualityScope: String, CaseIterable, Identifiable {
+    case full
+    case changedSince
+    case changedOnly
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .full: return "Full"
+        case .changedSince: return "Changed since"
+        case .changedOnly: return "Changed only"
+        }
+    }
+}
+
+enum QualityStage: String, CaseIterable, Identifiable {
+    case audit
+    case lint
+    case test
+    case validate
+
+    var id: String { rawValue }
+
+    var label: String { rawValue.capitalized }
+
+    var icon: String {
+        switch self {
+        case .audit: return "magnifyingglass"
+        case .lint: return "paintbrush"
+        case .test: return "checklist"
+        case .validate: return "hammer"
+        }
+    }
+}
+
+struct QualityReviewOutput: Decodable {
+    let command: String
+    let summary: QualityReviewSummary
+    let audit: QualityStageResult?
+    let lint: QualityStageResult?
+    let test: QualityStageResult?
+}
+
+struct QualityReviewSummary: Decodable {
+    let component: String
+    let passed: Bool
+    let scope: String
+    let status: String
+    let totalFindings: Int
+}
+
+struct QualityStageResult: Decodable, Identifiable {
+    let stage: String
+    let ran: Bool
+    let passed: Bool
+    let exitCode: Int?
+    let findingCount: Int?
+    let hint: String?
+    let output: JSONValue?
+
+    var id: String { stage }
+
+    var statusLabel: String {
+        guard ran else { return "Skipped" }
+        return passed ? "Passed" : "Failed"
+    }
+}
+
+struct QualityTriageOutput: Decodable {
+    let command: String
+    let target: QualityTriageTarget?
+    let summary: QualityTriageSummary
+    let components: [QualityTriageComponent]
+}
+
+struct QualityTriageTarget: Decodable {
+    let id: String
+    let kind: String
+}
+
+struct QualityTriageSummary: Decodable {
+    let actions: Int
+    let components: Int
+    let failingChecks: Int
+    let needsReview: Int
+    let openIssues: Int
+    let openPrs: Int
+    let reposResolved: Int
+    let reposUnresolved: Int
+    let stale: Int
+}
+
+struct QualityTriageComponent: Decodable, Identifiable {
+    let componentId: String
+    let localPath: String?
+    let actions: [QualityTriageAction]
+    let issues: QualityTriageItemGroup?
+    let pullRequests: QualityTriageItemGroup?
+    let repo: QualityTriageRepo?
+
+    var id: String { componentId }
+}
+
+struct QualityTriageAction: Decodable, Identifiable {
+    let kind: String
+    let label: String
+    let severity: String
+
+    var id: String { "\(kind)-\(label)" }
+}
+
+struct QualityTriageItemGroup: Decodable {
+    let open: Int
+    let items: [QualityTriageItem]
+}
+
+struct QualityTriageItem: Decodable, Identifiable {
+    let number: Int
+    let state: String
+    let title: String
+    let updatedAt: String?
+    let url: String?
+    let author: String?
+    let draft: Bool?
+    let mergeState: String?
+    let nextAction: String?
+
+    var id: Int { number }
+}
+
+struct QualityTriageRepo: Decodable {
+    let owner: String
+    let name: String
+    let provider: String
+    let url: String?
+}

--- a/Homeboy/Extensions/Quality/QualityViewModel.swift
+++ b/Homeboy/Extensions/Quality/QualityViewModel.swift
@@ -1,0 +1,131 @@
+import Combine
+import Foundation
+import SwiftUI
+
+@MainActor
+final class QualityViewModel: ObservableObject, ConfigurationObserving {
+    var cancellables = Set<AnyCancellable>()
+
+    @Published var components: [ComponentConfiguration] = []
+    @Published var selectedComponentId: String?
+    @Published var scope: QualityScope = .full
+    @Published var changedSince = "origin/main"
+    @Published var review: QualityReviewOutput?
+    @Published var triage: QualityTriageOutput?
+    @Published var consoleOutput = ""
+    @Published var isRunningReview = false
+    @Published var isRunningTriage = false
+    @Published var runningStage: QualityStage?
+    @Published var error: (any DisplayableError)?
+
+    private let configManager = ConfigurationManager.shared
+
+    init() {
+        observeConfiguration()
+        refreshComponents()
+    }
+
+    var selectedComponent: ComponentConfiguration? {
+        guard let selectedComponentId else { return components.first }
+        return components.first { $0.id == selectedComponentId }
+    }
+
+    var canRun: Bool {
+        selectedComponent != nil && !isBusy
+    }
+
+    var isBusy: Bool {
+        isRunningReview || isRunningTriage || runningStage != nil
+    }
+
+    func handleConfigChange(_ change: ConfigurationChangeType) {
+        switch change {
+        case .projectDidSwitch, .projectModified:
+            refreshComponents()
+        default:
+            break
+        }
+    }
+
+    func refreshComponents() {
+        if let project = configManager.activeProject {
+            components = configManager.loadComponentsForProject(project)
+        } else {
+            components = configManager.loadAllComponents()
+        }
+
+        if selectedComponentId == nil || !components.contains(where: { $0.id == selectedComponentId }) {
+            selectedComponentId = components.first?.id
+        }
+    }
+
+    func runReview() {
+        guard let component = selectedComponent else { return }
+        isRunningReview = true
+        error = nil
+        consoleOutput = "Running homeboy review --summary..."
+
+        Task {
+            do {
+                review = try await HomeboyCLI.shared.qualityReviewSummary(
+                    componentId: component.id,
+                    path: component.localPath,
+                    scope: scope,
+                    changedSince: changedSinceValue
+                )
+                consoleOutput = "Review summary loaded for \(component.id)."
+            } catch {
+                self.error = error.toDisplayableError(source: "Quality Review")
+                consoleOutput = error.localizedDescription
+            }
+            isRunningReview = false
+        }
+    }
+
+    func runTriage() {
+        guard let component = selectedComponent else { return }
+        isRunningTriage = true
+        error = nil
+        consoleOutput = "Running homeboy triage component..."
+
+        Task {
+            do {
+                triage = try await HomeboyCLI.shared.qualityTriage(componentId: component.id)
+                consoleOutput = "Triage report loaded for \(component.id)."
+            } catch {
+                self.error = error.toDisplayableError(source: "Quality Triage")
+                consoleOutput = error.localizedDescription
+            }
+            isRunningTriage = false
+        }
+    }
+
+    func runStage(_ stage: QualityStage) {
+        guard let component = selectedComponent else { return }
+        runningStage = stage
+        error = nil
+        consoleOutput = "Running homeboy \(stage.rawValue)..."
+
+        Task {
+            do {
+                let response = try await HomeboyCLI.shared.qualityStage(
+                    stage,
+                    componentId: component.id,
+                    path: component.localPath,
+                    scope: scope,
+                    changedSince: changedSinceValue
+                )
+                consoleOutput = response.output.isEmpty ? response.errorOutput : response.output
+            } catch {
+                self.error = error.toDisplayableError(source: "Quality \(stage.label)")
+                consoleOutput = error.localizedDescription
+            }
+            runningStage = nil
+        }
+    }
+
+    private var changedSinceValue: String? {
+        let value = changedSince.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+}

--- a/Homeboy/Extensions/Quality/Views/QualityView.swift
+++ b/Homeboy/Extensions/Quality/Views/QualityView.swift
@@ -1,0 +1,281 @@
+import SwiftUI
+
+struct QualityView: View {
+    @StateObject private var viewModel = QualityViewModel()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+
+            if viewModel.components.isEmpty {
+                ContentUnavailableView(
+                    "No Components",
+                    systemImage: "shippingbox",
+                    description: Text("Add a component before running Homeboy quality checks.")
+                )
+            } else {
+                HSplitView {
+                    summaryPane
+                        .frame(minWidth: 460)
+                    consolePane
+                        .frame(minWidth: 340)
+                }
+            }
+        }
+        .frame(minWidth: 900, minHeight: 600)
+        .onAppear { viewModel.refreshComponents() }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Label("Quality", systemImage: "checkmark.seal")
+                    .font(.title2.bold())
+
+                Spacer()
+
+                if viewModel.isBusy {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+
+            HStack(spacing: 12) {
+                Picker("Component", selection: Binding(
+                    get: { viewModel.selectedComponentId ?? "" },
+                    set: { viewModel.selectedComponentId = $0 }
+                )) {
+                    ForEach(viewModel.components) { component in
+                        Text(component.id).tag(component.id)
+                    }
+                }
+                .frame(minWidth: 220)
+
+                Picker("Scope", selection: $viewModel.scope) {
+                    ForEach(QualityScope.allCases) { scope in
+                        Text(scope.label).tag(scope)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 300)
+
+                if viewModel.scope == .changedSince {
+                    TextField("Git ref", text: $viewModel.changedSince)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 160)
+                }
+
+                Spacer()
+
+                Button("Run Triage") { viewModel.runTriage() }
+                    .disabled(!viewModel.canRun)
+
+                Button("Run Review") { viewModel.runReview() }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!viewModel.canRun)
+            }
+        }
+        .padding()
+    }
+
+    private var summaryPane: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                if let error = viewModel.error {
+                    InlineErrorView(error)
+                }
+
+                if let review = viewModel.review {
+                    reviewSummary(review)
+                    stageGrid(review)
+                } else {
+                    emptyReview
+                }
+
+                if let triage = viewModel.triage {
+                    triageSummary(triage)
+                }
+            }
+            .padding()
+        }
+    }
+
+    private var emptyReview: some View {
+        ContentUnavailableView(
+            "Run Review",
+            systemImage: "doc.text.magnifyingglass",
+            description: Text("Start with `homeboy review --summary` for a read-only audit/lint/test overview.")
+        )
+        .frame(maxWidth: .infinity, minHeight: 220)
+    }
+
+    private func reviewSummary(_ review: QualityReviewOutput) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Label(review.summary.status.capitalized, systemImage: review.summary.passed ? "checkmark.circle.fill" : "xmark.octagon.fill")
+                    .font(.headline)
+                    .foregroundColor(review.summary.passed ? .green : .red)
+                Spacer()
+                Text(review.summary.scope)
+                    .font(.caption.monospaced())
+                    .foregroundColor(.secondary)
+            }
+
+            Text(review.summary.component)
+                .font(.title3.bold())
+
+            Text("\(review.summary.totalFindings) findings across audit, lint, and test stages")
+                .foregroundColor(.secondary)
+        }
+        .padding()
+        .background(Color(nsColor: .controlBackgroundColor))
+        .cornerRadius(10)
+    }
+
+    private func stageGrid(_ review: QualityReviewOutput) -> some View {
+        let stages = [review.audit, review.lint, review.test].compactMap { $0 }
+
+        return LazyVGrid(columns: [GridItem(.adaptive(minimum: 220), spacing: 12)], spacing: 12) {
+            ForEach(stages) { stage in
+                stageCard(stage)
+            }
+
+            stageActionCard(.validate, result: nil)
+        }
+    }
+
+    private func stageCard(_ result: QualityStageResult) -> some View {
+        let stage = QualityStage(rawValue: result.stage) ?? .audit
+        return stageActionCard(stage, result: result)
+    }
+
+    private func stageActionCard(_ stage: QualityStage, result: QualityStageResult?) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Label(stage.label, systemImage: stage.icon)
+                    .font(.headline)
+                Spacer()
+                if let result {
+                    Text(result.statusLabel)
+                        .font(.caption.bold())
+                        .foregroundColor(result.passed ? .green : .red)
+                }
+            }
+
+            if let result {
+                Text("Findings: \(result.findingCount ?? 0)")
+                    .font(.caption)
+                if let hint = result.hint {
+                    Text(hint)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(2)
+                }
+            } else {
+                Text("Run a direct non-mutating validation check.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Button(viewModel.runningStage == stage ? "Running..." : "Run \(stage.label)") {
+                viewModel.runStage(stage)
+            }
+            .disabled(!viewModel.canRun)
+        }
+        .padding()
+        .background(Color(nsColor: .controlBackgroundColor))
+        .cornerRadius(10)
+    }
+
+    private func triageSummary(_ triage: QualityTriageOutput) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Triage")
+                .font(.headline)
+
+            HStack(spacing: 16) {
+                metric("Open Issues", triage.summary.openIssues)
+                metric("Open PRs", triage.summary.openPrs)
+                metric("Actions", triage.summary.actions)
+                metric("Failing Checks", triage.summary.failingChecks)
+            }
+
+            ForEach(triage.components) { component in
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(component.componentId)
+                        .font(.subheadline.bold())
+
+                    ForEach(component.actions) { action in
+                        Label(action.label, systemImage: action.severity == "high" ? "exclamationmark.triangle.fill" : "info.circle")
+                            .foregroundColor(action.severity == "high" ? .orange : .secondary)
+                    }
+
+                    ForEach(component.pullRequests?.items ?? []) { item in
+                        triageLink(item, prefix: "PR")
+                    }
+                    ForEach(component.issues?.items ?? []) { item in
+                        triageLink(item, prefix: "Issue")
+                    }
+                }
+                .padding(.top, 4)
+            }
+        }
+        .padding()
+        .background(Color(nsColor: .controlBackgroundColor))
+        .cornerRadius(10)
+    }
+
+    private func metric(_ label: String, _ value: Int) -> some View {
+        VStack(alignment: .leading) {
+            Text(String(value))
+                .font(.title3.bold())
+            Text(label)
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private func triageLink(_ item: QualityTriageItem, prefix: String) -> some View {
+        HStack {
+            if let url = item.url, let parsedURL = URL(string: url) {
+                Link("\(prefix) #\(item.number)", destination: parsedURL)
+            } else {
+                Text("\(prefix) #\(item.number)")
+            }
+            Text(item.title)
+                .lineLimit(1)
+            Spacer()
+            if let nextAction = item.nextAction {
+                Text(nextAction)
+                    .font(.caption.monospaced())
+                    .foregroundColor(.secondary)
+            }
+        }
+        .font(.caption)
+    }
+
+    private var consolePane: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Console")
+                    .font(.headline)
+                Spacer()
+                CopyButton.console(viewModel.consoleOutput, source: "Quality")
+                    .disabled(viewModel.consoleOutput.isEmpty)
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+
+            Divider()
+
+            ScrollView {
+                Text(viewModel.consoleOutput.isEmpty ? "Quality command output will appear here." : viewModel.consoleOutput)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundColor(viewModel.consoleOutput.isEmpty ? .secondary : .primary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(8)
+            }
+            .background(Color(nsColor: .textBackgroundColor))
+        }
+    }
+}

--- a/tests/ContractTests.swift
+++ b/tests/ContractTests.swift
@@ -478,6 +478,9 @@ func runTests(testDir: String) throws {
     // Test 20: API/Auth model decoding and command shapes
     try testAPIAuthContracts(decoder: decoder)
 
+    // Test 21: Quality workspace command shapes
+    try testQualityWorkspaceCommandShapes(testDir: testDir)
+
     print("")
     print("All contract tests passed")
 }
@@ -649,6 +652,61 @@ func testGitStatus(fixturesDir: String, decoder: JSONDecoder) throws {
             userInfo: [NSLocalizedDescriptionKey: "git-status.json: status should be successful"])
     }
     print("[PASS] status success fields decoded")
+    print("")
+}
+
+func testQualityWorkspaceCommandShapes(testDir: String) throws {
+    print("Test: Quality workspace command shapes")
+    print("--------------------------------------")
+
+    let sourceURL = URL(fileURLWithPath: "Homeboy/Core/CLI/HomeboyCLI.swift")
+    let contentViewURL = URL(fileURLWithPath: "Homeboy/App/ContentView.swift")
+    let qualityViewURL = URL(fileURLWithPath: "Homeboy/Extensions/Quality/Views/QualityView.swift")
+    let qualityViewModelURL = URL(fileURLWithPath: "Homeboy/Extensions/Quality/QualityViewModel.swift")
+
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+    let contentView = try String(contentsOf: contentViewURL, encoding: .utf8)
+    let qualityView = try String(contentsOf: qualityViewURL, encoding: .utf8)
+    let qualityViewModel = try String(contentsOf: qualityViewModelURL, encoding: .utf8)
+
+    func requireContains(_ haystack: String, _ needle: String, _ message: String, code: Int) throws {
+        guard haystack.contains(needle) else {
+            throw NSError(domain: "ContractTest", code: code,
+                userInfo: [NSLocalizedDescriptionKey: message])
+        }
+        print("[PASS] \(message)")
+    }
+
+    func requireNotContains(_ haystack: String, _ needle: String, _ message: String, code: Int) throws {
+        guard !haystack.contains(needle) else {
+            throw NSError(domain: "ContractTest", code: code,
+                userInfo: [NSLocalizedDescriptionKey: message])
+        }
+        print("[PASS] \(message)")
+    }
+
+    try requireContains(contentView, "case quality = \"Quality\"", "Quality is registered as a core tool", code: 100)
+    try requireContains(contentView, "QualityView()", "QualityView is mounted in the core tool stack", code: 101)
+    try requireContains(source, #"["review", componentId, "--summary"]"#, "Quality review uses current review --summary command", code: 102)
+    try requireContains(source, #"["triage", "component", componentId]"#, "Quality triage uses current triage component command", code: 103)
+    try requireContains(source, #"args.append(contentsOf: ["--changed-since", changedSince])"#, "Quality scope supports changed-since", code: 104)
+    try requireContains(source, #"args.append("--changed-only")"#, "Quality scope supports changed-only", code: 105)
+    try requireContains(source, #"args.append(contentsOf: ["--path", path])"#, "Quality commands support component path override", code: 106)
+    try requireContains(source, "executeCommandWithOutputFile", "Quality decoding reads --output JSON envelopes", code: 107)
+    try requireContains(qualityView, "Run Review", "Quality UI exposes review entry point", code: 108)
+    try requireContains(qualityView, "Run Triage", "Quality UI exposes triage entry point", code: 109)
+    try requireContains(qualityView, "Findings:", "Quality UI renders stage finding summaries", code: 110)
+    try requireContains(qualityViewModel, "HomeboyCLI.shared.qualityStage", "Quality view model exposes stage deep-dives", code: 111)
+
+    try requireNotContains(source, #"["audit", "code""#, "Removed stale audit code invocation", code: 112)
+    try requireNotContains(source, #"["audit", "docs""#, "Removed stale audit docs invocation", code: 113)
+    try requireNotContains(source, #"["audit", "structure""#, "Removed stale audit structure invocation", code: 114)
+    try requireNotContains(source, #"["supports""#, "Removed stale supports command invocation", code: 115)
+    try requireNotContains(qualityView, "--fix", "Quality UI does not expose lint --fix", code: 116)
+    try requireNotContains(qualityView, "--write", "Quality UI does not expose write actions", code: 117)
+    try requireNotContains(source, "--baseline", "Quality helpers do not expose baseline writes", code: 118)
+    try requireNotContains(source, "--ratchet", "Quality helpers do not expose ratchet writes", code: 119)
+
     print("")
 }
 


### PR DESCRIPTION
## Summary
- Add a new Quality core workspace for component-level `homeboy review --summary` and `homeboy triage component` workflows.
- Add read-only scope controls for full, changed-since, and changed-only review runs, plus stage deep-dive buttons for audit/lint/test/validate.
- Decode `--output` JSON envelopes for review/triage and avoid exposing write-capable quality actions in this first slice.

## Tests
- `swift tests/ContractTests.swift tests`
- `homeboy review --help`
- `homeboy triage --help`
- `homeboy audit --help`
- `homeboy review homeboy-desktop --path /Users/chubes/Developer/homeboy-desktop@feat-quality-workspace --summary`
- `plutil -lint Homeboy.xcodeproj/project.pbxproj`

Not run: `xcodebuild` because this host only has Command Line Tools selected (`xcodebuild` requires full Xcode). Not run: `xcodegen generate` because `xcodegen` is not installed.

Closes #35

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the desktop quality workspace; Chris to review before merge.
