### PR TITLE
fix: use status full for workspace discovery

### DIFF
--- a/Homeboy/Core/CLI/HomeboyCLI.swift
+++ b/Homeboy/Core/CLI/HomeboyCLI.swift
@@ -366,9 +366,9 @@ struct ProjectMutationOutput: Decodable {
     let deleted: [String]?
 }
 
-// MARK: - Init Output Models (NEW)
+// MARK: - Workspace Status Output Models
 
-/// Output from `homeboy init --json` command
+/// Output from `homeboy status --full --json` command
 /// Provides full context including extensions, components, and config gaps
 struct InitOutput: Decodable {
     let command: String
@@ -535,16 +535,13 @@ private init() {}
         return decoded
     }
 
-    // MARK: - Init Command
+    // MARK: - Workspace Status Command
 
-    /// Run `homeboy init` to get full context including extensions and components
+    /// Run `homeboy status --full` to get full context including extensions and components
     /// This is the primary way the desktop app discovers the workspace state
-    func initWorkspace(path: String? = nil) async throws -> InitOutput {
-        var args = ["init"]
-        if let p = path {
-            args.append(contentsOf: ["--path", p])
-        }
-        return try await cli.executeCommand(args, dataType: InitOutput.self, source: "Init", timeout: 30)
+    func initWorkspace() async throws -> InitOutput {
+        let args = ["status", "--full"]
+        return try await cli.executeCommand(args, dataType: InitOutput.self, source: "Status", timeout: 30)
     }
 
     // MARK: - Git Commands

--- a/tests/ContractTests.swift
+++ b/tests/ContractTests.swift
@@ -1152,6 +1152,8 @@ func testHomeboyCLIHelperCommandShapes() throws {
         "log line counts are converted before parser validation", code: 85)
     try requireContains("[\"-C\", String(context)]",
         "log context counts are converted before parser validation", code: 86)
+    try requireContains("let args = [\"status\", \"--full\"]",
+        "workspace discovery uses homeboy status --full", code: 92)
 
     try requireNotContains("[\"--type\", type]",
         "file find no longer uses stale --type flag", code: 87)
@@ -1163,6 +1165,8 @@ func testHomeboyCLIHelperCommandShapes() throws {
         "helper commands do not pass literal limit interpolation templates", code: 90)
     try requireNotContains(#"\(context)"#,
         "helper commands do not pass literal context interpolation templates", code: 91)
+    try requireNotContains("var args = [\"init\"]",
+        "workspace discovery no longer uses deprecated homeboy init", code: 93)
 
     print("")
 }


### PR DESCRIPTION
## Summary
- Replace the desktop workspace discovery call from deprecated `homeboy init` to `homeboy status --full`.
- Remove the obsolete path flag handling from the discovery wrapper because `status --full` does not accept `--path`.
- Add a contract source-shape assertion so the deprecated `init` call does not return.

## Tests
- `swift tests/ContractTests.swift tests`
- `swiftc -parse Homeboy/Core/CLI/HomeboyCLI.swift`
- `homeboy review homeboy-desktop --path /Users/chubes/Developer/homeboy-desktop@fix-init-status-full --summary`

Closes #14

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updated the CLI wrapper and contract test, ran verification, and prepared this PR for Chris to review.