### PR TITLE
docs: refresh CLI parity matrix

### DIFF
--- a/docs/CLI-PARITY.md
+++ b/docs/CLI-PARITY.md
@@ -2,80 +2,95 @@
 
 This matrix maps the current `homeboy` CLI command surface to Homeboy Desktop support.
 
-Source of truth checked for this pass: `homeboy --help` and top-level `homeboy <command> --help` from the installed CLI on 2026-04-27.
+Source of truth checked for this pass: `homeboy --help` plus focused help for the workspace commands from the installed CLI on 2026-04-27, and the current desktop `main` branch.
 
 ## Status Legend
 
-- **supported**: the desktop app exposes the command family with current-enough wrappers for normal use.
-- **partial/stale**: the desktop app exposes part of the command family, but command shapes or models are known stale.
-- **missing**: no meaningful desktop surface exists.
-- **intentionally CLI-only**: the command is best kept in terminal workflows for now.
+- **supported first-pass UI**: the desktop app exposes the workflow with current CLI wrappers, but may intentionally omit advanced flags.
+- **read-only UI**: the desktop app exposes inspection/status output only; mutating commands stay in the CLI.
+- **partial/stale**: a desktop surface exists, but some wrappers or models still need cleanup.
+- **intentionally CLI-only**: the command is terminal/operator-shaped and should not get desktop UI without a stronger product need.
+- **missing workflow**: no meaningful desktop surface exists yet.
 
 ## Matrix
 
-| CLI command | Desktop support status | Current app surface / file references | Recommended UI/API work | Tracking issue |
+| CLI command | Desktop support status | Current app surface / file references | Desktop boundary / remaining work | Tracking |
 |---|---|---|---|---|
