### PR TITLE
Add run history workspace

### DIFF
--- a/Homeboy.xcodeproj/project.pbxproj
+++ b/Homeboy.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		0D4D7E7A5AB24A1D85E8A003 /* QualityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4D7E7A5AB24A1D85E8A103 /* QualityView.swift */; };
 		0FE6351E7C94950D6A459978 /* DeployerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F978C6E7F1C5288FF7303DF7 /* DeployerView.swift */; };
 		1162E40A1D0549D9B68608A8 /* BenchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1162E4091D0549D9B68608A8 /* BenchView.swift */; };
+		1162E40B1D0549D9B68608A8 /* RunHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1162E40C1D0549D9B68608A8 /* RunHistoryView.swift */; };
+		1162E40D1D0549D9B68608A8 /* RunHistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1162E40E1D0549D9B68608A8 /* RunHistoryViewModel.swift */; };
 		102A2F3B4C5D6E7F8091A2B3 /* RigsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3B4C5D6E7F8091A2B3102A /* RigsView.swift */; };
 		1A2B3102F3B4C5D6E7F8091A /* RigsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4C5D6E7F8091A2B3102A2F /* RigsViewModel.swift */; };
 		1A164D8DD4607926F6964B95 /* CopyableContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5BD1368E35CA013C4E064C8 /* CopyableContent.swift */; };
@@ -128,6 +130,8 @@
 		0D4D7E7A5AB24A1D85E8A103 /* QualityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QualityView.swift; sourceTree = "<group>"; };
 		0DC18F8D8A50F464D296BB74 /* InlineWarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineWarningView.swift; sourceTree = "<group>"; };
 		1162E4091D0549D9B68608A8 /* BenchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchView.swift; sourceTree = "<group>"; };
+		1162E40C1D0549D9B68608A8 /* RunHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunHistoryView.swift; sourceTree = "<group>"; };
+		1162E40E1D0549D9B68608A8 /* RunHistoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunHistoryViewModel.swift; sourceTree = "<group>"; };
 		13F8D60E3516F29F554438A0 /* VersionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionParser.swift; sourceTree = "<group>"; };
 		14349D465EC79FD6D1D8C70C /* DatabaseTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseTypes.swift; sourceTree = "<group>"; };
 		1682E9BF7F10ED915C606359 /* RemoteFileEditorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileEditorViewModel.swift; sourceTree = "<group>"; };
@@ -445,6 +449,7 @@
 				8007D7D3CCEF3F80C36AA686 /* Components */,
 				E900FE3D44D913C0F5C320A7 /* Modules */,
 				4C5D6E7F8091A2B3102A2F3B /* Rigs */,
+				1162E40F1D0549D9B68608A8 /* RunHistory */,
 				F08C0BC0AC87CDDCAA5955CF /* Settings */,
 				1162E4091D0549D9B68608A8 /* BenchView.swift */,
 				3A80F92FC849ACD9591EDEFE /* LoginView.swift */,
@@ -471,6 +476,15 @@
 				3B4C5D6E7F8091A2B3102A2F /* RigsViewModel.swift */,
 			);
 			path = Rigs;
