### PR TITLE
Add run history CLI models

### DIFF
--- a/Homeboy.xcodeproj/project.pbxproj
+++ b/Homeboy.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		278021F9D228BBDA95267232 /* HomeboyCLI+FileDatabaseCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D870E69E9C29278BC862CD05 /* HomeboyCLI+FileDatabaseCommands.swift */; };
 		278021F9D228BBDA95267233 /* HomeboyCLI+QualityCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D870E69E9C29278BC862CD06 /* HomeboyCLI+QualityCommands.swift */; };
 		278021F9D228BBDA95267234 /* HomeboyCLI+RigBenchReleaseCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D870E69E9C29278BC862CD07 /* HomeboyCLI+RigBenchReleaseCommands.swift */; };
+		278021F9D228BBDA95267238 /* HomeboyCLI+RunCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D870E69E9C29278BC862CD0B /* HomeboyCLI+RunCommands.swift */; };
 		278021F9D228BBDA95267235 /* HomeboyCLI+StackCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D870E69E9C29278BC862CD08 /* HomeboyCLI+StackCommands.swift */; };
 		278021F9D228BBDA95267236 /* HomeboyCLI+WorkspaceCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D870E69E9C29278BC862CD09 /* HomeboyCLI+WorkspaceCommands.swift */; };
 		278021F9D228BBDA95267237 /* HomeboyCLIModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = D870E69E9C29278BC862CD0A /* HomeboyCLIModels.swift */; };
@@ -212,6 +213,7 @@
 		D870E69E9C29278BC862CD05 /* HomeboyCLI+FileDatabaseCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+FileDatabaseCommands.swift"; sourceTree = "<group>"; };
 		D870E69E9C29278BC862CD06 /* HomeboyCLI+QualityCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+QualityCommands.swift"; sourceTree = "<group>"; };
 		D870E69E9C29278BC862CD07 /* HomeboyCLI+RigBenchReleaseCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+RigBenchReleaseCommands.swift"; sourceTree = "<group>"; };
+		D870E69E9C29278BC862CD0B /* HomeboyCLI+RunCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+RunCommands.swift"; sourceTree = "<group>"; };
 		D870E69E9C29278BC862CD08 /* HomeboyCLI+StackCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+StackCommands.swift"; sourceTree = "<group>"; };
 		D870E69E9C29278BC862CD09 /* HomeboyCLI+WorkspaceCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+WorkspaceCommands.swift"; sourceTree = "<group>"; };
 		D870E69E9C29278BC862CD0A /* HomeboyCLIModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeboyCLIModels.swift; sourceTree = "<group>"; };
@@ -411,6 +413,7 @@
 				D870E69E9C29278BC862CD05 /* HomeboyCLI+FileDatabaseCommands.swift */,
 				D870E69E9C29278BC862CD06 /* HomeboyCLI+QualityCommands.swift */,
 				D870E69E9C29278BC862CD07 /* HomeboyCLI+RigBenchReleaseCommands.swift */,
+				D870E69E9C29278BC862CD0B /* HomeboyCLI+RunCommands.swift */,
 				D870E69E9C29278BC862CD08 /* HomeboyCLI+StackCommands.swift */,
 				D870E69E9C29278BC862CD09 /* HomeboyCLI+WorkspaceCommands.swift */,
 				D870E69E9C29278BC862CD04 /* HomeboyCLI.swift */,
@@ -754,6 +757,7 @@
 				278021F9D228BBDA95267232 /* HomeboyCLI+FileDatabaseCommands.swift in Sources */,
 				278021F9D228BBDA95267233 /* HomeboyCLI+QualityCommands.swift in Sources */,
 				278021F9D228BBDA95267234 /* HomeboyCLI+RigBenchReleaseCommands.swift in Sources */,
