### PR TITLE
fix: use homeboy upgrade for CLI updates

### DIFF
--- a/Homeboy/App/HomeboyApp.swift
+++ b/Homeboy/App/HomeboyApp.swift
@@ -207,7 +207,7 @@ struct CLIUpdateSheet: View {
         upgradeError = nil
 
         Task {
-            let success = await runBrewUpgrade()
+            let success = await runHomeboyUpgrade()
             await MainActor.run {
                 isUpgrading = false
                 if success {
@@ -217,16 +217,15 @@ struct CLIUpdateSheet: View {
         }
     }
 
-    private func runBrewUpgrade() async -> Bool {
-        let brewPaths = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"]
-        guard let brewPath = brewPaths.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) else {
-            await MainActor.run { upgradeError = AppError("Homebrew not found", source: "CLI Upgrade") }
+    private func runHomeboyUpgrade() async -> Bool {
+        guard let homeboyPath = await CLIVersionChecker.shared.cliPath() else {
+            await MainActor.run { upgradeError = AppError("Homeboy CLI not found", source: "CLI Upgrade") }
             return false
         }
 
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: brewPath)
-        process.arguments = ["upgrade", "homeboy"]
+        process.executableURL = URL(fileURLWithPath: homeboyPath)
+        process.arguments = ["upgrade"]
 
         let pipe = Pipe()
         process.standardOutput = pipe
@@ -236,7 +235,9 @@ struct CLIUpdateSheet: View {
             try process.run()
 
             let handle = pipe.fileHandleForReading
+            var sawOutput = false
             for try await line in handle.bytes.lines {
+                sawOutput = true
                 await MainActor.run { upgradeOutput = line }
             }
 
@@ -244,6 +245,8 @@ struct CLIUpdateSheet: View {
 
             if process.terminationStatus == 0 {
                 await CLIVersionChecker.shared.clearCache()
+            } else if !sawOutput {
+                await MainActor.run { upgradeError = AppError("homeboy upgrade exited with status \(process.terminationStatus)", source: "CLI Upgrade") }
             }
 
             return process.terminationStatus == 0

--- a/Homeboy/Core/CLI/CLIVersionChecker.swift
+++ b/Homeboy/Core/CLI/CLIVersionChecker.swift
@@ -154,6 +154,10 @@ actor CLIVersionChecker {
 
     /// Check full version info including update availability
     func checkForUpdate() async -> VersionInfo {
+        if let upgradeCheck = await upgradeCheckVersionInfo() {
+            return upgradeCheck
+        }
+
         async let installedTask = installedVersion()
         async let latestTask = latestVersion()
 
@@ -176,6 +180,64 @@ actor CLIVersionChecker {
             isInstalled: isInstalled,
             updateAvailable: updateAvailable
         )
+    }
+
+    /// Prefer Homeboy's own upgrade surface so Desktop does not assume an install method.
+    private func upgradeCheckVersionInfo() async -> VersionInfo? {
+        guard let path = cliPath() else { return nil }
+
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("homeboy-upgrade-check-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: path)
+        process.arguments = ["upgrade", "--check", "--output", outputURL.path]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+
+            guard process.terminationStatus == 0,
+                  FileManager.default.fileExists(atPath: outputURL.path) else {
+                return nil
+            }
+
+            let data = try Data(contentsOf: outputURL)
+            let envelope = try JSONDecoder().decode(UpgradeCheckEnvelope.self, from: data)
+            guard envelope.success else { return nil }
+
+            return VersionInfo(
+                installed: envelope.data.currentVersion,
+                latest: envelope.data.latestVersion,
+                path: path,
+                isInstalled: true,
+                updateAvailable: envelope.data.updateAvailable
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private struct UpgradeCheckEnvelope: Decodable {
+        let success: Bool
+        let data: UpgradeCheckData
+    }
+
+    private struct UpgradeCheckData: Decodable {
+        let currentVersion: String?
+        let latestVersion: String?
+        let updateAvailable: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case currentVersion = "current_version"
+            case latestVersion = "latest_version"
+            case updateAvailable = "update_available"
+        }
     }
 
     /// Compare semantic versions: returns -1 if v1 < v2, 0 if equal, 1 if v1 > v2

--- a/Homeboy/Views/Settings/ExtensionsSettingsTab.swift
+++ b/Homeboy/Views/Settings/ExtensionsSettingsTab.swift
@@ -17,8 +17,8 @@ struct ExtensionsSettingsTab: View {
                         description: Text("Install extensions to extend functionality")
                     )
                 } else {
-                    ForEach(extensionManager.extensions) { extension in
-                        extensionRow(extension)
+                    ForEach(extensionManager.extensions) { loadedExtension in
+                        extensionRow(loadedExtension)
                     }
                 }
             }
@@ -65,8 +65,8 @@ struct ExtensionsSettingsTab: View {
             titleVisibility: .visible
         ) {
             Button("Uninstall", role: .destructive) {
-                if let extension = selectedExtensionForUninstall {
-                    Task { try? await extensionManager.uninstallExtension(extensionId: extension.id) }
+                if let loadedExtension = selectedExtensionForUninstall {
+                    Task { try? await extensionManager.uninstallExtension(extensionId: loadedExtension.id) }
                 }
                 selectedExtensionForUninstall = nil
             }
@@ -74,8 +74,8 @@ struct ExtensionsSettingsTab: View {
                 selectedExtensionForUninstall = nil
             }
         } message: {
-            if let extension = selectedExtensionForUninstall {
-                Text("Are you sure you want to uninstall \"\(extension.name)\"? This will delete all extension files including its virtual environment.")
+            if let loadedExtension = selectedExtensionForUninstall {
+                Text("Are you sure you want to uninstall \"\(loadedExtension.name)\"? This will delete all extension files including its virtual environment.")
             }
         }
     }
@@ -83,29 +83,29 @@ struct ExtensionsSettingsTab: View {
     // MARK: - Extension Row
     
     @ViewBuilder
-    private func extensionRow(_ extension: LoadedExtension) -> some View {
+    private func extensionRow(_ loadedExtension: LoadedExtension) -> some View {
         HStack {
-            Image(systemName: extension.icon)
+            Image(systemName: loadedExtension.icon)
                 .font(.title2)
                 .foregroundColor(.accentColor)
                 .frame(width: 32)
             
             VStack(alignment: .leading, spacing: 2) {
                 HStack {
-                    Text(extension.name)
+                    Text(loadedExtension.name)
                         .font(.headline)
                     
-                    Text("v\(extension.manifest.version)")
+                    Text("v\(loadedExtension.manifest.version)")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
                 
-                Text(extension.manifest.description)
+                Text(loadedExtension.manifest.description)
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .lineLimit(1)
                 
-                Text("by \(extension.manifest.author)")
+                Text("by \(loadedExtension.manifest.author)")
                     .font(.caption2)
                     .foregroundColor(.secondary)
             }
@@ -113,11 +113,11 @@ struct ExtensionsSettingsTab: View {
             Spacer()
             
             // Status badge
-                        statusBadge(for: extension.state, extensionName: extension.name)
+            statusBadge(for: loadedExtension.state, extensionName: loadedExtension.name)
             
             // Remove button
             Button("Remove") {
-                selectedExtensionForUninstall = extension
+                selectedExtensionForUninstall = loadedExtension
                 showUninstallConfirmation = true
             }
             .buttonStyle(.bordered)
@@ -180,4 +180,3 @@ struct ExtensionsSettingsTab: View {
     }
 
 }
-

--- a/Homeboy/Views/Settings/GeneralSettingsTab.swift
+++ b/Homeboy/Views/Settings/GeneralSettingsTab.swift
@@ -15,7 +15,7 @@ struct GeneralSettingsTab: View {
     @State private var upgradeOutput: String = ""
 
     private let installCommands = "brew tap extra-chill/tap\nbrew install homeboy"
-    private let upgradeCommand = "brew upgrade homeboy"
+    private let upgradeCommand = "homeboy upgrade"
 
     var body: some View {
         Form {
@@ -246,11 +246,11 @@ struct GeneralSettingsTab: View {
         upgradeOutput = ""
 
         Task {
-            let result = await runBrewUpgrade()
+            let result = await runHomeboyUpgrade()
             await MainActor.run {
                 isUpgrading = false
-                upgradeOutput = ""
                 if result {
+                    upgradeOutput = ""
                     // Clear cache and recheck version
                     Task {
                         await CLIVersionChecker.shared.clearCache()
@@ -261,19 +261,17 @@ struct GeneralSettingsTab: View {
         }
     }
 
-    private func runBrewUpgrade() async -> Bool {
-        // Find brew executable
-        let brewPaths = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"]
-        guard let brewPath = brewPaths.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) else {
+    private func runHomeboyUpgrade() async -> Bool {
+        guard let homeboyPath = await CLIVersionChecker.shared.cliPath() else {
             await MainActor.run {
-                upgradeOutput = "Homebrew not found"
+                upgradeOutput = "Homeboy CLI not found"
             }
             return false
         }
 
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: brewPath)
-        process.arguments = ["upgrade", "homeboy"]
+        process.executableURL = URL(fileURLWithPath: homeboyPath)
+        process.arguments = ["upgrade"]
 
         let pipe = Pipe()
         process.standardOutput = pipe
@@ -284,13 +282,20 @@ struct GeneralSettingsTab: View {
 
             // Read output asynchronously
             let handle = pipe.fileHandleForReading
+            var sawOutput = false
             for try await line in handle.bytes.lines {
+                sawOutput = true
                 await MainActor.run {
                     upgradeOutput = line
                 }
             }
 
             process.waitUntilExit()
+            if process.terminationStatus != 0, !sawOutput {
+                await MainActor.run {
+                    upgradeOutput = "homeboy upgrade exited with status \(process.terminationStatus)"
+                }
+            }
             return process.terminationStatus == 0
         } catch {
             await MainActor.run {


### PR DESCRIPTION
## Summary
- Use Homeboy's own `upgrade --check --output` surface for CLI update detection, falling back to the previous GitHub release comparison only when the installed CLI cannot provide structured check output.
- Run CLI upgrades through the installed `homeboy upgrade` command instead of hardcoding `brew upgrade homeboy`.
- Rename `extension` local identifiers in the settings extension view so the requested Swift parser check passes with current Swift keyword handling.

## Tests
- `swift tests/ContractTests.swift tests`
- `plutil -lint Homeboy.xcodeproj/project.pbxproj`
- `swiftc -parse Homeboy/App/*.swift Homeboy/Views/Settings/*.swift Homeboy/Core/CLI/*.swift`

Closes #56

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the CLI upgrade surface change, ran the requested verification commands, and drafted this PR description for Chris to review.