+			sourceTree = "<group>";
+		};
+		1162E40F1D0549D9B68608A8 /* RunHistory */ = {
+			isa = PBXGroup;
+			children = (
+				1162E40C1D0549D9B68608A8 /* RunHistoryView.swift */,
+				1162E40E1D0549D9B68608A8 /* RunHistoryViewModel.swift */,
+			);
+			path = RunHistory;
 			sourceTree = "<group>";
 		};
 		8007D7D3CCEF3F80C36AA686 /* Components */ = {
@@ -800,6 +814,8 @@
 				465D0E037B7E2705A578EAF2 /* RemotePathResolver.swift in Sources */,
 				102A2F3B4C5D6E7F8091A2B3 /* RigsView.swift in Sources */,
 				1A2B3102F3B4C5D6E7F8091A /* RigsViewModel.swift in Sources */,
+				1162E40B1D0549D9B68608A8 /* RunHistoryView.swift in Sources */,
+				1162E40D1D0549D9B68608A8 /* RunHistoryViewModel.swift in Sources */,
 				58C9903BC07607162259D792 /* SSHKeyManager.swift in Sources */,
 				71419F89166E98CC7C4A3A98 /* SSHService.swift in Sources */,
 				E8A0E0A1E7364CFEB6EB48AF /* SchemaResolver.swift in Sources */,

--- a/Homeboy/App/ContentView.swift
+++ b/Homeboy/App/ContentView.swift
@@ -14,6 +14,7 @@ enum NavigationItem: Hashable {
 enum CoreTool: String, CaseIterable, Identifiable {
     case deployer = "Deployer"
     case bench = "Bench"
+    case runHistory = "Run History"
     case release = "Release"
     case rigs = "Rigs"
     case stackManager = "Stacks"
@@ -31,6 +32,7 @@ enum CoreTool: String, CaseIterable, Identifiable {
         switch self {
         case .deployer: return "arrow.up.to.line"
         case .bench: return "speedometer"
+        case .runHistory: return "clock.arrow.circlepath"
         case .release: return "tag"
         case .rigs: return "shippingbox.and.arrow.backward"
         case .stackManager: return "square.stack.3d.up"
@@ -79,6 +81,8 @@ struct ContentView: View {
                 .opacity(selectedItem == .coreTool(.deployer) ? 1 : 0)
             BenchView()
                 .opacity(selectedItem == .coreTool(.bench) ? 1 : 0)
+            RunHistoryView()
+                .opacity(selectedItem == .coreTool(.runHistory) ? 1 : 0)
             ReleaseWorkflowView()
                 .opacity(selectedItem == .coreTool(.release) ? 1 : 0)
             RigsView()

--- a/Homeboy/Views/RunHistory/RunHistoryView.swift
+++ b/Homeboy/Views/RunHistory/RunHistoryView.swift
@@ -1,0 +1,441 @@
+import SwiftUI
+
+struct RunHistoryView: View {
+    @StateObject private var viewModel = RunHistoryViewModel()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+
+            if viewModel.isLoadingRuns && viewModel.runs.isEmpty {
+                ProgressView("Loading run history...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if viewModel.runs.isEmpty {
+                emptyState
+            } else {
+                HSplitView {
+                    runTable
+                        .frame(minWidth: 680, idealWidth: 820)
+                    detailPane
+                        .frame(minWidth: 440)
+                }
+            }
+        }
+        .frame(minWidth: 1120, minHeight: 680)
+        .onAppear {
+            if viewModel.runs.isEmpty {
+                viewModel.loadRuns()
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Run History")
+                        .font(.title2.bold())
+                    Text("Read-only view of persisted Homeboy CLI run records")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                if viewModel.isLoadingRuns {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Loading...")
+                        .foregroundColor(.secondary)
+                }
+
+                Button {
+                    viewModel.loadRuns()
+                } label: {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.bordered)
+                .disabled(viewModel.isLoadingRuns)
+            }
+
+            filters
+
+            if let error = viewModel.error {
+                InlineErrorView(error)
+            }
+        }
+        .padding()
+    }
+
+    private var filters: some View {
+        HStack(spacing: 10) {
+            filterField("Kind", text: $viewModel.kindFilter, width: 100)
+            filterField("Status", text: $viewModel.statusFilter, width: 100)
+            filterField("Component", text: $viewModel.componentFilter, width: 140)
+            filterField("Rig", text: $viewModel.rigFilter, width: 120)
+
+            Stepper(value: $viewModel.limit, in: 1...500, step: 25) {
+                Text("Limit: \(viewModel.limit)")
+                    .monospacedDigit()
+            }
+            .frame(width: 130)
+
+            Button("Apply") {
+                viewModel.applyFilters()
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(viewModel.isLoadingRuns)
+
+            Button("Reset") {
+                viewModel.resetFilters()
+            }
+            .buttonStyle(.bordered)
+            .disabled(!viewModel.hasActiveFilters || viewModel.isLoadingRuns)
+
+            Spacer()
+        }
+    }
+
+    private func filterField(_ title: String, text: Binding<String>, width: CGFloat) -> some View {
+        TextField(title, text: text)
+            .textFieldStyle(.roundedBorder)
+            .frame(width: width)
+            .onSubmit {
+                viewModel.applyFilters()
+            }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 48))
+                .foregroundColor(.secondary)
+            Text("No Runs Found")
+                .font(.headline)
+            Text(viewModel.hasActiveFilters ? "No persisted runs match the current filters." : "Homeboy has not recorded any persisted runs yet.")
+                .foregroundColor(.secondary)
+            if viewModel.hasActiveFilters {
+                Button("Reset Filters") {
+                    viewModel.resetFilters()
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var runTable: some View {
+        Table(viewModel.runs, selection: $viewModel.selectedRunID) {
+            TableColumn("Status") { run in
+                statusBadge(run.status)
+            }
+            .width(min: 88, ideal: 100)
+
+            TableColumn("Kind") { run in
+                Text(run.kind)
+                    .font(.body.monospaced())
+            }
+            .width(min: 70, ideal: 90)
+
+            TableColumn("Started") { run in
+                Text(formatTimestamp(run.startedAt))
+            }
+            .width(min: 150, ideal: 170)
+
+            TableColumn("Finished / Duration") { run in
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(formatTimestamp(run.finishedAt))
+                    if let duration = durationText(started: run.startedAt, finished: run.finishedAt) {
+                        Text(duration)
+                            .font(.caption.monospacedDigit())
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            .width(min: 150, ideal: 180)
+
+            TableColumn("Component") { run in
+                secondaryText(run.componentId)
+            }
+            .width(min: 110, ideal: 140)
+
+            TableColumn("Rig") { run in
+                secondaryText(run.rigId)
+            }
+            .width(min: 90, ideal: 120)
+
+            TableColumn("Git SHA") { run in
+                Text(shortSHA(run.gitSha))
+                    .font(.body.monospaced())
+                    .textSelection(.enabled)
+            }
+            .width(min: 90, ideal: 110)
+
+            TableColumn("Command") { run in
+                Text(run.command ?? "-")
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .textSelection(.enabled)
+            }
+            .width(min: 220, ideal: 320)
+        }
+        .onChange(of: viewModel.selectedRunID) { newValue in
+            viewModel.selectRun(newValue)
+        }
+    }
+
+    private var detailPane: some View {
+        VStack(spacing: 0) {
+            if viewModel.isLoadingDetail {
+                ProgressView("Loading run detail...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let detail = viewModel.selectedRunDetail {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        detailHeader(detail)
+                        summarySection(detail)
+                        metadataSection(detail)
+                        artifactsSection(detail.artifacts)
+                        findingsSection(viewModel.findings)
+                    }
+                    .padding()
+                }
+            } else {
+                ContentUnavailableView(
+                    "Select a Run",
+                    systemImage: "clock.arrow.circlepath",
+                    description: Text("Choose a run from the table to inspect metadata, artifacts, and findings")
+                )
+            }
+        }
+    }
+
+    private func detailHeader(_ run: RunDetail) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                statusBadge(run.status)
+                Text(run.kind)
+                    .font(.headline.monospaced())
+                Spacer()
+            }
+            Text(run.id)
+                .font(.title3.bold())
+                .textSelection(.enabled)
+            if let note = run.statusNote, !note.isEmpty {
+                Text(note)
+                    .foregroundColor(.secondary)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+
+    private func summarySection(_ run: RunDetail) -> some View {
+        GroupBox("Summary") {
+            VStack(alignment: .leading, spacing: 8) {
+                summaryRow("Started", formatTimestamp(run.startedAt))
+                summaryRow("Finished", formatTimestamp(run.finishedAt))
+                summaryRow("Duration", durationText(started: run.startedAt, finished: run.finishedAt) ?? "-")
+                summaryRow("Component", run.componentId ?? "-")
+                summaryRow("Rig", run.rigId ?? "-")
+                summaryRow("Git SHA", run.gitSha ?? "-")
+                summaryRow("CWD", run.cwd ?? "-")
+                summaryRow("Homeboy", run.homeboyVersion ?? "-")
+                summaryRow("Command", run.command ?? "-")
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func metadataSection(_ run: RunDetail) -> some View {
+        GroupBox("Metadata JSON") {
+            CopyableTextView(
+                console: run.metadata.prettyPrintedJSONString,
+                source: "Run Metadata: \(run.id)",
+                maxHeight: 220
+            )
+        }
+    }
+
+    private func artifactsSection(_ artifacts: [RunArtifact]) -> some View {
+        GroupBox("Artifacts") {
+            if artifacts.isEmpty {
+                Text("No artifacts recorded")
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(artifacts) { artifact in
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Text(artifact.kind)
+                                    .font(.caption.bold())
+                                Text(artifact.artifactType)
+                                    .font(.caption.monospaced())
+                                    .foregroundColor(.secondary)
+                                Spacer()
+                                if let size = artifact.sizeBytes {
+                                    Text(formatBytes(size))
+                                        .font(.caption.monospacedDigit())
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+                            Text(artifact.path)
+                                .font(.caption.monospaced())
+                                .textSelection(.enabled)
+                            if let url = artifact.url, !url.isEmpty {
+                                Text(url)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .textSelection(.enabled)
+                            }
+                        }
+                        .padding(8)
+                        .background(Color(nsColor: .controlBackgroundColor))
+                        .cornerRadius(6)
+                    }
+                }
+            }
+        }
+    }
+
+    private func findingsSection(_ findings: [RunFinding]) -> some View {
+        GroupBox("Findings") {
+            if findings.isEmpty {
+                Text("No findings recorded")
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(findings) { finding in
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Text(finding.tool)
+                                    .font(.caption.bold())
+                                if let severity = finding.severity, !severity.isEmpty {
+                                    Text(severity)
+                                        .font(.caption.monospaced())
+                                        .foregroundColor(severityColor(severity))
+                                }
+                                if finding.fixable == true {
+                                    Text("fixable")
+                                        .font(.caption.monospaced())
+                                        .foregroundColor(.blue)
+                                }
+                                Spacer()
+                            }
+                            Text(finding.message)
+                                .textSelection(.enabled)
+                            if let file = finding.file, !file.isEmpty {
+                                Text([file, finding.line.map { String($0) }].compactMap { $0 }.joined(separator: ":"))
+                                    .font(.caption.monospaced())
+                                    .foregroundColor(.secondary)
+                                    .textSelection(.enabled)
+                            }
+                            if let rule = finding.rule, !rule.isEmpty {
+                                Text(rule)
+                                    .font(.caption.monospaced())
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        .padding(8)
+                        .background(Color(nsColor: .controlBackgroundColor))
+                        .cornerRadius(6)
+                    }
+                }
+            }
+        }
+    }
+
+    private func summaryRow(_ label: String, _ value: String) -> some View {
+        HStack(alignment: .top) {
+            Text(label)
+                .font(.caption.bold())
+                .foregroundColor(.secondary)
+                .frame(width: 82, alignment: .leading)
+            Text(value)
+                .textSelection(.enabled)
+            Spacer()
+        }
+    }
+
+    private func statusBadge(_ status: String) -> some View {
+        Label(status, systemImage: statusIcon(status))
+            .font(.caption.bold())
+            .foregroundColor(statusColor(status))
+    }
+
+    private func secondaryText(_ value: String?) -> some View {
+        Text(value?.isEmpty == false ? value! : "-")
+            .foregroundColor(value?.isEmpty == false ? .primary : .secondary)
+            .textSelection(.enabled)
+    }
+
+    private func shortSHA(_ value: String?) -> String {
+        guard let value, !value.isEmpty else { return "-" }
+        return String(value.prefix(8))
+    }
+
+    private func formatTimestamp(_ value: String?) -> String {
+        guard let value, !value.isEmpty else { return "-" }
+        guard let date = parseDate(value) else { return value }
+
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .medium
+        return formatter.string(from: date)
+    }
+
+    private func durationText(started: String, finished: String?) -> String? {
+        guard let start = parseDate(started), let finished, let end = parseDate(finished) else { return nil }
+        let seconds = max(0, Int(end.timeIntervalSince(start)))
+        if seconds < 60 { return "\(seconds)s" }
+        if seconds < 3600 { return "\(seconds / 60)m \(seconds % 60)s" }
+        return "\(seconds / 3600)h \((seconds % 3600) / 60)m"
+    }
+
+    private func parseDate(_ value: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: value) {
+            return date
+        }
+
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: value)
+    }
+
+    private func formatBytes(_ bytes: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+    }
+
+    private func statusIcon(_ status: String) -> String {
+        switch status.lowercased() {
+        case "success", "passed", "pass": return "checkmark.circle.fill"
+        case "failed", "failure", "error": return "xmark.octagon.fill"
+        case "running", "started": return "play.circle.fill"
+        default: return "circle.fill"
+        }
+    }
+
+    private func statusColor(_ status: String) -> Color {
+        switch status.lowercased() {
+        case "success", "passed", "pass": return .green
+        case "failed", "failure", "error": return .red
+        case "running", "started": return .blue
+        default: return .secondary
+        }
+    }
+
+    private func severityColor(_ severity: String) -> Color {
+        switch severity.lowercased() {
+        case "error", "critical", "high": return .red
+        case "warning", "medium": return .orange
+        case "low", "info": return .secondary
+        default: return .primary
+        }
+    }
+}
+
+#Preview {
+    RunHistoryView()
+}

--- a/Homeboy/Views/RunHistory/RunHistoryViewModel.swift
+++ b/Homeboy/Views/RunHistory/RunHistoryViewModel.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+@MainActor
+final class RunHistoryViewModel: ObservableObject {
+    @Published var runs: [RunSummary] = []
+    @Published var selectedRunID: String?
+    @Published var selectedRunDetail: RunDetail?
+    @Published var findings: [RunFinding] = []
+    @Published var kindFilter = ""
+    @Published var statusFilter = ""
+    @Published var componentFilter = ""
+    @Published var rigFilter = ""
+    @Published var limit = 50
+    @Published var isLoadingRuns = false
+    @Published var isLoadingDetail = false
+    @Published var error: (any DisplayableError)?
+
+    private var loadedDetailRunID: String?
+
+    var hasActiveFilters: Bool {
+        !kindFilter.isEmpty || !statusFilter.isEmpty || !componentFilter.isEmpty || !rigFilter.isEmpty || limit != 50
+    }
+
+    var selectedRun: RunSummary? {
+        runs.first { $0.id == selectedRunID }
+    }
+
+    func loadRuns() {
+        guard HomeboyCLI.shared.isInstalled else {
+            error = AppError("Homeboy CLI is not installed. Install via Settings -> CLI.", source: "Run History")
+            return
+        }
+
+        isLoadingRuns = true
+        error = nil
+
+        Task {
+            do {
+                let loaded = try await HomeboyCLI.shared.runsList(filter: currentFilter)
+                runs = loaded
+                isLoadingRuns = false
+
+                if let selectedRunID, loaded.contains(where: { $0.id == selectedRunID }) {
+                    loadSelectedRunIfNeeded()
+                } else {
+                    selectRun(loaded.first?.id)
+                }
+            } catch {
+                isLoadingRuns = false
+                self.error = error.toDisplayableError(source: "Run History")
+            }
+        }
+    }
+
+    func selectRun(_ id: String?) {
+        guard selectedRunID != id else { return }
+        selectedRunID = id
+        selectedRunDetail = nil
+        findings = []
+        loadedDetailRunID = nil
+        loadSelectedRunIfNeeded()
+    }
+
+    func applyFilters() {
+        selectedRunID = nil
+        selectedRunDetail = nil
+        findings = []
+        loadedDetailRunID = nil
+        loadRuns()
+    }
+
+    func resetFilters() {
+        kindFilter = ""
+        statusFilter = ""
+        componentFilter = ""
+        rigFilter = ""
+        limit = 50
+        applyFilters()
+    }
+
+    func loadSelectedRunIfNeeded() {
+        guard let id = selectedRunID, loadedDetailRunID != id, !isLoadingDetail else { return }
+        isLoadingDetail = true
+        error = nil
+
+        Task {
+            do {
+                async let detailTask = HomeboyCLI.shared.runsShow(id: id)
+                async let findingsTask = HomeboyCLI.shared.runsFindings(id: id, limit: 100)
+                selectedRunDetail = try await detailTask
+                findings = try await findingsTask
+                loadedDetailRunID = id
+            } catch {
+                self.error = error.toDisplayableError(source: "Run History")
+            }
+
+            isLoadingDetail = false
+        }
+    }
+
+    private var currentFilter: RunsListFilter {
+        RunsListFilter(
+            kind: nilIfEmpty(kindFilter),
+            componentId: nilIfEmpty(componentFilter),
+            rigId: nilIfEmpty(rigFilter),
+            status: nilIfEmpty(statusFilter),
+            limit: limit
+        )
+    }
+
+    private func nilIfEmpty(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}


### PR DESCRIPTION
## Summary
- Add a read-only Run History core sidebar workspace backed by the existing Homeboy CLI run-history wrappers.
- Add filters for kind, status, component, rig, and limit plus a run table with lazy-loaded detail, metadata JSON, artifacts, and findings.
- Keep the UI read-only: no daemon dependency, no daemon auto-start, and no job execution controls.

## Verification
- `swift tests/ContractTests.swift tests`
- `plutil -lint Homeboy.xcodeproj/project.pbxproj`
- `xcodebuild -project Homeboy.xcodeproj -scheme Homeboy -configuration Debug build` could not run because the active developer directory is CommandLineTools, not full Xcode.

## Limitations
- Full Xcode build verification was unavailable on this machine without changing machine-level Xcode configuration.
- Compare/cross-linking is intentionally left as a follow-up on top of the read-only history workspace.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Drafted the SwiftUI run history workspace, view model, project wiring, and verification/PR preparation for Chris to review and test.