+				278021F9D228BBDA95267238 /* HomeboyCLI+RunCommands.swift in Sources */,
 				278021F9D228BBDA95267235 /* HomeboyCLI+StackCommands.swift in Sources */,
 				278021F9D228BBDA95267236 /* HomeboyCLI+WorkspaceCommands.swift in Sources */,
 				278021F9D228BBDA95267237 /* HomeboyCLIModels.swift in Sources */,

--- a/Homeboy/Core/CLI/HomeboyCLI+RunCommands.swift
+++ b/Homeboy/Core/CLI/HomeboyCLI+RunCommands.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+struct RunsListFilter {
+    var kind: String?
+    var componentId: String?
+    var rigId: String?
+    var status: String?
+    var limit: Int?
+}
+
+struct RunsCompareFilter {
+    var kind: String = "bench"
+    var componentId: String?
+    var rigId: String?
+    var scenarioId: String?
+    var status: String?
+    var metrics: [String] = ["total_elapsed_ms"]
+    var limit: Int?
+}
+
+@MainActor
+extension HomeboyCLI {
+    func runsList(filter: RunsListFilter = RunsListFilter()) async throws -> [RunSummary] {
+        var args = ["runs", "list"]
+        appendRunsListFilter(filter, to: &args)
+        let output: RunsListOutput = try await cli.executeCommand(
+            args,
+            dataType: RunsListOutput.self,
+            source: "Runs List",
+            timeout: 30
+        )
+        return output.runs
+    }
+
+    func runsShow(id: String) async throws -> RunDetail {
+        let output: RunsShowOutput = try await cli.executeCommand(
+            ["runs", "show", id],
+            dataType: RunsShowOutput.self,
+            source: "Runs Show",
+            timeout: 30
+        )
+        return output.run
+    }
+
+    func runsArtifacts(id: String) async throws -> [RunArtifact] {
+        let output: RunsArtifactsOutput = try await cli.executeCommand(
+            ["runs", "artifacts", id],
+            dataType: RunsArtifactsOutput.self,
+            source: "Runs Artifacts",
+            timeout: 30
+        )
+        return output.artifacts
+    }
+
+    func runsFindings(
+        id: String,
+        tool: String? = nil,
+        file: String? = nil,
+        fingerprint: String? = nil,
+        limit: Int? = nil
+    ) async throws -> [RunFinding] {
+        var args = ["runs", "findings", id]
+        if let tool, !tool.isEmpty {
+            args.append(contentsOf: ["--tool", tool])
+        }
+        if let file, !file.isEmpty {
+            args.append(contentsOf: ["--file", file])
+        }
+        if let fingerprint, !fingerprint.isEmpty {
+            args.append(contentsOf: ["--fingerprint", fingerprint])
+        }
+        if let limit {
+            args.append(contentsOf: ["--limit", String(limit)])
+        }
+
+        let output: RunsFindingsOutput = try await cli.executeCommand(
+            args,
+            dataType: RunsFindingsOutput.self,
+            source: "Runs Findings",
+            timeout: 30
+        )
+        return output.findings
+    }
+
+    func runsCompare(filter: RunsCompareFilter = RunsCompareFilter()) async throws -> RunsCompareOutput {
+        var args = ["runs", "compare", "--format", "json", "--kind", filter.kind]
+        if let componentId = filter.componentId, !componentId.isEmpty {
+            args.append(contentsOf: ["--component", componentId])
+        }
+        if let rigId = filter.rigId, !rigId.isEmpty {
+            args.append(contentsOf: ["--rig", rigId])
+        }
+        if let scenarioId = filter.scenarioId, !scenarioId.isEmpty {
+            args.append(contentsOf: ["--scenario", scenarioId])
+        }
+        if let status = filter.status, !status.isEmpty {
+            args.append(contentsOf: ["--status", status])
+        }
+        for metric in filter.metrics where !metric.isEmpty {
+            args.append(contentsOf: ["--metric", metric])
+        }
+        if let limit = filter.limit {
+            args.append(contentsOf: ["--limit", String(limit)])
+        }
+
+        return try await cli.executeCommand(
+            args,
+            dataType: RunsCompareOutput.self,
+            source: "Runs Compare",
+            timeout: 30
+        )
+    }
+
+    private func appendRunsListFilter(_ filter: RunsListFilter, to args: inout [String]) {
+        if let kind = filter.kind, !kind.isEmpty {
+            args.append(contentsOf: ["--kind", kind])
+        }
+        if let componentId = filter.componentId, !componentId.isEmpty {
+            args.append(contentsOf: ["--component", componentId])
+        }
+        if let rigId = filter.rigId, !rigId.isEmpty {
+            args.append(contentsOf: ["--rig", rigId])
+        }
+        if let status = filter.status, !status.isEmpty {
+            args.append(contentsOf: ["--status", status])
+        }
+        if let limit = filter.limit {
+            args.append(contentsOf: ["--limit", String(limit)])
+        }
+    }
+}