-| `homeboy project` | partial/stale | Settings project fields and project switcher; `Homeboy/Core/CLI/HomeboyCLI.swift` project wrappers; stale `CLIBridge` `--json` wrappers in `Homeboy/Core/CLI/CLIBridge.swift`; pin calls in `Homeboy/Extensions/RemoteFileEditor/RemoteFileEditorViewModel.swift` and `Homeboy/Extensions/RemoteLogViewer/RemoteLogViewerViewModel.swift`. | Modernize stale read/write wrappers, replace deprecated workspace discovery, and keep project pin add/remove aligned with the current `project pin` contract. | Existing: [#14](https://github.com/Extra-Chill/homeboy-desktop/issues/14), [#16](https://github.com/Extra-Chill/homeboy-desktop/issues/16), [#20](https://github.com/Extra-Chill/homeboy-desktop/issues/20), [#24](https://github.com/Extra-Chill/homeboy-desktop/issues/24) |
-| `homeboy ssh` | partial/stale | Generic SSH command helper in `Homeboy/Core/CLI/HomeboyCLI.swift`; server setup surfaces in `Homeboy/Views/Settings/ServersSettingsTab.swift`. | Keep as supporting infrastructure for file/log/db/deploy views. Add a terminal-like SSH command runner only if users need ad-hoc command execution beyond existing tools. | Covered by matrix; no new issue. |
-| `homeboy server` | partial/stale | Server settings UI in `Homeboy/Views/Settings/ServersSettingsTab.swift`; key helpers and CRUD wrappers in `Homeboy/Core/CLI/HomeboyCLI.swift`; stale `CLIBridge` `--json` wrappers. | Modernize read wrappers, confirm `server key` subcommands still match, and keep SSH-key status as a shared service for remote tools. | Existing: [#20](https://github.com/Extra-Chill/homeboy-desktop/issues/20) |
-| `homeboy test` | missing | No dedicated test runner UI. | Add through the proposed Quality workspace rather than a standalone sidebar item. Support changed-since/changed-only scope, coverage summary, and failure output. | New: [#35](https://github.com/Extra-Chill/homeboy-desktop/issues/35) |
-| `homeboy bench` | missing | No benchmark wrappers or UI. | Add a Benchmark workspace with scenario listing, run configuration, result summaries, baseline/ratchet confirmation, and later rig comparisons. | New: [#34](https://github.com/Extra-Chill/homeboy-desktop/issues/34) |
-| `homeboy lint` | missing | No direct lint wrappers; old audit/refactor wrappers do not cover modern lint. | Add through the Quality workspace. Treat `lint --fix` as a confirmed write action. | New: [#35](https://github.com/Extra-Chill/homeboy-desktop/issues/35) |
-| `homeboy db` | partial/stale | Database browser in `Homeboy/Extensions/DatabaseBrowser/`; wrappers in `Homeboy/Core/CLI/HomeboyCLI.swift` for `tables`, `describe`, `query`, `search`, `delete-row`, `drop-table`. | Modernize stale `db search` helper shape and verify destructive confirmation flags against current CLI. Keep database browsing as a core tool. | Existing: [#22](https://github.com/Extra-Chill/homeboy-desktop/issues/22) |
-| `homeboy file` | partial/stale | File editor in `Homeboy/Extensions/RemoteFileEditor/`; wrappers in `Homeboy/Core/CLI/HomeboyCLI.swift` for list/read/write/delete/rename/find/grep. | Modernize stale `file find` and `file grep` shapes. Consider adding download/edit operations if the file editor needs richer remote workflows. | Existing: [#22](https://github.com/Extra-Chill/homeboy-desktop/issues/22) |
-| `homeboy fleet` | partial/stale | Fleet wrappers in `Homeboy/Core/CLI/HomeboyCLI.swift`; limited configuration relationship through projects/components. | Modernize `fleet create` (`--projects`) and decide whether fleet status/check/exec belong in a fleet dashboard or the Quality/Deploy views. | Existing: [#21](https://github.com/Extra-Chill/homeboy-desktop/issues/21) |
-| `homeboy logs` | partial/stale | Log viewer in `Homeboy/Extensions/RemoteLogViewer/`; wrappers in `Homeboy/Core/CLI/HomeboyCLI.swift` for list/show/clear/search. | Modernize stale `logs show` and `logs search` helper shapes; keep pin creation aligned with `project pin`. | Existing: [#22](https://github.com/Extra-Chill/homeboy-desktop/issues/22), [#24](https://github.com/Extra-Chill/homeboy-desktop/issues/24) |
-| `homeboy transfer` | missing | No transfer workflow. | Do not force into File Editor. If needed, add a transfer sheet that models local/server source and destination plus dry-run output. | Covered by matrix; no new issue until user demand. |
-| `homeboy triage` | missing | No attention-report UI. | Add through the Quality workspace as a read-only dashboard for components, projects, fleets, rigs, and workspace scope. | New: [#35](https://github.com/Extra-Chill/homeboy-desktop/issues/35) |
-| `homeboy deploy` | partial/stale | Deployer core tool in `Homeboy/Extensions/Deployer/`; direct CLI calls in `Homeboy/Extensions/Deployer/DeployerViewModel.swift`. | Keep deploy as a core tool, but split release/build/change planning into a separate workflow so deploy stays deploy-only. Verify current deploy result envelope. | New: [#36](https://github.com/Extra-Chill/homeboy-desktop/issues/36) |
-| `homeboy component` | partial/stale | Components settings UI in `Homeboy/Views/Settings/ComponentsSettingsTab.swift`; wrappers/models in `Homeboy/Core/CLI/HomeboyCLI.swift`; config structs in `Homeboy/Core/Config/ComponentConfiguration.swift`. | Modernize component create/set/read shapes and add missing component model fields before building new component workflows on top. | Existing: [#15](https://github.com/Extra-Chill/homeboy-desktop/issues/15), [#20](https://github.com/Extra-Chill/homeboy-desktop/issues/20), [#21](https://github.com/Extra-Chill/homeboy-desktop/issues/21) |
-| `homeboy config` | intentionally CLI-only | No global config editor beyond app settings and CLI path/version display. | Keep global config editing in CLI for now. Desktop should edit project/server/component records through focused screens, not expose raw JSON pointer mutation. | Covered by matrix; no new issue. |
-| `homeboy extension` | partial/stale | Extension manager in `Homeboy/Core/Extensions/ExtensionManager.swift`; extension views under `Homeboy/Views/Extensions/`; platform action calls in `Homeboy/Views/Extensions/ExtensionContainerView.swift`. | Modernize stale list/setup/uninstall/run argument shapes. Preserve dynamic extension rendering after the command contract is current. | Existing: [#23](https://github.com/Extra-Chill/homeboy-desktop/issues/23) |
-| `homeboy status` | partial/stale | Workspace discovery still calls removed/deprecated `init`; status is not a first-class desktop dashboard. | Replace `init` with `status --full`, then consider a status summary card in the main project surface. | Existing: [#14](https://github.com/Extra-Chill/homeboy-desktop/issues/14) |
-| `homeboy docs` | partial/stale | Docs references in `docs/CLI.md` and `docs/EXTENSION-SPEC.md`; no in-app docs browser. | Fix stale doc references first. An in-app docs browser is optional; command docs can stay CLI-only unless users need contextual help panes. | Existing: [#26](https://github.com/Extra-Chill/homeboy-desktop/issues/26) |
-| `homeboy changelog` | intentionally CLI-only | No changelog UI. | Keep generated changelog inspection in CLI. Desktop release workflow can link to changes/release output instead of editing changelogs. | Covered by matrix; no new issue. |
-| `homeboy git` | missing | No Git workspace. Component state is indirectly displayed in deploy/status contexts only. | Add read-only git status/changes first, then guarded write actions only after confirmation UX exists. | New: [#37](https://github.com/Extra-Chill/homeboy-desktop/issues/37) |
-| `homeboy issues` | missing | No issue reconciliation UI. | Decide whether `issues reconcile` belongs in the Quality workspace or Git/GitHub workspace; start by linking findings to issue URLs. | New: [#37](https://github.com/Extra-Chill/homeboy-desktop/issues/37) |
-| `homeboy version` | missing | Version values are inferred in deploy output, but no version command surface exists. | Add to the Release/Build workflow as read-only version target inspection before any bump/release action. | New: [#36](https://github.com/Extra-Chill/homeboy-desktop/issues/36) |
-| `homeboy build` | partial/stale | Deployer has local shell `buildCommand` execution in `Homeboy/Extensions/Deployer/DeployerViewModel.swift`, not `homeboy build`. | Move build execution/status toward `homeboy build` in the Release/Build workflow; keep arbitrary shell build commands only where Homeboy config requires them. | New: [#36](https://github.com/Extra-Chill/homeboy-desktop/issues/36) |
-| `homeboy validate` | missing | No validation workflow. | Add through the Quality workspace as a lightweight parse/compile check. | New: [#35](https://github.com/Extra-Chill/homeboy-desktop/issues/35) |
-| `homeboy changes` | missing | No changes-since-tag UI. | Add to the Release/Build workflow as the first read-only release planning surface. | New: [#36](https://github.com/Extra-Chill/homeboy-desktop/issues/36) |
-| `homeboy release` | missing | No release planning/execution UI. | Add dry-run preview first, then guarded release execution. Do not merge into Deployer; release and deploy have different risk profiles. | New: [#36](https://github.com/Extra-Chill/homeboy-desktop/issues/36) |
-| `homeboy review` | missing | No review umbrella UI. | Add through the Quality workspace as the primary modern quality entry point. | New: [#35](https://github.com/Extra-Chill/homeboy-desktop/issues/35) |
-| `homeboy audit` | partial/stale | Stale quick actions in `Homeboy/Core/CLI/HomeboyCLI.swift` still call removed `audit code`, `audit docs`, and `audit structure`; no modern audit results UI. | Replace with current `homeboy audit <component>` plus filters, then surface through the Quality workspace. | Existing: [#18](https://github.com/Extra-Chill/homeboy-desktop/issues/18), [#27](https://github.com/Extra-Chill/homeboy-desktop/issues/27); New: [#35](https://github.com/Extra-Chill/homeboy-desktop/issues/35) |
-| `homeboy refactor` | partial/stale | Refactor wrappers exist in `Homeboy/Core/CLI/HomeboyCLI.swift`, but no visible workflow and at least `rename` shape is stale. | Fix stale wrappers, then decide whether refactor proposals/actions live in Quality as confirmed write operations. | Existing: [#22](https://github.com/Extra-Chill/homeboy-desktop/issues/22); New: [#35](https://github.com/Extra-Chill/homeboy-desktop/issues/35) |
-| `homeboy rig` | missing | No rig models, wrappers, or screens. | Add a dedicated Rigs screen; do not force rigs into Settings or Deployer. | New: [#32](https://github.com/Extra-Chill/homeboy-desktop/issues/32) |
-| `homeboy stack` | missing | No stack models, wrappers, or screens. | Add a Stack Manager screen for spec listing/status first, then guarded apply/sync. | New: [#33](https://github.com/Extra-Chill/homeboy-desktop/issues/33) |
-| `homeboy undo` | partial/stale | Wrappers in `Homeboy/Core/CLI/HomeboyCLI.swift` for latest/specific undo and list. No obvious visible screen. | Surface undo from workflows that perform Homeboy writes (`refactor`, `lint --fix`, release actions) rather than as a standalone global screen. | Covered by [#35](https://github.com/Extra-Chill/homeboy-desktop/issues/35) for write-capable quality actions. |
-| `homeboy auth` | missing | Desktop has its own `AuthManager`, but no Homeboy project API auth wrappers. | Add a separate API/Auth workspace so Homeboy project credentials are not conflated with desktop login. | New: [#38](https://github.com/Extra-Chill/homeboy-desktop/issues/38) |
-| `homeboy api` | missing | No API request explorer. | Start with authenticated GET requests and response copy/export; gate mutating verbs behind preview/confirmation. | New: [#38](https://github.com/Extra-Chill/homeboy-desktop/issues/38) |
-| `homeboy upgrade` | partial/stale | CLI update UI exists in `Homeboy/Views/Settings/GeneralSettingsTab.swift`, but shells out to `brew upgrade homeboy`; app launch migration also uses brew in `Homeboy/App/HomeboyApp.swift`. | Replace brew-specific upgrade paths with `homeboy upgrade --check` / `homeboy upgrade` so source/cargo/binary installs work. | Covered by matrix; file implementation issue when stale-command burners finish. |
-| `homeboy cargo` | intentionally CLI-only | No cargo wrapper. | Keep as CLI-only extension convenience. Desktop should surface component-level build/test/validate instead. | Covered by matrix; no new issue. |
-| `homeboy wp` | intentionally CLI-only | WordPress settings/auth surfaces exist, but no WP-CLI passthrough. | Keep as CLI-only unless a future WordPress operations console is explicitly designed. | Covered by matrix; no new issue. |
+| `homeboy project` | partial/stale | Project switcher and settings-backed project CRUD; wrappers in `Homeboy/Core/CLI/HomeboyCLI+WorkspaceCommands.swift`. | Usable as app infrastructure. Legacy CRUD helpers still need removal from old `CLIBridge` surface. | [#54](https://github.com/Extra-Chill/homeboy-desktop/issues/54) |
+| `homeboy ssh` | partial/stale | Generic SSH support behind file, log, db, and deploy workflows; server settings in `Homeboy/Views/Settings/ServersSettingsTab.swift`. | Keep as supporting infrastructure. Add an ad-hoc SSH console only if a real desktop workflow needs it. | Matrix only |
+| `homeboy server` | partial/stale | Server settings UI plus server wrappers in `Homeboy/Core/CLI/HomeboyCLI+WorkspaceCommands.swift`. | Usable for normal server setup. Legacy wrappers remain cleanup debt. | [#54](https://github.com/Extra-Chill/homeboy-desktop/issues/54) |
+| `homeboy test` | supported first-pass UI | Quality workspace stage button via `Homeboy/Extensions/Quality/Views/QualityView.swift` and `Homeboy/Core/CLI/HomeboyCLI+QualityCommands.swift`. | Supports normal scoped runs (`changed-since`, `changed-only`, path override). Advanced analysis/drift/write flows remain CLI-only. | Matrix only |
+| `homeboy bench` | supported first-pass UI | Bench workspace in `Homeboy/Views/BenchView.swift`; wrappers in `Homeboy/Core/CLI/HomeboyCLI+RigBenchReleaseCommands.swift`. | Lists scenarios and runs benchmarks with iteration control. Baseline, ratchet, multi-run, concurrency, settings, and `--rig` comparisons remain CLI-only. | Matrix only |
+| `homeboy lint` | supported first-pass UI | Quality workspace stage button. | Read-only lint output is supported. `--fix`, baseline, ratchet, sniffs/category filters, and per-file/glob targeting remain CLI-only. | Matrix only |
+| `homeboy db` | supported first-pass UI | Database browser in `Homeboy/Extensions/DatabaseBrowser/`; db wrappers in `Homeboy/Core/CLI/HomeboyCLI+WorkspaceCommands.swift`. | Core browsing/querying works. Keep destructive operations guarded. | Matrix only |
+| `homeboy file` | supported first-pass UI | Remote file editor in `Homeboy/Extensions/RemoteFileEditor/`; file wrappers in `Homeboy/Core/CLI/HomeboyCLI+WorkspaceCommands.swift`. | Core list/read/write/delete/rename/search workflows exist. Keep destructive operations guarded. | Matrix only |
+| `homeboy fleet` | partial/stale | Fleet relationships in settings/config models and `FleetManagementView`. | Basic configuration exists; fleet status/check/exec style operations are still CLI-shaped unless a dashboard is designed. | Matrix only |
+| `homeboy logs` | supported first-pass UI | Remote log viewer in `Homeboy/Extensions/RemoteLogViewer/`; log wrappers in `Homeboy/Core/CLI/HomeboyCLI+WorkspaceCommands.swift`. | Core log viewing/search exists. Pinning remains scoped to log/file workflows. | Matrix only |
+| `homeboy transfer` | missing workflow | No dedicated transfer workflow. | Keep out of File Editor for now. If needed, add a focused local/server transfer sheet with dry-run output. | Matrix only |
+| `homeboy triage` | supported first-pass UI | Quality workspace `Run Triage` action; `qualityTriage()` wrapper. | `triage component` is surfaced. Project/fleet/rig/workspace triage plus filters (`--mine`, labels, failing checks, drilldown) remain CLI-only. | Matrix only |
+| `homeboy deploy` | supported first-pass UI | Deployer tool in `Homeboy/Extensions/Deployer/`. | Deploy remains its own guarded write workflow. Release/build planning is now separate from deployment. | Matrix only |
+| `homeboy component` | partial/stale | Component settings UI and models; wrappers in `Homeboy/Core/CLI/HomeboyCLI+WorkspaceCommands.swift`. | Usable for normal component config. Legacy CRUD helpers remain cleanup debt. | [#54](https://github.com/Extra-Chill/homeboy-desktop/issues/54) |
+| `homeboy config` | intentionally CLI-only | App settings expose focused project/server/component fields, not raw global config mutation. | Keep raw global config editing in the CLI. | Matrix only |
+| `homeboy daemon` | intentionally CLI-only | No daemon management UI. | Desktop consumes CLI/API behavior; it should not manage the local daemon lifecycle unless a future diagnostic screen needs it. | Matrix only |
+| `homeboy extension` | supported first-pass UI | Extension manager and dynamic extension views under `Homeboy/Core/Extensions/` and `Homeboy/Views/Extensions/`. | Extension install/setup/run exists as app infrastructure. Advanced extension authoring stays CLI/docs-driven. | Matrix only |
+| `homeboy status` | supported first-pass UI | Workspace discovery now uses `status --full` in `Homeboy/Core/CLI/HomeboyCLI+WorkspaceCommands.swift`. | Primary app bootstrap path is current. A richer top-level status dashboard can wait for product need. | Matrix only |
+| `homeboy docs` | intentionally CLI-only | Static docs live under `docs/`; no in-app docs browser. | Keep command docs in CLI/browser docs. Contextual help panes can be added later without wrapping `homeboy docs`. | Matrix only |
+| `homeboy changelog` | intentionally CLI-only | No changelog UI. | Changelog generation/inspection stays CLI-only. Release planning can link to `changes`/`release --dry-run` output instead. | Matrix only |
+| `homeboy git` | read-only UI | Git workspace in `Homeboy/Extensions/GitOperations/`; `gitStatus()` wrapper plus GitHub issue/PR navigation. | Read-only `git status` is supported. `commit`, `push`, `pull`, `rebase`, `cherry-pick`, `tag`, `issue`, and `pr` writes stay CLI-only until confirmation UX exists. | Matrix only |
+| `homeboy issues` | missing workflow | No issue reconciliation UI. | Could belong in Quality or Git/GitHub later. No active desktop tracker until the workflow is designed. | Matrix only |
+| `homeboy version` | supported first-pass UI | Release workspace reads `version show` in `ReleaseWorkflowViewModel`. | Read-only version inspection is supported. `version bump` aliases release execution and remains CLI-only. | Matrix only |
+| `homeboy build` | supported first-pass UI | Release workspace `Build` action calls `homeboy build`; deployer still has deployment-specific build handling. | Component build is supported from release planning. Bulk/project build modes remain CLI-only. | Matrix only |
+| `homeboy validate` | supported first-pass UI | Quality workspace validation stage. | Direct non-mutating validation is supported. No advanced workflow beyond component/path selection. | Matrix only |
+| `homeboy changes` | supported first-pass UI | Release workspace reads `homeboy changes` and renders commits since baseline. | Single-component planning is supported. Project/bulk change reports and `--git-diffs` remain CLI-only. | Matrix only |
+| `homeboy release` | read-only UI | Release workspace runs `homeboy release <component> --dry-run`. | Dry-run planning is supported. Mutating release execution, recover, deploy-after-release, skip checks/publish, and GitHub release controls remain CLI-only. | Matrix only |
+| `homeboy review` | supported first-pass UI | Quality workspace `Run Review` action calls `homeboy review --summary`. | Read-only summary is supported with scope controls. PR-comment output, baselines, and ratchets remain CLI-only. | Matrix only |
+| `homeboy audit` | supported first-pass UI | Quality stage button plus audit slice helpers in `Homeboy/Core/CLI/HomeboyCLI+QualityCommands.swift`. | Current `homeboy audit <component>` stage is supported. Baseline/ratchet writes stay CLI-only. | Matrix only |
+| `homeboy refactor` | partial/stale | Refactor wrappers still exist in `Homeboy/Core/CLI/HomeboyCLI+QualityCommands.swift`, but no visible workflow. | Keep mutating refactors out of the UI until proposal/confirmation UX exists. Remove or modernize unused wrappers only when a concrete desktop workflow needs them. | Matrix only |
+| `homeboy rig` | supported first-pass UI | Rigs workspace in `Homeboy/Views/Rigs/`; wrappers in `Homeboy/Core/CLI/HomeboyCLI+RigBenchReleaseCommands.swift`. | Supports list/show/status/check plus confirmed `up`/`down`. `install`, `update`, `sources`, `sync`, and `app` lifecycle commands remain CLI-only. | Matrix only |
+| `homeboy stack` | read-only UI | Stack manager in `Homeboy/App/ContentView.swift`; wrappers in `Homeboy/Core/CLI/HomeboyCLI+StackCommands.swift`. | Supports list/show/status/inspect. `create`, `add-pr`, `remove-pr`, `apply`, `rebase`, `sync`, `push`, and `diff` remain CLI-only until guarded write UX exists. | Matrix only |
+| `homeboy undo` | partial/stale | Undo wrappers exist in `Homeboy/Core/CLI/HomeboyCLI+RigBenchReleaseCommands.swift`, but no visible undo surface. | Surface undo from workflows that perform Homeboy writes rather than as a standalone command center. | Matrix only |
+| `homeboy auth` | supported first-pass UI | API/Auth workspace in `Homeboy/Views/Components/APIAuthWorkspaceView.swift`; wrappers in `Homeboy/Core/CLI/HomeboyCLI+WorkspaceCommands.swift`. | Supports project auth status/login/logout. This is separate from the desktop app login session. | Matrix only |
+| `homeboy api` | read-only UI | API/Auth safe GET explorer. | `api get` is supported. `post`, `put`, `patch`, and `delete` remain CLI-only until preview/confirmation UX exists. | Matrix only |
+| `homeboy upgrade` | partial/stale | CLI update UI exists in `Homeboy/Views/Settings/GeneralSettingsTab.swift`, but still uses Homebrew-specific paths. | Replace with `homeboy upgrade --check` / `homeboy upgrade` so source/cargo/binary installs work. | [#56](https://github.com/Extra-Chill/homeboy-desktop/issues/56) |
+| `homeboy list` | intentionally CLI-only | Alias for `--help`; no desktop wrapper. | No UI needed. | Matrix only |
+| `homeboy cargo` | intentionally CLI-only | No Cargo passthrough UI. | Keep as CLI-only extension convenience. Desktop should expose component-level build/test/validate instead. | Matrix only |
+| `homeboy wp` | intentionally CLI-only | WordPress settings/auth surfaces exist, but no WP-CLI passthrough. | Keep as CLI-only unless a WordPress operations console is explicitly designed. | Matrix only |
 
-## Follow-Up Issues Filed From This Matrix
+## Workspace Additions Now Shipped
 
-- [#32 Add desktop rig management workflow](https://github.com/Extra-Chill/homeboy-desktop/issues/32)
-- [#33 Add desktop stack manager](https://github.com/Extra-Chill/homeboy-desktop/issues/33)
-- [#34 Add benchmark workspace](https://github.com/Extra-Chill/homeboy-desktop/issues/34)
-- [#35 Add component quality workspace](https://github.com/Extra-Chill/homeboy-desktop/issues/35)
-- [#36 Add release and build workflow](https://github.com/Extra-Chill/homeboy-desktop/issues/36)
-- [#37 Add Git and GitHub operations workspace](https://github.com/Extra-Chill/homeboy-desktop/issues/37)
-- [#38 Add API and auth workspace](https://github.com/Extra-Chill/homeboy-desktop/issues/38)
+The workspace PR wave closed the old missing-workflow trackers for Bench, Rigs, Stacks, Git, API/Auth, Quality, and Release/build planning. Those closed issues are intentionally not listed as active follow-up work above.
 
-## Existing Stale-Command / Model Issues Referenced
+| Area | Shipped desktop surface | Intentional boundary |
+|---|---|---|
+| Bench | `BenchView` lists scenarios and runs benchmarks. | Baseline/ratchet, rig comparison, multi-run/concurrency, and settings overrides remain CLI-only. |
+| Rigs | `RigsView` lists specs, shows status/check output, and confirms `up`/`down`. | Rig package install/update, sources management, stack sync, and app launcher lifecycle remain CLI-only. |
+| Stacks | `StackManagerView` lists specs, shows status, and runs read-only inspection. | Stack mutation/materialization commands remain CLI-only. |
+| Git | `GitOperationsView` shows component status and GitHub navigation. | Git writes and issue/PR mutations remain CLI-only. |
+| API/Auth | `APIAuthWorkspaceView` supports auth status/login/logout and read-only GET requests. | Mutating API verbs remain CLI-only. |
+| Quality | `QualityView` wraps review, triage, audit, lint, test, and validate as non-mutating actions. | Fix/write/baseline/ratchet workflows remain CLI-only. |
+| Release/build planning | `ReleaseWorkflowView` shows changes, version, release dry-run, and build. | Actual release execution remains CLI-only. |
 
-- [#14 Migrate from deprecated `init` command to `status --full`](https://github.com/Extra-Chill/homeboy-desktop/issues/14)
-- [#15 Update `ComponentConfiguration` with missing CLI fields](https://github.com/Extra-Chill/homeboy-desktop/issues/15)
-- [#16 Update `ProjectConfiguration` with missing CLI fields](https://github.com/Extra-Chill/homeboy-desktop/issues/16)
-- [#17 Track portable Homeboy component config](https://github.com/Extra-Chill/homeboy-desktop/issues/17)
-- [#18 Modernize audit quick actions](https://github.com/Extra-Chill/homeboy-desktop/issues/18)
-- [#19 Replace removed supports capability probe](https://github.com/Extra-Chill/homeboy-desktop/issues/19)
-- [#20 Update read-only CLI calls for current JSON output contract](https://github.com/Extra-Chill/homeboy-desktop/issues/20)
-- [#21 Modernize component and fleet mutation commands](https://github.com/Extra-Chill/homeboy-desktop/issues/21)
-- [#22 Modernize CLI helper command shapes](https://github.com/Extra-Chill/homeboy-desktop/issues/22)
-- [#23 Modernize ExtensionManager command shapes](https://github.com/Extra-Chill/homeboy-desktop/issues/23)
-- [#24 Update Remote Log Viewer pin command](https://github.com/Extra-Chill/homeboy-desktop/issues/24)
-- [#25 Split HomeboyCLI god file](https://github.com/Extra-Chill/homeboy-desktop/issues/25)
-- [#26 Fix stale desktop documentation references](https://github.com/Extra-Chill/homeboy-desktop/issues/26)
-- [#27 Improve Swift audit fingerprint coverage](https://github.com/Extra-Chill/homeboy-desktop/issues/27)
+## Still-Missing Desktop Workflows
+
+- `homeboy transfer` has no desktop workflow.
+- `homeboy issues` has no desktop workflow.
+- `homeboy undo` has wrappers but no visible workflow.
+- Advanced stack/rig/bench/release/git/API mutation flows are intentionally CLI-only until the app has specific confirmation UX for each risk profile.
+
+## Upstream Audit Detector False-Positive History
+
+Some audit findings previously seen against Homeboy Desktop were detector-shape issues in the upstream Homeboy auditor, not desktop product gaps. The linked upstream issues are closed as completed; if a matching finding reappears, treat it as an upstream-detector regression unless the specific finding reproduces as a real app bug.
+
+- [`unreferenced_export`](https://github.com/Extra-Chill/homeboy/issues/1544): can miss exported entry points referenced by framework registration patterns.
+- [`missing_interface`](https://github.com/Extra-Chill/homeboy/issues/1545): can conflate traits, helper types, and interface-like conventions.
+- [`missing_registration`](https://github.com/Extra-Chill/homeboy/issues/1546) and [`missing_method`](https://github.com/Extra-Chill/homeboy/issues/1547): can over-apply endpoint-style conventions to supporting types.
+- [`naming_mismatch`](https://github.com/Extra-Chill/homeboy/issues/1548): can flag helper/utility files that intentionally do not match a directory's primary suffix.
+- [`repeated_field_pattern`](https://github.com/Extra-Chill/homeboy/issues/1549): can misread registration arrays and repeated language idioms.
+- [`upstream_workaround`](https://github.com/Extra-Chill/homeboy/issues/1550): can mistake historical design references for active workaround markers.
+- [`dead_guard`](https://github.com/Extra-Chill/homeboy/issues/1552): can miss runtime-context guards used by tests, activation paths, or platform bootstraps.
+
+## Active Desktop Follow-Up Issues
+
+- [#54 Refactor: remove legacy CLI CRUD wrappers from CLIBridge](https://github.com/Extra-Chill/homeboy-desktop/issues/54)
+- [#56 Fix: use homeboy upgrade instead of Homebrew-specific upgrade path](https://github.com/Extra-Chill/homeboy-desktop/issues/56)
+- [#57 Test: split desktop contract tests by command surface](https://github.com/Extra-Chill/homeboy-desktop/issues/57)

--- a/docs/CLI-PARITY.md
+++ b/docs/CLI-PARITY.md
@@ -16,9 +16,9 @@ Source of truth checked for this pass: `homeboy --help` plus focused help for th
 
 | CLI command | Desktop support status | Current app surface / file references | Desktop boundary / remaining work | Tracking |
 |---|---|---|---|---|
-| `homeboy project` | partial/stale | Project switcher and settings-backed project CRUD; wrappers in `Homeboy/Core/CLI/HomeboyCLI+WorkspaceCommands.swift`. | Usable as app infrastructure. Legacy CRUD helpers still need removal from old `CLIBridge` surface. | [#54](https://github.com/Extra-Chill/homeboy-desktop/issues/54) |
+| `homeboy project` | supported first-pass UI | Project switcher and settings-backed project CRUD; wrappers in `Homeboy/Core/CLI/HomeboyCLI+WorkspaceCommands.swift`. | Usable as app infrastructure. Raw global config editing stays CLI-only. | Matrix only |
 | `homeboy ssh` | partial/stale | Generic SSH support behind file, log, db, and deploy workflows; server settings in `Homeboy/Views/Settings/ServersSettingsTab.swift`. | Keep as supporting infrastructure. Add an ad-hoc SSH console only if a real desktop workflow needs it. | Matrix only |
-| `homeboy server` | partial/stale | Server settings UI plus server wrappers in `Homeboy/Core/CLI/HomeboyCLI+WorkspaceCommands.swift`. | Usable for normal server setup. Legacy wrappers remain cleanup debt. | [#54](https://github.com/Extra-Chill/homeboy-desktop/issues/54) |
+| `homeboy server` | supported first-pass UI | Server settings UI plus server wrappers in `Homeboy/Core/CLI/HomeboyCLI+WorkspaceCommands.swift`. | Usable for normal server setup. Advanced SSH/key diagnostics stay CLI-only until a focused UI needs them. | Matrix only |
 | `homeboy test` | supported first-pass UI | Quality workspace stage button via `Homeboy/Extensions/Quality/Views/QualityView.swift` and `Homeboy/Core/CLI/HomeboyCLI+QualityCommands.swift`. | Supports normal scoped runs (`changed-since`, `changed-only`, path override). Advanced analysis/drift/write flows remain CLI-only. | Matrix only |
 | `homeboy bench` | supported first-pass UI | Bench workspace in `Homeboy/Views/BenchView.swift`; wrappers in `Homeboy/Core/CLI/HomeboyCLI+RigBenchReleaseCommands.swift`. | Lists scenarios and runs benchmarks with iteration control. Baseline, ratchet, multi-run, concurrency, settings, and `--rig` comparisons remain CLI-only. | Matrix only |
 | `homeboy lint` | supported first-pass UI | Quality workspace stage button. | Read-only lint output is supported. `--fix`, baseline, ratchet, sniffs/category filters, and per-file/glob targeting remain CLI-only. | Matrix only |
@@ -29,7 +29,7 @@ Source of truth checked for this pass: `homeboy --help` plus focused help for th
 | `homeboy transfer` | missing workflow | No dedicated transfer workflow. | Keep out of File Editor for now. If needed, add a focused local/server transfer sheet with dry-run output. | Matrix only |
 | `homeboy triage` | supported first-pass UI | Quality workspace `Run Triage` action; `qualityTriage()` wrapper. | `triage component` is surfaced. Project/fleet/rig/workspace triage plus filters (`--mine`, labels, failing checks, drilldown) remain CLI-only. | Matrix only |
 | `homeboy deploy` | supported first-pass UI | Deployer tool in `Homeboy/Extensions/Deployer/`. | Deploy remains its own guarded write workflow. Release/build planning is now separate from deployment. | Matrix only |
-| `homeboy component` | partial/stale | Component settings UI and models; wrappers in `Homeboy/Core/CLI/HomeboyCLI+WorkspaceCommands.swift`. | Usable for normal component config. Legacy CRUD helpers remain cleanup debt. | [#54](https://github.com/Extra-Chill/homeboy-desktop/issues/54) |
+| `homeboy component` | supported first-pass UI | Component settings UI and models; wrappers in `Homeboy/Core/CLI/HomeboyCLI+WorkspaceCommands.swift`. | Usable for normal component config. Bulk/JSON-pointer style edits stay CLI-only. | Matrix only |
 | `homeboy config` | intentionally CLI-only | App settings expose focused project/server/component fields, not raw global config mutation. | Keep raw global config editing in the CLI. | Matrix only |
 | `homeboy daemon` | intentionally CLI-only | No daemon management UI. | Desktop consumes CLI/API behavior; it should not manage the local daemon lifecycle unless a future diagnostic screen needs it. | Matrix only |
 | `homeboy extension` | supported first-pass UI | Extension manager and dynamic extension views under `Homeboy/Core/Extensions/` and `Homeboy/Views/Extensions/`. | Extension install/setup/run exists as app infrastructure. Advanced extension authoring stays CLI/docs-driven. | Matrix only |
@@ -51,7 +51,7 @@ Source of truth checked for this pass: `homeboy --help` plus focused help for th
 | `homeboy undo` | partial/stale | Undo wrappers exist in `Homeboy/Core/CLI/HomeboyCLI+RigBenchReleaseCommands.swift`, but no visible undo surface. | Surface undo from workflows that perform Homeboy writes rather than as a standalone command center. | Matrix only |
 | `homeboy auth` | supported first-pass UI | API/Auth workspace in `Homeboy/Views/Components/APIAuthWorkspaceView.swift`; wrappers in `Homeboy/Core/CLI/HomeboyCLI+WorkspaceCommands.swift`. | Supports project auth status/login/logout. This is separate from the desktop app login session. | Matrix only |
 | `homeboy api` | read-only UI | API/Auth safe GET explorer. | `api get` is supported. `post`, `put`, `patch`, and `delete` remain CLI-only until preview/confirmation UX exists. | Matrix only |
-| `homeboy upgrade` | partial/stale | CLI update UI exists in `Homeboy/Views/Settings/GeneralSettingsTab.swift`, but still uses Homebrew-specific paths. | Replace with `homeboy upgrade --check` / `homeboy upgrade` so source/cargo/binary installs work. | [#56](https://github.com/Extra-Chill/homeboy-desktop/issues/56) |
+| `homeboy upgrade` | supported first-pass UI | CLI update UI in `Homeboy/Views/Settings/GeneralSettingsTab.swift` and launch-time update sheet now use `homeboy upgrade --check` / `homeboy upgrade`. | Install help still shows the Homebrew path, but update execution is no longer Homebrew-specific. | Matrix only |
 | `homeboy list` | intentionally CLI-only | Alias for `--help`; no desktop wrapper. | No UI needed. | Matrix only |
 | `homeboy cargo` | intentionally CLI-only | No Cargo passthrough UI. | Keep as CLI-only extension convenience. Desktop should expose component-level build/test/validate instead. | Matrix only |
 | `homeboy wp` | intentionally CLI-only | WordPress settings/auth surfaces exist, but no WP-CLI passthrough. | Keep as CLI-only unless a WordPress operations console is explicitly designed. | Matrix only |
@@ -91,6 +91,4 @@ Some audit findings previously seen against Homeboy Desktop were detector-shape 
 
 ## Active Desktop Follow-Up Issues
 
-- [#54 Refactor: remove legacy CLI CRUD wrappers from CLIBridge](https://github.com/Extra-Chill/homeboy-desktop/issues/54)
-- [#56 Fix: use homeboy upgrade instead of Homebrew-specific upgrade path](https://github.com/Extra-Chill/homeboy-desktop/issues/56)
-- [#57 Test: split desktop contract tests by command surface](https://github.com/Extra-Chill/homeboy-desktop/issues/57)
+No active follow-up issues remain from this parity pass. New desktop work should be filed from a concrete workflow need rather than from the historical parity backlog.


### PR DESCRIPTION
## Summary
- Refreshes `docs/CLI-PARITY.md` against the current `homeboy --help` command surface and current desktop workspaces.
- Marks the shipped Bench, Rigs, Stacks, Git, API/Auth, Quality, and Release/build planning surfaces accurately, including their read-only or CLI-only boundaries.
- Removes misleading closed tracker references and keeps only active desktop follow-ups plus upstream audit detector false-positive history.

## Tests
- `swift tests/ContractTests.swift tests`
- `plutil -lint Homeboy.xcodeproj/project.pbxproj`
- `git diff --check -- docs/CLI-PARITY.md`
- `homeboy audit homeboy-desktop --path /Users/chubes/Developer/homeboy-desktop@docs-refresh-cli-parity --changed-since origin/main`
- `homeboy lint homeboy-desktop --path /Users/chubes/Developer/homeboy-desktop@docs-refresh-cli-parity --changed-since origin/main`
- Manually verified active desktop issue links (#54, #56, #57) and upstream audit issue links resolve via `gh issue view`.

Closes #55

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5; `openai/gpt-5.5`)
- **Used for:** Drafted the documentation refresh, checked current CLI/app surfaces, ran local verification, and prepared the PR. Chris remains responsible for review and merge.
