### PR TITLE
fix: decode current config model fields

### DIFF
--- a/Homeboy/Core/CLI/HomeboyCLI.swift
+++ b/Homeboy/Core/CLI/HomeboyCLI.swift
@@ -30,7 +30,12 @@ struct ProjectConfigCLI: Decodable {
     let serverId: String?
     let basePath: String?
     let tablePrefix: String?
+    let changelogNextSectionLabel: String?
+    let changelogNextSectionAliases: [String]?
     let componentIds: [String]
+    let components: [ProjectComponentAttachmentCLI]
+    let componentOverrides: [String: ProjectComponentOverrides]
+    let services: [String]
     let remoteFiles: RemoteFileConfigCLI
     let remoteLogs: RemoteLogConfigCLI
     let database: DatabaseConfigCLI
@@ -38,10 +43,59 @@ struct ProjectConfigCLI: Decodable {
     let api: ApiConfigCLI
     let subTargets: [SubTargetCLI]
     let sharedTables: [String]
+
+    private enum CodingKeys: String, CodingKey {
+        case domain, serverId, basePath, tablePrefix
+        case changelogNextSectionLabel, changelogNextSectionAliases
+        case componentIds, components, componentOverrides, services
+        case remoteFiles, remoteLogs, database, tools, api, subTargets, sharedTables
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        domain = try container.decodeIfPresent(String.self, forKey: .domain)
+        serverId = try container.decodeIfPresent(String.self, forKey: .serverId)
+        basePath = try container.decodeIfPresent(String.self, forKey: .basePath)
+        tablePrefix = try container.decodeIfPresent(String.self, forKey: .tablePrefix)
+        changelogNextSectionLabel = try container.decodeIfPresent(String.self, forKey: .changelogNextSectionLabel)
+        changelogNextSectionAliases = try container.decodeIfPresent([String].self, forKey: .changelogNextSectionAliases)
+        components = try container.decodeIfPresent([ProjectComponentAttachmentCLI].self, forKey: .components) ?? []
+        componentIds = try container.decodeIfPresent([String].self, forKey: .componentIds)
+            ?? components.map { $0.id }
+        componentOverrides = try container.decodeIfPresent([String: ProjectComponentOverrides].self, forKey: .componentOverrides) ?? [:]
+        services = try container.decodeIfPresent([String].self, forKey: .services) ?? []
+        remoteFiles = try container.decodeIfPresent(RemoteFileConfigCLI.self, forKey: .remoteFiles) ?? RemoteFileConfigCLI()
+        remoteLogs = try container.decodeIfPresent(RemoteLogConfigCLI.self, forKey: .remoteLogs) ?? RemoteLogConfigCLI()
+        database = try container.decodeIfPresent(DatabaseConfigCLI.self, forKey: .database) ?? DatabaseConfigCLI()
+        tools = try container.decodeIfPresent(ToolsConfigCLI.self, forKey: .tools) ?? ToolsConfigCLI()
+        api = try container.decodeIfPresent(ApiConfigCLI.self, forKey: .api) ?? ApiConfigCLI()
+        subTargets = try container.decodeIfPresent([SubTargetCLI].self, forKey: .subTargets) ?? []
+        sharedTables = try container.decodeIfPresent([String].self, forKey: .sharedTables) ?? []
+    }
+}
+
+struct ProjectComponentAttachmentCLI: Decodable {
+    let id: String
+    let localPath: String
+
+    private enum CodingKeys: String, CodingKey {
+        case id, localPath
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        localPath = try container.decodeIfPresent(String.self, forKey: .localPath) ?? ""
+    }
 }
 
 struct RemoteFileConfigCLI: Decodable {
     let pinnedFiles: [PinnedRemoteFileCLI]
+
+    init(pinnedFiles: [PinnedRemoteFileCLI] = []) {
+        self.pinnedFiles = pinnedFiles
+    }
 }
 
 struct PinnedRemoteFileCLI: Decodable, Identifiable {
@@ -52,6 +106,10 @@ struct PinnedRemoteFileCLI: Decodable, Identifiable {
 
 struct RemoteLogConfigCLI: Decodable {
     let pinnedLogs: [PinnedRemoteLogCLI]
+
+    init(pinnedLogs: [PinnedRemoteLogCLI] = []) {
+        self.pinnedLogs = pinnedLogs
+    }
 }
 
 struct PinnedRemoteLogCLI: Decodable, Identifiable {
@@ -67,11 +125,24 @@ struct DatabaseConfigCLI: Decodable {
     let name: String
     let user: String
     let useSshTunnel: Bool
+
+    init(host: String = "localhost", port: Int = 3306, name: String = "", user: String = "", useSshTunnel: Bool = true) {
+        self.host = host
+        self.port = port
+        self.name = name
+        self.user = user
+        self.useSshTunnel = useSshTunnel
+    }
 }
 
 struct ToolsConfigCLI: Decodable {
     let bandcampScraper: BandcampScraperConfig?
     let newsletter: NewsletterToolConfig?
+
+    init(bandcampScraper: BandcampScraperConfig? = nil, newsletter: NewsletterToolConfig? = nil) {
+        self.bandcampScraper = bandcampScraper
+        self.newsletter = newsletter
+    }
 
     struct BandcampScraperConfig: Decodable {
         let defaultTag: String?
@@ -85,6 +156,11 @@ struct ToolsConfigCLI: Decodable {
 struct ApiConfigCLI: Decodable {
     let baseUrl: String
     let enabled: Bool
+
+    init(baseUrl: String = "", enabled: Bool = false) {
+        self.baseUrl = baseUrl
+        self.enabled = enabled
+    }
 }
 
 // MARK: - API/Auth CLI Output Models
@@ -280,14 +356,57 @@ struct ComponentRecordCLI: Decodable, Identifiable {
     let remotePath: String
     let buildArtifact: String?
     let buildCommand: String?
-    let extensions: [String: ScopedExtensionConfig]?  // NEW: Extension configs by ID
+    let extensions: [String: ScopedExtensionConfigCLI]?  // NEW: Extension configs by ID
     let versionTargets: [VersionTargetCLI]?
     let changelogTarget: String?       // NEW: Dedicated changelog file path
+    let changelogNextSectionLabel: String?
+    let changelogNextSectionAliases: [String]?
     let hooks: [String: [String]]?     // NEW: Lifecycle hooks
+    let extractCommand: String?
+    let remoteOwner: String?
+    let deployStrategy: String?
+    let gitDeploy: GitDeployConfig?
+    let remoteUrl: String?
+    let autoCleanup: Bool
+    let docsDir: String?
+    let docsDirs: [String]
+    let scopes: ScopeConfig?
 
     struct VersionTargetCLI: Decodable {
         let file: String
         let pattern: String?
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, aliases, localPath, remotePath, buildArtifact, buildCommand, extensions, versionTargets
+        case changelogTarget, changelogNextSectionLabel, changelogNextSectionAliases, hooks
+        case extractCommand, remoteOwner, deployStrategy, gitDeploy, remoteUrl, autoCleanup
+        case docsDir, docsDirs, scopes
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        aliases = try container.decodeIfPresent([String].self, forKey: .aliases) ?? []
+        localPath = try container.decode(String.self, forKey: .localPath)
+        remotePath = try container.decode(String.self, forKey: .remotePath)
+        buildArtifact = try container.decodeIfPresent(String.self, forKey: .buildArtifact)
+        buildCommand = try container.decodeIfPresent(String.self, forKey: .buildCommand)
+        extensions = try container.decodeIfPresent([String: ScopedExtensionConfigCLI].self, forKey: .extensions)
+        versionTargets = try container.decodeIfPresent([VersionTargetCLI].self, forKey: .versionTargets)
+        changelogTarget = try container.decodeIfPresent(String.self, forKey: .changelogTarget)
+        changelogNextSectionLabel = try container.decodeIfPresent(String.self, forKey: .changelogNextSectionLabel)
+        changelogNextSectionAliases = try container.decodeIfPresent([String].self, forKey: .changelogNextSectionAliases)
+        hooks = try container.decodeIfPresent([String: [String]].self, forKey: .hooks)
+        extractCommand = try container.decodeIfPresent(String.self, forKey: .extractCommand)
+        remoteOwner = try container.decodeIfPresent(String.self, forKey: .remoteOwner)
+        deployStrategy = try container.decodeIfPresent(String.self, forKey: .deployStrategy)
+        gitDeploy = try container.decodeIfPresent(GitDeployConfig.self, forKey: .gitDeploy)
+        remoteUrl = try container.decodeIfPresent(String.self, forKey: .remoteUrl)
+        autoCleanup = try container.decodeIfPresent(Bool.self, forKey: .autoCleanup) ?? false
+        docsDir = try container.decodeIfPresent(String.self, forKey: .docsDir)
+        docsDirs = try container.decodeIfPresent([String].self, forKey: .docsDirs) ?? []
+        scopes = try container.decodeIfPresent(ScopeConfig.self, forKey: .scopes)
     }
 }
 
@@ -351,7 +470,7 @@ struct BenchScenarioDelta: Decodable, Identifiable {
 
 /// Extension configuration scoped to a component (for CLI output parsing)
 /// Settings use [String: String] for simplicity - CLI returns settings as strings
-struct ScopedExtensionConfig: Decodable {
+struct ScopedExtensionConfigCLI: Decodable {
     let version: String?
     let settings: [String: String]?
 }

--- a/Homeboy/Core/Config/ComponentConfiguration.swift
+++ b/Homeboy/Core/Config/ComponentConfiguration.swift
@@ -14,6 +14,56 @@ struct ScopedExtensionConfig: Codable {
     var settings: [String: String]?  // Simplified: key-value string pairs
 }
 
+/// Include/exclude path scopes for a Homeboy command family.
+struct CommandScopeConfig: Codable, Equatable {
+    var include: [String]
+    var exclude: [String]
+
+    init(include: [String] = [], exclude: [String] = []) {
+        self.include = include
+        self.exclude = exclude
+    }
+}
+
+/// Component command scopes matching CLI's ScopeConfig.
+struct ScopeConfig: Codable, Equatable {
+    var defaults: CommandScopeConfig?
+    var audit: CommandScopeConfig?
+    var lint: CommandScopeConfig?
+    var test: CommandScopeConfig?
+    var refactor: CommandScopeConfig?
+    var deploy: CommandScopeConfig?
+    var release: CommandScopeConfig?
+    var fleet: CommandScopeConfig?
+}
+
+/// Server-side git deployment settings matching CLI's GitDeployConfig.
+struct GitDeployConfig: Codable, Equatable {
+    var remote: String
+    var branch: String
+    var postPull: [String]
+    var tagPattern: String?
+
+    init(remote: String = "origin", branch: String = "main", postPull: [String] = [], tagPattern: String? = nil) {
+        self.remote = remote
+        self.branch = branch
+        self.postPull = postPull
+        self.tagPattern = tagPattern
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case remote, branch, postPull, tagPattern
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        remote = try container.decodeIfPresent(String.self, forKey: .remote) ?? "origin"
+        branch = try container.decodeIfPresent(String.self, forKey: .branch) ?? "main"
+        postPull = try container.decodeIfPresent([String].self, forKey: .postPull) ?? []
+        tagPattern = try container.decodeIfPresent(String.self, forKey: .tagPattern)
+    }
+}
+
 /// Standalone component configuration stored in ~/.config/homeboy/components/{id}.json
 /// Components are reusable across projects - projects reference components by ID.
 /// Aligned with CLI's Component struct (CLI is authoritative).
@@ -27,7 +77,18 @@ struct ComponentConfiguration: Codable, Identifiable {
     var extensions: [String: ScopedExtensionConfig]?  // NEW: Extension configs by ID
     var versionTargets: [VersionTarget]?
     var changelogTarget: String?       // NEW: Dedicated changelog file path
+    var changelogNextSectionLabel: String?
+    var changelogNextSectionAliases: [String]?
     var hooks: [String: [String]]?     // NEW: Lifecycle hooks
+    var extractCommand: String?
+    var remoteOwner: String?
+    var deployStrategy: String?
+    var gitDeploy: GitDeployConfig?
+    var remoteURL: String?
+    var autoCleanup: Bool
+    var docsDir: String?
+    var docsDirs: [String]
+    var scopes: ScopeConfig?
 
     init(
         id: String,
@@ -39,7 +100,18 @@ struct ComponentConfiguration: Codable, Identifiable {
         extensions: [String: ScopedExtensionConfig]? = nil,
         versionTargets: [VersionTarget]? = nil,
         changelogTarget: String? = nil,
-        hooks: [String: [String]]? = nil
+        changelogNextSectionLabel: String? = nil,
+        changelogNextSectionAliases: [String]? = nil,
+        hooks: [String: [String]]? = nil,
+        extractCommand: String? = nil,
+        remoteOwner: String? = nil,
+        deployStrategy: String? = nil,
+        gitDeploy: GitDeployConfig? = nil,
+        remoteURL: String? = nil,
+        autoCleanup: Bool = false,
+        docsDir: String? = nil,
+        docsDirs: [String] = [],
+        scopes: ScopeConfig? = nil
     ) {
         self.id = id
         self.aliases = aliases
@@ -50,7 +122,51 @@ struct ComponentConfiguration: Codable, Identifiable {
         self.extensions = extensions
         self.versionTargets = versionTargets
         self.changelogTarget = changelogTarget
+        self.changelogNextSectionLabel = changelogNextSectionLabel
+        self.changelogNextSectionAliases = changelogNextSectionAliases
         self.hooks = hooks
+        self.extractCommand = extractCommand
+        self.remoteOwner = remoteOwner
+        self.deployStrategy = deployStrategy
+        self.gitDeploy = gitDeploy
+        self.remoteURL = remoteURL
+        self.autoCleanup = autoCleanup
+        self.docsDir = docsDir
+        self.docsDirs = docsDirs
+        self.scopes = scopes
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, aliases, localPath, remotePath, buildArtifact, buildCommand, extensions, versionTargets
+        case changelogTarget, changelogNextSectionLabel, changelogNextSectionAliases, hooks
+        case extractCommand, remoteOwner, deployStrategy, gitDeploy, remoteURL = "remoteUrl", autoCleanup
+        case docsDir, docsDirs, scopes
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        id = try container.decode(String.self, forKey: .id)
+        aliases = try container.decodeIfPresent([String].self, forKey: .aliases) ?? []
+        localPath = try container.decode(String.self, forKey: .localPath)
+        remotePath = try container.decode(String.self, forKey: .remotePath)
+        buildArtifact = try container.decodeIfPresent(String.self, forKey: .buildArtifact)
+        buildCommand = try container.decodeIfPresent(String.self, forKey: .buildCommand)
+        extensions = try container.decodeIfPresent([String: ScopedExtensionConfig].self, forKey: .extensions)
+        versionTargets = try container.decodeIfPresent([VersionTarget].self, forKey: .versionTargets)
+        changelogTarget = try container.decodeIfPresent(String.self, forKey: .changelogTarget)
+        changelogNextSectionLabel = try container.decodeIfPresent(String.self, forKey: .changelogNextSectionLabel)
+        changelogNextSectionAliases = try container.decodeIfPresent([String].self, forKey: .changelogNextSectionAliases)
+        hooks = try container.decodeIfPresent([String: [String]].self, forKey: .hooks)
+        extractCommand = try container.decodeIfPresent(String.self, forKey: .extractCommand)
+        remoteOwner = try container.decodeIfPresent(String.self, forKey: .remoteOwner)
+        deployStrategy = try container.decodeIfPresent(String.self, forKey: .deployStrategy)
+        gitDeploy = try container.decodeIfPresent(GitDeployConfig.self, forKey: .gitDeploy)
+        remoteURL = try container.decodeIfPresent(String.self, forKey: .remoteURL)
+        autoCleanup = try container.decodeIfPresent(Bool.self, forKey: .autoCleanup) ?? false
+        docsDir = try container.decodeIfPresent(String.self, forKey: .docsDir)
+        docsDirs = try container.decodeIfPresent([String].self, forKey: .docsDirs) ?? []
+        scopes = try container.decodeIfPresent(ScopeConfig.self, forKey: .scopes)
     }
 
     /// Display name computed from id (e.g., "chubes-theme" -> "Chubes Theme")

--- a/Homeboy/Core/Config/ProjectConfiguration.swift
+++ b/Homeboy/Core/Config/ProjectConfiguration.swift
@@ -58,6 +58,70 @@ struct PinnedRemoteLog: Codable, Identifiable, Equatable {
     }
 }
 
+/// Component attachment stored on a Homeboy project.
+struct ProjectComponentAttachment: Codable, Equatable {
+    var id: String
+    var localPath: String
+
+    init(id: String, localPath: String = "") {
+        self.id = id
+        self.localPath = localPath
+    }
+}
+
+/// Project-scoped overrides for a linked component.
+struct ProjectComponentOverrides: Codable, Equatable {
+    var remotePath: String?
+    var buildArtifact: String?
+    var extractCommand: String?
+    var remoteOwner: String?
+    var deployStrategy: String?
+    var gitDeploy: GitDeployConfig?
+    var hooks: [String: [String]]
+    var scopes: ScopeConfig?
+    var cliPath: String?
+
+    init(
+        remotePath: String? = nil,
+        buildArtifact: String? = nil,
+        extractCommand: String? = nil,
+        remoteOwner: String? = nil,
+        deployStrategy: String? = nil,
+        gitDeploy: GitDeployConfig? = nil,
+        hooks: [String: [String]] = [:],
+        scopes: ScopeConfig? = nil,
+        cliPath: String? = nil
+    ) {
+        self.remotePath = remotePath
+        self.buildArtifact = buildArtifact
+        self.extractCommand = extractCommand
+        self.remoteOwner = remoteOwner
+        self.deployStrategy = deployStrategy
+        self.gitDeploy = gitDeploy
+        self.hooks = hooks
+        self.scopes = scopes
+        self.cliPath = cliPath
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case remotePath, buildArtifact, extractCommand, remoteOwner, deployStrategy
+        case gitDeploy, hooks, scopes, cliPath
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        remotePath = try container.decodeIfPresent(String.self, forKey: .remotePath)
+        buildArtifact = try container.decodeIfPresent(String.self, forKey: .buildArtifact)
+        extractCommand = try container.decodeIfPresent(String.self, forKey: .extractCommand)
+        remoteOwner = try container.decodeIfPresent(String.self, forKey: .remoteOwner)
+        deployStrategy = try container.decodeIfPresent(String.self, forKey: .deployStrategy)
+        gitDeploy = try container.decodeIfPresent(GitDeployConfig.self, forKey: .gitDeploy)
+        hooks = try container.decodeIfPresent([String: [String]].self, forKey: .hooks) ?? [:]
+        scopes = try container.decodeIfPresent(ScopeConfig.self, forKey: .scopes)
+        cliPath = try container.decodeIfPresent(String.self, forKey: .cliPath)
+    }
+}
+
 // MARK: - Project Configuration
 
 /// Configuration for a single project (WordPress site, Node.js app, etc.)
@@ -79,13 +143,19 @@ struct ProjectConfiguration: Codable, Identifiable {
     var api: APIConfig
     var subTargets: [SubTarget]
     var sharedTables: [String]
+    var components: [ProjectComponentAttachment]
     var componentIds: [String]
+    var componentOverrides: [String: ProjectComponentOverrides]
+    var services: [String]
+    var changelogNextSectionLabel: String?
+    var changelogNextSectionAliases: [String]?
 
     private enum CodingKeys: String, CodingKey {
         case id, name, domain
         case serverId, basePath, tablePrefix
         case extensions, remoteFiles, remoteLogs, database, tools, api
-        case subTargets, sharedTables, componentIds
+        case subTargets, sharedTables, components, componentIds, componentOverrides, services
+        case changelogNextSectionLabel, changelogNextSectionAliases
     }
 
     /// Whether this is a WordPress project (inferred from extensions or table prefix)
@@ -120,7 +190,12 @@ struct ProjectConfiguration: Codable, Identifiable {
         api: APIConfig,
         subTargets: [SubTarget] = [],
         sharedTables: [String] = [],
-        componentIds: [String] = []
+        components: [ProjectComponentAttachment] = [],
+        componentIds: [String] = [],
+        componentOverrides: [String: ProjectComponentOverrides] = [:],
+        services: [String] = [],
+        changelogNextSectionLabel: String? = nil,
+        changelogNextSectionAliases: [String]? = nil
     ) {
         self.id = id
         self.name = name
@@ -136,7 +211,12 @@ struct ProjectConfiguration: Codable, Identifiable {
         self.api = api
         self.subTargets = subTargets
         self.sharedTables = sharedTables
+        self.components = components
         self.componentIds = componentIds
+        self.componentOverrides = componentOverrides
+        self.services = services
+        self.changelogNextSectionLabel = changelogNextSectionLabel
+        self.changelogNextSectionAliases = changelogNextSectionAliases
     }
 
     /// Creates a ProjectConfiguration from CLI's project show output
@@ -200,7 +280,14 @@ struct ProjectConfiguration: Codable, Identifiable {
         }
 
         self.sharedTables = config.sharedTables
+        self.components = config.components.map { component in
+            ProjectComponentAttachment(id: component.id, localPath: component.localPath)
+        }
         self.componentIds = config.componentIds
+        self.componentOverrides = config.componentOverrides
+        self.services = config.services
+        self.changelogNextSectionLabel = config.changelogNextSectionLabel
+        self.changelogNextSectionAliases = config.changelogNextSectionAliases
     }
 
     /// Creates a ProjectConfiguration from CLI's ProjectListItem (minimal data for picker)
@@ -227,6 +314,7 @@ struct ProjectConfiguration: Codable, Identifiable {
             api: APIConfig(),
             subTargets: [],
             sharedTables: [],
+            components: [],
             componentIds: []
         )
     }
@@ -246,6 +334,7 @@ struct ProjectConfiguration: Codable, Identifiable {
         extensions = try container.decodeIfPresent([String].self, forKey: .extensions) ?? []
         subTargets = try container.decodeIfPresent([SubTarget].self, forKey: .subTargets) ?? []
         sharedTables = try container.decodeIfPresent([String].self, forKey: .sharedTables) ?? []
+        components = try container.decodeIfPresent([ProjectComponentAttachment].self, forKey: .components) ?? []
 
         remoteFiles = try container.decodeIfPresent(RemoteFileConfig.self, forKey: .remoteFiles)
             ?? RemoteFileConfig()
@@ -259,7 +348,12 @@ struct ProjectConfiguration: Codable, Identifiable {
         api = try container.decodeIfPresent(APIConfig.self, forKey: .api)
             ?? APIConfig()
 
-        componentIds = try container.decodeIfPresent([String].self, forKey: .componentIds) ?? []
+        componentIds = try container.decodeIfPresent([String].self, forKey: .componentIds)
+            ?? components.map { $0.id }
+        componentOverrides = try container.decodeIfPresent([String: ProjectComponentOverrides].self, forKey: .componentOverrides) ?? [:]
+        services = try container.decodeIfPresent([String].self, forKey: .services) ?? []
+        changelogNextSectionLabel = try container.decodeIfPresent(String.self, forKey: .changelogNextSectionLabel)
+        changelogNextSectionAliases = try container.decodeIfPresent([String].self, forKey: .changelogNextSectionAliases)
     }
 
     /// Custom encoder
@@ -283,7 +377,12 @@ struct ProjectConfiguration: Codable, Identifiable {
 
         try container.encode(subTargets, forKey: .subTargets)
         try container.encode(sharedTables, forKey: .sharedTables)
+        try container.encode(components, forKey: .components)
         try container.encode(componentIds, forKey: .componentIds)
+        try container.encode(componentOverrides, forKey: .componentOverrides)
+        try container.encode(services, forKey: .services)
+        try container.encodeIfPresent(changelogNextSectionLabel, forKey: .changelogNextSectionLabel)
+        try container.encodeIfPresent(changelogNextSectionAliases, forKey: .changelogNextSectionAliases)
     }
 }
 

--- a/tests/ContractTests.swift
+++ b/tests/ContractTests.swift
@@ -259,13 +259,88 @@ struct VersionTargetTest: Decodable {
     let pattern: String?
 }
 
+struct CommandScopeConfigTest: Decodable {
+    let include: [String]
+    let exclude: [String]
+}
+
+struct ScopeConfigTest: Decodable {
+    let defaults: CommandScopeConfigTest?
+    let audit: CommandScopeConfigTest?
+    let lint: CommandScopeConfigTest?
+    let test: CommandScopeConfigTest?
+    let refactor: CommandScopeConfigTest?
+    let deploy: CommandScopeConfigTest?
+    let release: CommandScopeConfigTest?
+    let fleet: CommandScopeConfigTest?
+}
+
+struct GitDeployConfigTest: Decodable {
+    let remote: String
+    let branch: String
+    let postPull: [String]
+    let tagPattern: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case remote, branch, postPull, tagPattern
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        remote = try container.decodeIfPresent(String.self, forKey: .remote) ?? "origin"
+        branch = try container.decodeIfPresent(String.self, forKey: .branch) ?? "main"
+        postPull = try container.decodeIfPresent([String].self, forKey: .postPull) ?? []
+        tagPattern = try container.decodeIfPresent(String.self, forKey: .tagPattern)
+    }
+}
+
 struct ComponentConfigurationTest: Decodable {
     let id: String
+    let aliases: [String]
     let localPath: String
     let remotePath: String
     let buildArtifact: String?
     let versionTargets: [VersionTargetTest]?
     let buildCommand: String?
+    let changelogNextSectionLabel: String?
+    let changelogNextSectionAliases: [String]?
+    let extractCommand: String?
+    let remoteOwner: String?
+    let deployStrategy: String?
+    let gitDeploy: GitDeployConfigTest?
+    let remoteUrl: String?
+    let autoCleanup: Bool
+    let docsDir: String?
+    let docsDirs: [String]
+    let scopes: ScopeConfigTest?
+
+    private enum CodingKeys: String, CodingKey {
+        case id, aliases, localPath, remotePath, buildArtifact, versionTargets, buildCommand
+        case changelogNextSectionLabel, changelogNextSectionAliases, extractCommand, remoteOwner
+        case deployStrategy, gitDeploy, remoteUrl, autoCleanup, docsDir, docsDirs, scopes
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        aliases = try container.decodeIfPresent([String].self, forKey: .aliases) ?? []
+        localPath = try container.decode(String.self, forKey: .localPath)
+        remotePath = try container.decode(String.self, forKey: .remotePath)
+        buildArtifact = try container.decodeIfPresent(String.self, forKey: .buildArtifact)
+        versionTargets = try container.decodeIfPresent([VersionTargetTest].self, forKey: .versionTargets)
+        buildCommand = try container.decodeIfPresent(String.self, forKey: .buildCommand)
+        changelogNextSectionLabel = try container.decodeIfPresent(String.self, forKey: .changelogNextSectionLabel)
+        changelogNextSectionAliases = try container.decodeIfPresent([String].self, forKey: .changelogNextSectionAliases)
+        extractCommand = try container.decodeIfPresent(String.self, forKey: .extractCommand)
+        remoteOwner = try container.decodeIfPresent(String.self, forKey: .remoteOwner)
+        deployStrategy = try container.decodeIfPresent(String.self, forKey: .deployStrategy)
+        gitDeploy = try container.decodeIfPresent(GitDeployConfigTest.self, forKey: .gitDeploy)
+        remoteUrl = try container.decodeIfPresent(String.self, forKey: .remoteUrl)
+        autoCleanup = try container.decodeIfPresent(Bool.self, forKey: .autoCleanup) ?? false
+        docsDir = try container.decodeIfPresent(String.self, forKey: .docsDir)
+        docsDirs = try container.decodeIfPresent([String].self, forKey: .docsDirs) ?? []
+        scopes = try container.decodeIfPresent(ScopeConfigTest.self, forKey: .scopes)
+    }
 
     var displayName: String {
         id.split(separator: "-")
@@ -279,6 +354,77 @@ struct ComponentConfigurationTest: Decodable {
 
     var versionPattern: String? {
         versionTargets?.first?.pattern
+    }
+}
+
+struct ProjectComponentAttachmentTest: Decodable {
+    let id: String
+    let localPath: String
+
+    private enum CodingKeys: String, CodingKey {
+        case id, localPath
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        localPath = try container.decodeIfPresent(String.self, forKey: .localPath) ?? ""
+    }
+}
+
+struct ProjectComponentOverridesTest: Decodable {
+    let remotePath: String?
+    let buildArtifact: String?
+    let extractCommand: String?
+    let remoteOwner: String?
+    let deployStrategy: String?
+    let gitDeploy: GitDeployConfigTest?
+    let hooks: [String: [String]]
+    let scopes: ScopeConfigTest?
+    let cliPath: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case remotePath, buildArtifact, extractCommand, remoteOwner, deployStrategy
+        case gitDeploy, hooks, scopes, cliPath
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        remotePath = try container.decodeIfPresent(String.self, forKey: .remotePath)
+        buildArtifact = try container.decodeIfPresent(String.self, forKey: .buildArtifact)
+        extractCommand = try container.decodeIfPresent(String.self, forKey: .extractCommand)
+        remoteOwner = try container.decodeIfPresent(String.self, forKey: .remoteOwner)
+        deployStrategy = try container.decodeIfPresent(String.self, forKey: .deployStrategy)
+        gitDeploy = try container.decodeIfPresent(GitDeployConfigTest.self, forKey: .gitDeploy)
+        hooks = try container.decodeIfPresent([String: [String]].self, forKey: .hooks) ?? [:]
+        scopes = try container.decodeIfPresent(ScopeConfigTest.self, forKey: .scopes)
+        cliPath = try container.decodeIfPresent(String.self, forKey: .cliPath)
+    }
+}
+
+struct ProjectConfigCLITest: Decodable {
+    let domain: String?
+    let changelogNextSectionLabel: String?
+    let changelogNextSectionAliases: [String]?
+    let components: [ProjectComponentAttachmentTest]
+    let componentIds: [String]
+    let componentOverrides: [String: ProjectComponentOverridesTest]
+    let services: [String]
+
+    private enum CodingKeys: String, CodingKey {
+        case domain, changelogNextSectionLabel, changelogNextSectionAliases
+        case components, componentIds, componentOverrides, services
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        domain = try container.decodeIfPresent(String.self, forKey: .domain)
+        changelogNextSectionLabel = try container.decodeIfPresent(String.self, forKey: .changelogNextSectionLabel)
+        changelogNextSectionAliases = try container.decodeIfPresent([String].self, forKey: .changelogNextSectionAliases)
+        components = try container.decodeIfPresent([ProjectComponentAttachmentTest].self, forKey: .components) ?? []
+        componentIds = try container.decodeIfPresent([String].self, forKey: .componentIds) ?? components.map { $0.id }
+        componentOverrides = try container.decodeIfPresent([String: ProjectComponentOverridesTest].self, forKey: .componentOverrides) ?? [:]
+        services = try container.decodeIfPresent([String].self, forKey: .services) ?? []
     }
 }
 
@@ -480,6 +626,12 @@ func runTests(testDir: String) throws {
 
     // Test 21: Quality workspace command shapes
     try testQualityWorkspaceCommandShapes(testDir: testDir)
+
+    // Test 22: Current component configuration fields
+    try testCurrentComponentConfigurationFields(fixturesDir: fixturesDir, decoder: decoder)
+
+    // Test 23: Current project configuration fields
+    try testCurrentProjectConfigurationFields(decoder: decoder)
 
     print("")
     print("All contract tests passed")
@@ -1075,6 +1227,138 @@ func testVersionTargetsParsing(fixturesDir: String, decoder: JSONDecoder) throws
             userInfo: [NSLocalizedDescriptionKey: "versionPattern computed property should not be nil"])
     }
     print("[PASS] versionPattern computed property: present")
+    print("")
+}
+
+func testCurrentComponentConfigurationFields(fixturesDir: String, decoder: JSONDecoder) throws {
+    print("Test: current component configuration fields")
+    print("--------------------------------------------")
+
+    let fixture = URL(fileURLWithPath: "\(fixturesDir)/component.json")
+    let data = try Data(contentsOf: fixture)
+    let component = try decoder.decode(ComponentConfigurationTest.self, from: data)
+
+    guard component.changelogNextSectionLabel == "Unreleased" else {
+        throw NSError(domain: "ContractTest", code: 230,
+            userInfo: [NSLocalizedDescriptionKey: "changelog_next_section_label did not decode"])
+    }
+    print("[PASS] changelog next section label decodes")
+
+    guard component.changelogNextSectionAliases == ["Next", "Upcoming"] else {
+        throw NSError(domain: "ContractTest", code: 231,
+            userInfo: [NSLocalizedDescriptionKey: "changelog_next_section_aliases did not decode"])
+    }
+    print("[PASS] changelog next section aliases decode")
+
+    guard component.extractCommand?.contains("unzip") == true,
+          component.remoteOwner == "www-data:www-data",
+          component.deployStrategy == "git" else {
+        throw NSError(domain: "ContractTest", code: 232,
+            userInfo: [NSLocalizedDescriptionKey: "deploy metadata fields did not decode"])
+    }
+    print("[PASS] deploy metadata fields decode")
+
+    guard component.gitDeploy?.remote == "origin",
+          component.gitDeploy?.branch == "main",
+          component.gitDeploy?.postPull == ["composer install --no-dev"],
+          component.gitDeploy?.tagPattern == "v{{version}}" else {
+        throw NSError(domain: "ContractTest", code: 233,
+            userInfo: [NSLocalizedDescriptionKey: "git_deploy did not decode"])
+    }
+    print("[PASS] git_deploy decodes")
+
+    guard component.remoteUrl == "https://github.com/Extra-Chill/extrachill.git",
+          component.autoCleanup == true,
+          component.docsDir == "docs",
+          component.docsDirs == ["docs", "guides"] else {
+        throw NSError(domain: "ContractTest", code: 234,
+            userInfo: [NSLocalizedDescriptionKey: "remote/docs cleanup fields did not decode"])
+    }
+    print("[PASS] remote/docs cleanup fields decode")
+
+    guard component.scopes?.defaults?.include == ["src/**"],
+          component.scopes?.defaults?.exclude == ["vendor/**"],
+          component.scopes?.audit?.include == ["Homeboy/**"] else {
+        throw NSError(domain: "ContractTest", code: 235,
+            userInfo: [NSLocalizedDescriptionKey: "scopes did not decode"])
+    }
+    print("[PASS] scopes decode")
+
+    let minimalGitDeploy = #"{"git_deploy":{}}"#.data(using: .utf8)!
+    struct MinimalGitDeployWrapper: Decodable { let gitDeploy: GitDeployConfigTest }
+    let wrapper = try decoder.decode(MinimalGitDeployWrapper.self, from: minimalGitDeploy)
+    guard wrapper.gitDeploy.remote == "origin", wrapper.gitDeploy.branch == "main", wrapper.gitDeploy.postPull.isEmpty else {
+        throw NSError(domain: "ContractTest", code: 236,
+            userInfo: [NSLocalizedDescriptionKey: "git_deploy defaults did not decode"])
+    }
+    print("[PASS] git_deploy defaults decode")
+    print("")
+}
+
+func testCurrentProjectConfigurationFields(decoder: JSONDecoder) throws {
+    print("Test: current project configuration fields")
+    print("------------------------------------------")
+
+    let json = #"""
+    {
+        "domain": "example.test",
+        "changelog_next_section_label": "Unreleased",
+        "changelog_next_section_aliases": ["Next"],
+        "components": [
+            {"id": "data-machine", "local_path": "/Users/chubes/Developer/data-machine"}
+        ],
+        "component_overrides": {
+            "data-machine": {
+                "remote_path": "wp-content/plugins/data-machine",
+                "extract_command": "unzip artifact.zip",
+                "remote_owner": "www-data:www-data",
+                "deploy_strategy": "git",
+                "git_deploy": {"post_pull": ["composer install --no-dev"]},
+                "hooks": {"post:deploy": ["wp cache flush"]},
+                "scopes": {"lint": {"include": ["inc/**"], "exclude": []}},
+                "cli_path": "studio wp"
+            }
+        },
+        "services": ["nginx", "php8.4-fpm"]
+    }
+    """#.data(using: .utf8)!
+
+    let project = try decoder.decode(ProjectConfigCLITest.self, from: json)
+    guard project.changelogNextSectionLabel == "Unreleased",
+          project.changelogNextSectionAliases == ["Next"] else {
+        throw NSError(domain: "ContractTest", code: 240,
+            userInfo: [NSLocalizedDescriptionKey: "project changelog fields did not decode"])
+    }
+    print("[PASS] Project changelog fields decode")
+
+    guard project.components.first?.id == "data-machine",
+          project.componentIds == ["data-machine"] else {
+        throw NSError(domain: "ContractTest", code: 241,
+            userInfo: [NSLocalizedDescriptionKey: "project components did not decode or derive componentIds"])
+    }
+    print("[PASS] Project components decode and derive componentIds")
+
+    guard project.services == ["nginx", "php8.4-fpm"] else {
+        throw NSError(domain: "ContractTest", code: 242,
+            userInfo: [NSLocalizedDescriptionKey: "project services did not decode"])
+    }
+    print("[PASS] Project services decode")
+
+    guard let override = project.componentOverrides["data-machine"],
+          override.remotePath == "wp-content/plugins/data-machine",
+          override.extractCommand == "unzip artifact.zip",
+          override.remoteOwner == "www-data:www-data",
+          override.deployStrategy == "git",
+          override.gitDeploy?.remote == "origin",
+          override.gitDeploy?.branch == "main",
+          override.gitDeploy?.postPull == ["composer install --no-dev"],
+          override.hooks["post:deploy"] == ["wp cache flush"],
+          override.scopes?.lint?.include == ["inc/**"],
+          override.cliPath == "studio wp" else {
+        throw NSError(domain: "ContractTest", code: 243,
+            userInfo: [NSLocalizedDescriptionKey: "project component_overrides did not decode"])
+    }
+    print("[PASS] Project component overrides decode")
     print("")
 }
 

--- a/tests/fixtures/component.json
+++ b/tests/fixtures/component.json
@@ -4,6 +4,31 @@
   "remote_path": "wp-content/themes/extrachill",
   "build_artifact": "build/extrachill.zip",
   "build_command": "./build.sh",
+  "changelog_next_section_label": "Unreleased",
+  "changelog_next_section_aliases": ["Next", "Upcoming"],
+  "extract_command": "unzip -o build/extrachill.zip -d /tmp/extrachill",
+  "remote_owner": "www-data:www-data",
+  "deploy_strategy": "git",
+  "git_deploy": {
+    "remote": "origin",
+    "branch": "main",
+    "post_pull": ["composer install --no-dev"],
+    "tag_pattern": "v{{version}}"
+  },
+  "remote_url": "https://github.com/Extra-Chill/extrachill.git",
+  "auto_cleanup": true,
+  "docs_dir": "docs",
+  "docs_dirs": ["docs", "guides"],
+  "scopes": {
+    "defaults": {
+      "include": ["src/**"],
+      "exclude": ["vendor/**"]
+    },
+    "audit": {
+      "include": ["Homeboy/**"],
+      "exclude": []
+    }
+  },
   "version_targets": [
     {
       "file": "style.css",


### PR DESCRIPTION
## Summary
- Add the current Homeboy component/project config fields to the Swift model layer so newer CLI JSON decodes without failing.
- Default legacy/missing array and bool fields during decode, including deriving `componentIds` from current project `components` output.
- Extend contract fixtures/tests to cover component deploy metadata, changelog aliases, docs/scopes, project services, and component overrides.

## Tests
- `swift tests/ContractTests.swift tests`
- `swiftc -parse Homeboy/Core/Config/ComponentConfiguration.swift Homeboy/Core/Config/ProjectConfiguration.swift Homeboy/Core/CLI/HomeboyCLI.swift`
- `homeboy review homeboy-desktop --path /Users/chubes/Developer/homeboy-desktop@fix-config-model-fields --summary` *(lint/tests pass; full review remains failed on 68 pre-existing audit findings)*
- `homeboy audit homeboy-desktop --path /Users/chubes/Developer/homeboy-desktop@fix-config-model-fields --changed-since origin/main`

Closes #15
Closes #16

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Swift model updates, contract fixtures/tests, and verification commands; Chris remains responsible for review and merge.