--- a/Homeboy/Core/CLI/HomeboyCLIModels.swift
+++ b/Homeboy/Core/CLI/HomeboyCLIModels.swift
@@ -468,6 +468,115 @@ struct BenchScenarioDelta: Decodable, Identifiable {
     let improvement: Bool
 }
 
+// MARK: - Run History CLI Output Models
+
+struct RunsListOutput: Decodable {
+    let command: String
+    let runs: [RunSummary]
+}
+
+struct RunsShowOutput: Decodable {
+    let command: String
+    let run: RunDetail
+}
+
+struct RunsArtifactsOutput: Decodable {
+    let command: String
+    let runId: String
+    let artifacts: [RunArtifact]
+}
+
+struct RunsFindingsOutput: Decodable {
+    let command: String
+    let runId: String
+    let findings: [RunFinding]
+}
+
+struct RunSummary: Decodable, Identifiable {
+    let id: String
+    let kind: String
+    let status: String
+    let startedAt: String
+    let finishedAt: String?
+    let componentId: String?
+    let rigId: String?
+    let gitSha: String?
+    let command: String?
+    let cwd: String?
+    let statusNote: String?
+}
+
+struct RunDetail: Decodable, Identifiable {
+    let id: String
+    let kind: String
+    let status: String
+    let startedAt: String
+    let finishedAt: String?
+    let componentId: String?
+    let rigId: String?
+    let gitSha: String?
+    let command: String?
+    let cwd: String?
+    let statusNote: String?
+    let homeboyVersion: String?
+    let metadata: JSONValue
+    let artifacts: [RunArtifact]
+}
+
+struct RunArtifact: Decodable, Identifiable {
+    let id: String
+    let runId: String
+    let kind: String
+    let artifactType: String
+    let path: String
+    let url: String?
+    let sha256: String?
+    let sizeBytes: Int64?
+    let mime: String?
+    let createdAt: String
+
+    private enum CodingKeys: String, CodingKey {
+        case id, runId, kind, path, url, sha256, sizeBytes, mime, createdAt
+        case artifactType = "type"
+    }
+}
+
+struct RunFinding: Decodable, Identifiable {
+    let id: String
+    let runId: String
+    let tool: String
+    let rule: String?
+    let file: String?
+    let line: Int64?
+    let severity: String?
+    let fingerprint: String?
+    let message: String
+    let fixable: Bool?
+    let metadataJson: JSONValue
+    let createdAt: String
+}
+
+struct RunsCompareOutput: Decodable {
+    let command: String
+    let kind: String
+    let componentId: String?
+    let rigId: String?
+    let scenarioId: String?
+    let metrics: [String]
+    let rows: [RunsCompareRow]
+}
+
+struct RunsCompareRow: Decodable, Identifiable {
+    let run: RunSummary
+    let artifactCount: Int
+    let scenarioId: String?
+    let metrics: [String: Double?]
+
+    var id: String {
+        [run.id, scenarioId].compactMap { $0 }.joined(separator: ":")
+    }
+}
+
 /// Extension configuration scoped to a component (for CLI output parsing)
 /// Settings use [String: String] for simplicity - CLI returns settings as strings
 struct ScopedExtensionConfigCLI: Decodable {
@@ -599,4 +708,3 @@ struct ConfigGapDetail: Decodable, Identifiable {
     
     var id: String { "\(componentId).\(field)" }
 }
-

--- a/tests/ContractTestRunner.swift
+++ b/tests/ContractTestRunner.swift
@@ -16,6 +16,7 @@ func runTests(testDir: String) throws {
     try runWorkspaceStatusConfigContractTests(testDir: testDir, fixturesDir: fixturesDir, decoder: decoder)
     try runFileLogDBContractTests(testDir: testDir, fixturesDir: fixturesDir, decoder: decoder)
     try runRigBenchReleaseUndoContractTests(testDir: testDir, fixturesDir: fixturesDir, decoder: decoder)
+    try runHistoryContractTests(testDir: testDir, fixturesDir: fixturesDir, decoder: decoder)
     try runStackGitAPIAuthContractTests(testDir: testDir, fixturesDir: fixturesDir, decoder: decoder)
     try runQualityAuditReviewTriageContractTests(testDir: testDir, fixturesDir: fixturesDir, decoder: decoder)
 

--- a/tests/ContractTestSupport.swift
+++ b/tests/ContractTestSupport.swift
@@ -484,6 +484,111 @@ struct BenchScenarioDeltaTest: Decodable {
     let improvement: Bool
 }
 
+// MARK: - Run History Output Types (mirror HomeboyCLI.swift)
+
+struct RunsListOutputTest: Decodable {
+    let command: String
+    let runs: [RunSummaryTest]
+}
+
+struct RunsShowOutputTest: Decodable {
+    let command: String
+    let run: RunDetailTest
+}
+
+struct RunsArtifactsOutputTest: Decodable {
+    let command: String
+    let runId: String
+    let artifacts: [RunArtifactTest]
+}
+
+struct RunsFindingsOutputTest: Decodable {
+    let command: String
+    let runId: String
+    let findings: [RunFindingTest]
+}
+
+struct RunSummaryTest: Decodable {
+    let id: String
+    let kind: String
+    let status: String
+    let startedAt: String
+    let finishedAt: String?
+    let componentId: String?
+    let rigId: String?
+    let gitSha: String?
+    let command: String?
+    let cwd: String?
+    let statusNote: String?
+}
+
+struct RunDetailTest: Decodable {
+    let id: String
+    let kind: String
+    let status: String
+    let startedAt: String
+    let finishedAt: String?
+    let componentId: String?
+    let rigId: String?
+    let gitSha: String?
+    let command: String?
+    let cwd: String?
+    let statusNote: String?
+    let homeboyVersion: String?
+    let metadata: JSONValueTest
+    let artifacts: [RunArtifactTest]
+}
+
+struct RunArtifactTest: Decodable {
+    let id: String
+    let runId: String
+    let kind: String
+    let artifactType: String
+    let path: String
+    let url: String?
+    let sha256: String?
+    let sizeBytes: Int64?
+    let mime: String?
+    let createdAt: String
+
+    private enum CodingKeys: String, CodingKey {
+        case id, runId, kind, path, url, sha256, sizeBytes, mime, createdAt
+        case artifactType = "type"
+    }
+}
+
+struct RunFindingTest: Decodable {
+    let id: String
+    let runId: String
+    let tool: String
+    let rule: String?
+    let file: String?
+    let line: Int64?
+    let severity: String?
+    let fingerprint: String?
+    let message: String
+    let fixable: Bool?
+    let metadataJson: JSONValueTest
+    let createdAt: String
+}
+
+struct RunsCompareOutputTest: Decodable {
+    let command: String
+    let kind: String
+    let componentId: String?
+    let rigId: String?
+    let scenarioId: String?
+    let metrics: [String]
+    let rows: [RunsCompareRowTest]
+}
+
+struct RunsCompareRowTest: Decodable {
+    let run: RunSummaryTest
+    let artifactCount: Int
+    let scenarioId: String?
+    let metrics: [String: Double?]
+}
+
 // MARK: - Release / Build Output Types (mirror HomeboyCLI.swift)
 
 struct ChangesOutputTest: Decodable {

--- a/tests/ContractTests.swift
+++ b/tests/ContractTests.swift
@@ -19,6 +19,7 @@ let aggregateFiles = [
     "WorkspaceStatusConfigContractTests.swift",
     "FileLogDBContractTests.swift",
     "RigBenchReleaseUndoContractTests.swift",
+    "RunHistoryContractTests.swift",
     "StackGitAPIAuthContractTests.swift",
     "QualityAuditReviewTriageContractTests.swift",
     "ContractTestRunner.swift",

--- a/tests/RunHistoryContractTests.swift
+++ b/tests/RunHistoryContractTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+// MARK: - run history
+
+func runHistoryContractTests(testDir: String, fixturesDir: String, decoder: JSONDecoder) throws {
+    try testRunHistoryFixtures(fixturesDir: fixturesDir, decoder: decoder)
+    try testRunHistoryWrapperCommandShapes()
+}
+
+func testRunHistoryFixtures(fixturesDir: String, decoder: JSONDecoder) throws {
+    print("Test: run history command contracts")
+    print("-----------------------------------")
+
+    let listData = try Data(contentsOf: URL(fileURLWithPath: "\(fixturesDir)/runs-list.json"))
+    let listResult = try decoder.decode(CLIResponse<RunsListOutputTest>.self, from: listData)
+    guard listResult.success, let runs = listResult.data?.runs, runs.count == 2 else {
+        throw NSError(domain: "ContractTest", code: 130,
+            userInfo: [NSLocalizedDescriptionKey: "runs-list.json did not decode two runs"])
+    }
+    guard runs[0].id == "run-bench-001", runs[0].componentId == "homeboy-desktop", runs[1].statusNote == "owner_process_not_running" else {
+        throw NSError(domain: "ContractTest", code: 131,
+            userInfo: [NSLocalizedDescriptionKey: "runs-list.json summary fields did not decode"])
+    }
+    print("[PASS] Runs list summaries decode")
+
+    let showData = try Data(contentsOf: URL(fileURLWithPath: "\(fixturesDir)/runs-show.json"))
+    let showResult = try decoder.decode(CLIResponse<RunsShowOutputTest>.self, from: showData)
+    guard showResult.success, let run = showResult.data?.run else {
+        throw NSError(domain: "ContractTest", code: 132,
+            userInfo: [NSLocalizedDescriptionKey: "runs-show.json did not decode run detail"])
+    }
+    guard run.id == "run-bench-001", run.homeboyVersion == "0.31.0", run.artifacts.count == 1 else {
+        throw NSError(domain: "ContractTest", code: 133,
+            userInfo: [NSLocalizedDescriptionKey: "runs-show.json detail fields did not decode"])
+    }
+    guard case .object(let metadata) = run.metadata,
+          case .array(let scenarios) = metadata["scenario_metrics"],
+          scenarios.count == 1 else {
+        throw NSError(domain: "ContractTest", code: 134,
+            userInfo: [NSLocalizedDescriptionKey: "runs-show.json metadata did not preserve arbitrary JSON"])
+    }
+    print("[PASS] Runs show detail and metadata decode")
+
+    let artifactsData = try Data(contentsOf: URL(fileURLWithPath: "\(fixturesDir)/runs-artifacts.json"))
+    let artifactsResult = try decoder.decode(CLIResponse<RunsArtifactsOutputTest>.self, from: artifactsData)
+    guard artifactsResult.success, let artifacts = artifactsResult.data?.artifacts, artifacts.count == 2 else {
+        throw NSError(domain: "ContractTest", code: 135,
+            userInfo: [NSLocalizedDescriptionKey: "runs-artifacts.json did not decode artifacts"])
+    }
+    guard artifacts[0].artifactType == "file", artifacts[1].artifactType == "url", artifacts[1].url == "https://example.test/report" else {
+        throw NSError(domain: "ContractTest", code: 136,
+            userInfo: [NSLocalizedDescriptionKey: "runs-artifacts.json file/url artifacts did not decode"])
+    }
+    print("[PASS] Runs artifacts file and URL records decode")
+
+    let findingsData = try Data(contentsOf: URL(fileURLWithPath: "\(fixturesDir)/runs-findings.json"))
+    let findingsResult = try decoder.decode(CLIResponse<RunsFindingsOutputTest>.self, from: findingsData)
+    guard findingsResult.success, let finding = findingsResult.data?.findings.first else {
+        throw NSError(domain: "ContractTest", code: 137,
+            userInfo: [NSLocalizedDescriptionKey: "runs-findings.json did not decode findings"])
+    }
+    guard finding.tool == "lint", finding.fixable == true,
+          case .object(let metadata) = finding.metadataJson,
+          case .string("lint-findings") = metadata["source_sidecar"] else {
+        throw NSError(domain: "ContractTest", code: 138,
+            userInfo: [NSLocalizedDescriptionKey: "runs-findings.json finding fields did not decode"])
+    }
+    print("[PASS] Runs findings decode")
+
+    let compareData = try Data(contentsOf: URL(fileURLWithPath: "\(fixturesDir)/runs-compare.json"))
+    let compareResult = try decoder.decode(CLIResponse<RunsCompareOutputTest>.self, from: compareData)
+    guard compareResult.success, let compare = compareResult.data, compare.command == "runs.compare" else {
+        throw NSError(domain: "ContractTest", code: 139,
+            userInfo: [NSLocalizedDescriptionKey: "runs-compare.json did not decode compare output"])
+    }
+    guard compare.rows.count == 2, compare.rows[0].metrics["total_elapsed_ms"] == 1200.5 else {
+        throw NSError(domain: "ContractTest", code: 140,
+            userInfo: [NSLocalizedDescriptionKey: "runs-compare.json compare rows did not decode"])
+    }
+    print("[PASS] Runs compare JSON decodes")
+    print("")
+}
+
+func testRunHistoryWrapperCommandShapes() throws {
+    print("Test: run history wrapper command shapes")
+    print("----------------------------------------")
+
+    let source = try cliSourceContent()
+
+    try assertContains(source, #"["runs", "list"]"#,
+        message: "runsList wrapper uses homeboy runs list")
+    try assertContains(source, #"["runs", "show", id]"#,
+        message: "runsShow wrapper uses homeboy runs show")
+    try assertContains(source, #"["runs", "artifacts", id]"#,
+        message: "runsArtifacts wrapper uses homeboy runs artifacts")
+    try assertContains(source, #"["runs", "findings", id]"#,
+        message: "runsFindings wrapper uses homeboy runs findings")
+    try assertContains(source, #"["runs", "compare", "--format", "json", "--kind", filter.kind]"#,
+        message: "runsCompare wrapper forces JSON output")
+    try assertContains(source, #"args.append(contentsOf: ["--component", componentId])"#,
+        message: "run history wrappers support --component")
+    try assertDoesNotContain(source, #"runs", "export"#,
+        message: "Desktop run history wrappers do not expose bundle export")
+    try assertDoesNotContain(source, #"runs", "import"#,
+        message: "Desktop run history wrappers do not expose bundle import")
+
+    print("")
+}

--- a/tests/fixtures/runs-artifacts.json
+++ b/tests/fixtures/runs-artifacts.json
@@ -1,0 +1,33 @@
+{
+  "success": true,
+  "data": {
+    "command": "runs.artifacts",
+    "run_id": "run-bench-001",
+    "artifacts": [
+      {
+        "id": "artifact-001",
+        "run_id": "run-bench-001",
+        "kind": "bench_results",
+        "type": "file",
+        "path": "/tmp/homeboy/bench-results.json",
+        "url": null,
+        "sha256": "0123456789abcdef",
+        "size_bytes": 2048,
+        "mime": "application/json",
+        "created_at": "2026-05-04T12:00:08Z"
+      },
+      {
+        "id": "artifact-002",
+        "run_id": "run-bench-001",
+        "kind": "frontend_url",
+        "type": "url",
+        "path": "https://example.test/report",
+        "url": "https://example.test/report",
+        "sha256": null,
+        "size_bytes": null,
+        "mime": null,
+        "created_at": "2026-05-04T12:00:09Z"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/runs-compare.json
+++ b/tests/fixtures/runs-compare.json
@@ -1,0 +1,55 @@
+{
+  "success": true,
+  "data": {
+    "command": "runs.compare",
+    "kind": "bench",
+    "component_id": "homeboy-desktop",
+    "rig_id": "desktop-smoke",
+    "scenario_id": "cold-launch",
+    "metrics": ["total_elapsed_ms", "p95_ms"],
+    "rows": [
+      {
+        "run": {
+          "id": "run-bench-001",
+          "kind": "bench",
+          "status": "pass",
+          "started_at": "2026-05-04T12:00:00Z",
+          "finished_at": "2026-05-04T12:00:08Z",
+          "component_id": "homeboy-desktop",
+          "rig_id": "desktop-smoke",
+          "git_sha": "abc123def456",
+          "command": "homeboy bench homeboy-desktop",
+          "cwd": "/Users/chubes/Developer/homeboy-desktop",
+          "status_note": null
+        },
+        "artifact_count": 1,
+        "scenario_id": "cold-launch",
+        "metrics": {
+          "total_elapsed_ms": 1200.5,
+          "p95_ms": 14.25
+        }
+      },
+      {
+        "run": {
+          "id": "run-bench-000",
+          "kind": "bench",
+          "status": "pass",
+          "started_at": "2026-05-03T12:00:00Z",
+          "finished_at": "2026-05-03T12:00:09Z",
+          "component_id": "homeboy-desktop",
+          "rig_id": "desktop-smoke",
+          "git_sha": "000abc111def",
+          "command": "homeboy bench homeboy-desktop",
+          "cwd": "/Users/chubes/Developer/homeboy-desktop",
+          "status_note": null
+        },
+        "artifact_count": 1,
+        "scenario_id": "cold-launch",
+        "metrics": {
+          "total_elapsed_ms": 1301.0,
+          "p95_ms": null
+        }
+      }
+    ]
+  }
+}

--- a/tests/fixtures/runs-findings.json
+++ b/tests/fixtures/runs-findings.json
@@ -1,0 +1,26 @@
+{
+  "success": true,
+  "data": {
+    "command": "runs.findings",
+    "run_id": "run-lint-002",
+    "findings": [
+      {
+        "id": "finding-001",
+        "run_id": "run-lint-002",
+        "tool": "lint",
+        "rule": "swiftlint:line_length",
+        "file": "Homeboy/Core/CLI/HomeboyCLI.swift",
+        "line": 42,
+        "severity": "warning",
+        "fingerprint": "Homeboy/Core/CLI/HomeboyCLI.swift:42:line_length",
+        "message": "Line should be 120 characters or less",
+        "fixable": true,
+        "metadata_json": {
+          "source_sidecar": "lint-findings",
+          "category": "style"
+        },
+        "created_at": "2026-05-04T11:31:00Z"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/runs-list.json
+++ b/tests/fixtures/runs-list.json
@@ -1,0 +1,34 @@
+{
+  "success": true,
+  "data": {
+    "command": "runs.list",
+    "runs": [
+      {
+        "id": "run-bench-001",
+        "kind": "bench",
+        "status": "pass",
+        "started_at": "2026-05-04T12:00:00Z",
+        "finished_at": "2026-05-04T12:00:08Z",
+        "component_id": "homeboy-desktop",
+        "rig_id": "desktop-smoke",
+        "git_sha": "abc123def456",
+        "command": "homeboy bench homeboy-desktop",
+        "cwd": "/Users/chubes/Developer/homeboy-desktop",
+        "status_note": null
+      },
+      {
+        "id": "run-lint-002",
+        "kind": "lint",
+        "status": "stale",
+        "started_at": "2026-05-04T11:30:00Z",
+        "finished_at": "2026-05-04T11:45:00Z",
+        "component_id": "homeboy-desktop",
+        "rig_id": null,
+        "git_sha": "def456abc123",
+        "command": "homeboy lint homeboy-desktop",
+        "cwd": "/Users/chubes/Developer/homeboy-desktop",
+        "status_note": "owner_process_not_running"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/runs-show.json
+++ b/tests/fixtures/runs-show.json
@@ -1,0 +1,46 @@
+{
+  "success": true,
+  "data": {
+    "command": "runs.show",
+    "run": {
+      "id": "run-bench-001",
+      "kind": "bench",
+      "status": "pass",
+      "started_at": "2026-05-04T12:00:00Z",
+      "finished_at": "2026-05-04T12:00:08Z",
+      "component_id": "homeboy-desktop",
+      "rig_id": "desktop-smoke",
+      "git_sha": "abc123def456",
+      "command": "homeboy bench homeboy-desktop",
+      "cwd": "/Users/chubes/Developer/homeboy-desktop",
+      "status_note": null,
+      "homeboy_version": "0.31.0",
+      "metadata": {
+        "selected_scenarios": ["cold-launch"],
+        "scenario_metrics": [
+          {
+            "scenario_id": "cold-launch",
+            "metrics": {
+              "total_elapsed_ms": 1200.5,
+              "p95_ms": 14.25
+            }
+          }
+        ]
+      },
+      "artifacts": [
+        {
+          "id": "artifact-001",
+          "run_id": "run-bench-001",
+          "kind": "bench_results",
+          "type": "file",
+          "path": "/tmp/homeboy/bench-results.json",
+          "url": null,
+          "sha256": "0123456789abcdef",
+          "size_bytes": 2048,
+          "mime": "application/json",
+          "created_at": "2026-05-04T12:00:08Z"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add Desktop Swift models and `HomeboyCLI` wrappers for CLI-backed `homeboy runs` list/show/artifacts/findings/compare JSON output.
- Add run history contract fixtures and decode tests using the existing CLI response envelope pattern.
- Keep this PR model-only; no Run History UI, daemon parity, daemon auto-start, or mutating run operations are added.

## Testing
- `swift tests/ContractTests.swift tests`
- `plutil -lint Homeboy.xcodeproj/project.pbxproj`

## Not run
- `xcodebuild -project Homeboy.xcodeproj -scheme Homeboy -configuration Debug build` because this machine's active developer directory is `/Library/Developer/CommandLineTools`, and `xcodebuild` requires full Xcode.

## Follow-up
- Build the Run History UI on top of `runsList(filter:)`, `runsShow(id:)`, `runsArtifacts(id:)`, `runsFindings(id:tool:file:fingerprint:limit:)`, and `runsCompare(filter:)`, with read-only list/detail/artifacts/findings surfaces first.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Drafted the Swift run-history models, CLI wrapper methods, contract fixtures/tests, and PR description. Chris remains responsible for review and validation.