### PR TITLE
Scope sidebar to active project

### DIFF
--- a/Homeboy.xcodeproj/project.pbxproj
+++ b/Homeboy.xcodeproj/project.pbxproj
@@ -7,201 +7,203 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0186B7D809C9473D9EC3F424 /* APIAuthWorkspaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0186B7D709C9473D9EC3F424 /* APIAuthWorkspaceView.swift */; };
+		023BC7FBF76D2C19E8B8559D /* DeployerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2FB01E9289515A3AC24A927 /* DeployerViewModel.swift */; };
 		023E9AE450BF036FF40C0E76 /* ProjectConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C794768AF4898995F64DB92D /* ProjectConfiguration.swift */; };
 		02AD314100925D82AE384CE8 /* GeneralSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8974EB4ED392FD3B52D70FD3 /* GeneralSettingsTab.swift */; };
+		04CC8776681CF107919B5B76 /* RigsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95BEB3F1E5A208F98850D372 /* RigsView.swift */; };
 		0597F5E10CC3D748D36710F9 /* ConfigurationObserving.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6676A7C26F7EE42CD5B9E7A /* ConfigurationObserving.swift */; };
 		0B1C053B8DCA686200739C43 /* ServerEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D75CB92C4916A5B3A8DE34 /* ServerEditSheet.swift */; };
-		0BB5245A79F8709EBD8C5269 /* ModuleInstallSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA1C2F245C5FCEF82A5D2D3 /* ModuleInstallSheet.swift */; };
-		0D4D7E7A5AB24A1D85E8A001 /* QualityModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4D7E7A5AB24A1D85E8A101 /* QualityModels.swift */; };
-		0D4D7E7A5AB24A1D85E8A002 /* QualityViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4D7E7A5AB24A1D85E8A102 /* QualityViewModel.swift */; };
-		0D4D7E7A5AB24A1D85E8A003 /* QualityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4D7E7A5AB24A1D85E8A103 /* QualityView.swift */; };
-		0FE6351E7C94950D6A459978 /* DeployerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F978C6E7F1C5288FF7303DF7 /* DeployerView.swift */; };
-		1162E40A1D0549D9B68608A8 /* BenchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1162E4091D0549D9B68608A8 /* BenchView.swift */; };
-		102A2F3B4C5D6E7F8091A2B3 /* RigsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3B4C5D6E7F8091A2B3102A /* RigsView.swift */; };
-		1A2B3102F3B4C5D6E7F8091A /* RigsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4C5D6E7F8091A2B3102A2F /* RigsViewModel.swift */; };
+		0D616728E30CB0C012851F18 /* GitOperationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3320B46DC4876237EA4C9ACE /* GitOperationsViewModel.swift */; };
+		180E9CC06D913B4F8B55A58A /* RemoteLogViewerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3683B37062C645B848E014 /* RemoteLogViewerViewModel.swift */; };
+		19F0A3B40B6B6BA59A201C7F /* HomeboyCLI+RunCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFAF5103FCB24063514E519F /* HomeboyCLI+RunCommands.swift */; };
 		1A164D8DD4607926F6964B95 /* CopyableContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5BD1368E35CA013C4E064C8 /* CopyableContent.swift */; };
+		1A9C5FC30453DD2AFD03062D /* BenchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941D61AD6DA0DA2420DB13B8 /* BenchView.swift */; };
+		1AEFFA5D377D403DDA560237 /* RemoteFileEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70AE598B819DE3CDD73692D4 /* RemoteFileEditorView.swift */; };
 		1D8C5CFC6CC66D4D2059241A /* CLIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0B9A725382C46F30D83C02 /* CLIError.swift */; };
-		1E0233CF5AC026C74233786E /* TableDataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EC7ED01925DBCB9195A8A4D /* TableDataView.swift */; };
-		1EBFEF675F781A40A250D009 /* BackupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2026B5BAE550AC7BD82744DA /* BackupService.swift */; };
 		22221233AC86561D48490886 /* RemoteFileBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C2AF5C1F794564BF7DC0F4 /* RemoteFileBrowserView.swift */; };
 		278021F9D228BBDA95267231 /* HomeboyCLI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D870E69E9C29278BC862CD04 /* HomeboyCLI.swift */; };
-		278021F9D228BBDA95267232 /* HomeboyCLI+FileDatabaseCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D870E69E9C29278BC862CD05 /* HomeboyCLI+FileDatabaseCommands.swift */; };
-		278021F9D228BBDA95267233 /* HomeboyCLI+QualityCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D870E69E9C29278BC862CD06 /* HomeboyCLI+QualityCommands.swift */; };
-		278021F9D228BBDA95267234 /* HomeboyCLI+RigBenchReleaseCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D870E69E9C29278BC862CD07 /* HomeboyCLI+RigBenchReleaseCommands.swift */; };
-		278021F9D228BBDA95267238 /* HomeboyCLI+RunCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D870E69E9C29278BC862CD0B /* HomeboyCLI+RunCommands.swift */; };
-		278021F9D228BBDA95267235 /* HomeboyCLI+StackCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D870E69E9C29278BC862CD08 /* HomeboyCLI+StackCommands.swift */; };
-		278021F9D228BBDA95267236 /* HomeboyCLI+WorkspaceCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D870E69E9C29278BC862CD09 /* HomeboyCLI+WorkspaceCommands.swift */; };
-		278021F9D228BBDA95267237 /* HomeboyCLIModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = D870E69E9C29278BC862CD0A /* HomeboyCLIModels.swift */; };
-		2846F25C9D6A4E7BB401AA01 /* GitOperationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3C5E2D1F7B4C9A9002DD11 /* GitOperationsView.swift */; };
 		27D41F217F00E3A8171BEC63 /* AppWarning.swift in Sources */ = {isa = PBXBuildFile; fileRef = C489D03946456721B73D70EA /* AppWarning.swift */; };
-		27FA9FFDA56F6C7BCAFE0296 /* ModulesSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C398F35F8687FF75D86A408 /* ModulesSettingsTab.swift */; };
 		29AC5918A42B81DE1D250360 /* ContentContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC77F3DE919D687C5088735B /* ContentContext.swift */; };
 		2A0D8EC80F531D2458B4F000 /* DatabaseSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99F53066BAD2365203BC1A21 /* DatabaseSettingsTab.swift */; };
 		2BDBF9B46483155A6701C845 /* ConfigurationChangeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4847DDB6175D9E32C423C8C /* ConfigurationChangeType.swift */; };
+		2FA2E2EB6635082599CF1172 /* RigsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35595CC7BEFD826A8FE56039 /* RigsViewModel.swift */; };
+		306DE99757A1BBA6E328A8FF /* HomeboyCLI+WorkspaceCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = A087DAB3F4E912476EC93E01 /* HomeboyCLI+WorkspaceCommands.swift */; };
 		30856C36D38963CB5A540EFC /* WarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20129FFBFEEBA4948B8DA194 /* WarningView.swift */; };
 		3188A425BBDAED4249534CE8 /* WordPressSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9172819247F48893F5F20EA2 /* WordPressSettingsTab.swift */; };
 		337BB8150B603A86CAECBE7F /* CopyButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4784FCC0B29C23649013882 /* CopyButton.swift */; };
-		34B6D8FD95927DA85561881D /* ModuleSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 432441A63F12FD70294090A6 /* ModuleSetupView.swift */; };
-		36948AE7BAD67E09B8873D53 /* ModuleActionsBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572D0318B7820B97ABDBC10A /* ModuleActionsBar.swift */; };
+		339E905F86E47CF88C0386B8 /* RemoteLogViewerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71037D397037D1741B78222 /* RemoteLogViewerView.swift */; };
+		34FF9AD0FE0BE2ADE1F07752 /* SiteListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21391AE5E442FFA2A2843821 /* SiteListView.swift */; };
+		36E2AEA91D720BC0FCE5D660 /* DeployerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E103FB783F1B8F1CF84750F4 /* DeployerView.swift */; };
 		38D566E59E85DF4E4D14C48F /* RemoteFileBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E7289F91C0EA517A3DE5DB9 /* RemoteFileBrowser.swift */; };
 		3CBF41346F060E438864152C /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59036A328B5EEE5B0D5DF9C /* AppError.swift */; };
 		3D5278E44CF446DC733DFDF7 /* ConsoleOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FDE17265BB36CD42258798 /* ConsoleOutput.swift */; };
-		3D9711220108F7258431211E /* ModuleInputsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E42F070FBBA9AFFEE6E6F44 /* ModuleInputsView.swift */; };
+		445A81283F88E81B8C1F0710 /* BackupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A9C1C6E1C766FEF2D21DE5 /* BackupService.swift */; };
+		46238C2E19607D4410D23FA2 /* HomeboyCLI+RigBenchReleaseCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DD2E86E7655D2ED45CB0E31 /* HomeboyCLI+RigBenchReleaseCommands.swift */; };
 		465D0E037B7E2705A578EAF2 /* RemotePathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0EEE1B29B6CBCC9B7AE92D /* RemotePathResolver.swift */; };
-		469CB781A5654E2EA41A3B30 /* RemoteFileEditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1682E9BF7F10ED915C606359 /* RemoteFileEditorViewModel.swift */; };
+		5312A3BDB64264012E062616 /* ExtensionInputsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACB611363480EC1ED86A127 /* ExtensionInputsView.swift */; };
 		53E684EC9B358CC6CF15C7C2 /* DatabaseTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14349D465EC79FD6D1D8C70C /* DatabaseTypes.swift */; };
 		57C3AE0D20A591DEE69B0FF0 /* HomeboyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFEA6E42C1D9292B10447CDA /* HomeboyApp.swift */; };
+		585F2338D58023625EBBA0B5 /* ExtensionsSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64DFC1DFC648B2D106BA5361 /* ExtensionsSettingsTab.swift */; };
 		58782E3C2B83E467318758D3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E134C3E1AFDFB8B9C3BFA989 /* Assets.xcassets */; };
 		58C9903BC07607162259D792 /* SSHKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9B567AD7EF6AEAFF4650E3 /* SSHKeyManager.swift */; };
-		58D7EB6E82E865D5736663C0 /* DeployerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C206F8FCC7B57F9E68E99A08 /* DeployerViewModel.swift */; };
-		5A7D2C4E91B8406DA0E3FB22 /* GitOperationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C1D9F4B2A6E438FA112CC33 /* GitOperationsViewModel.swift */; };
+		59B9942920AA8A82C6687BA1 /* ExtensionActionsBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84CD4544E216646E96957DA /* ExtensionActionsBar.swift */; };
+		5A7E75D51012C3ED36EA7853 /* CLIExtensionTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E32E869268148C1260D05F85 /* CLIExtensionTypes.swift */; };
 		5A9B1A9B7984F57035A97D82 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D06A62D2DDC840DC6A12CC7 /* KeychainService.swift */; };
-		5AAC8C88082027144361696A /* ModuleManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267B4789567169ABFC9AAD53 /* ModuleManifest.swift */; };
 		5B3425AA6A8A9C4C9EF5E29F /* FileBrowserSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD70F8136E9691D7528CB581 /* FileBrowserSidebarView.swift */; };
 		5BD322602F64CCA4E7A54FEF /* ConfigurationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BAE7C655CF0B3F2D679B188 /* ConfigurationManager.swift */; };
 		5BDE52F8E2A18B1F50AD060A /* JSONValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6E41FFC96012F3C390C094 /* JSONValue.swift */; };
 		5C04267FDCF7C82C4BE9B087 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7A27F9F448DAC4DF35613F9 /* APIClient.swift */; };
 		5CA76C92A6AF0C42784FD35D /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAEBF8AA9E2BEC2A55EF0D /* ErrorView.swift */; };
+		5CEF2659D6426FC7150A96C7 /* QualityModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F58D23C61F57585387766D /* QualityModels.swift */; };
+		6058DC822E13A3B7C56C64BF /* ExtensionSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B16E4FF8E5939CE6EF12EFA2 /* ExtensionSetupView.swift */; };
 		61876E7ACDA5C3D7A5D2E40F /* AppPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C840B787B398287BC5EEE6 /* AppPaths.swift */; };
-		6DA58994C9A0D94854E44A62 /* RemoteLogViewerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6E91E37345CFC1CFCF9AA6 /* RemoteLogViewerView.swift */; };
+		6861D39F7EB9C8E226731A6A /* HomeboyCLI+StackCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7F7ED4B0D0B46D19BF8438 /* HomeboyCLI+StackCommands.swift */; };
+		6D35EC810ADF631740FCC1B4 /* DatabaseBrowserViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0202298D08128098B45807E /* DatabaseBrowserViewModel.swift */; };
 		71419F89166E98CC7C4A3A98 /* SSHService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD23DCF3987518BDD613AA7A /* SSHService.swift */; };
 		72D058E4C987B44B3C2FE75F /* RemoteFileEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BBA2DD3A1B1041ACA3A049F /* RemoteFileEntry.swift */; };
+		7399D30F167F523492E0F251 /* FleetManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F708A9D50196DF375A7477A0 /* FleetManagementView.swift */; };
 		761826050ADDBB5E4B00E1AC /* CLIVersionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 811079398986364AA0E0542A /* CLIVersionChecker.swift */; };
 		76A91937D9017A5B0D9B0BA5 /* PinnableTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66B3D28A100F2CAE93D7DE64 /* PinnableTabBar.swift */; };
 		790A549F1DA4887FA2EF100F /* ServersSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF87669DD8D8EEF387C64926 /* ServersSettingsTab.swift */; };
-		7CFF60E56F49FFC68A830664 /* SiteListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7BEDC81C87152DCED825A3 /* SiteListView.swift */; };
+		79F089B7341476178AB41022 /* RemoteFileEditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42681ABDD9AC38676CDB315E /* RemoteFileEditorViewModel.swift */; };
+		7B4A55712A56BDD9EE21F504 /* HomeboyCLI+FileDatabaseCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B800E302E25370AFEB2EAA7 /* HomeboyCLI+FileDatabaseCommands.swift */; };
 		7EE844A0691D39F31A685114 /* ProjectSwitcherView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA62EB2C6FD0532AE4CCD204 /* ProjectSwitcherView.swift */; };
 		807E4729F90F95A12FAB99B7 /* CollapsibleSplitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED098FFBF749CD6DD355B1B /* CollapsibleSplitView.swift */; };
-		80D12DD221BE19316CB0BDCA /* RemoteLogViewerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E867876A7DCD50A851E6F8D7 /* RemoteLogViewerViewModel.swift */; };
 		8327EB6B86BD82A5A8F0E466 /* ServerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBD189DF7919CB05353FDC9 /* ServerConfig.swift */; };
 		8416680F81D345B2751765CC /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A80F92FC849ACD9591EDEFE /* LoginView.swift */; };
 		85A8C46096DE6DFF3BD11E63 /* FindableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385944CD36C9E1B61CE23EDE /* FindableTextView.swift */; };
 		85F4F94606B3D49BEFDC227F /* DeploymentService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFAD6C5159792F08A987DC9 /* DeploymentService.swift */; };
 		86C712A03FB9FC626DC46371 /* ArtifactVersionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60913533AA72054F3D79625C /* ArtifactVersionParser.swift */; };
-		8ACB39F91168D33D93F5B338 /* ModuleResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0354F3771ED337E0EDCAC7B5 /* ModuleResultsView.swift */; };
 		8B8811A6AB7570F644C36FC5 /* VersionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13F8D60E3516F29F554438A0 /* VersionParser.swift */; };
-		8C6CA13F14113243F0E6CDC4 /* ModuleContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69348F2856AF692571BB880E /* ModuleContainerView.swift */; };
-		8CC212749235B62EEE109984 /* DatabaseBrowserViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EDC4F278327A663263D4A7 /* DatabaseBrowserViewModel.swift */; };
 		8D62AD324E3C99747FA53FCB /* ComponentsSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830D15DCC64EB9AF17F822E0 /* ComponentsSettingsTab.swift */; };
-		8DD50D5975E4E471BDE8DB3B /* DatabaseBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAA8DDE50178FCA20E0FD11 /* DatabaseBrowserView.swift */; };
+		9057B57BD09E3D8A025D305D /* ExtensionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12EA4D980446363E3B0B3D1 /* ExtensionManager.swift */; };
+		93B2772BA952451AE39491B3 /* ExtensionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACBBAD050F5C69E93FA60880 /* ExtensionViewModel.swift */; };
+		969EDDA4900E1F2620099F30 /* WordPressSSHExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A3033E40F9E3B41E1E41BB /* WordPressSSHExtension.swift */; };
 		999116DB4DB5B3DF3EA9C171 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3C30739F765981B37603DD /* SidebarView.swift */; };
-		9ACBEB5DF2D256960184C815 /* QueryEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF490ADD191341069884F61B /* QueryEditorView.swift */; };
 		9CD0D78AD51869E4BCA3363C /* ComponentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E609811240E56A3A71CA778 /* ComponentConfiguration.swift */; };
+		9E83D8F4A47320D0DC38B248 /* ExtensionInstallSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCE83D5EB31A4A89A0764753 /* ExtensionInstallSheet.swift */; };
+		9EB8E162236E90FFB9585AC9 /* QualityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B709FB776FF5A95CAE18A7D2 /* QualityView.swift */; };
 		A051F697BD41C8D9A5298333 /* DataTableColumn.swift in Sources */ = {isa = PBXBuildFile; fileRef = C503C8896286EA38288A139F /* DataTableColumn.swift */; };
+		A182CEC738D74B3D10F1BA6B /* QueryEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91594B5A5CCE7AE78D16BD3 /* QueryEditorView.swift */; };
+		A28E717B2C7B1A41C6CF37F1 /* DatabaseBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B07DC101287321035F10830F /* DatabaseBrowserView.swift */; };
 		A34392C1F77DDF4B0B386D8C /* DataTableConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = F915FEEAF97ADD6EAADF6E4A /* DataTableConstants.swift */; };
+		A40B645FCF64C59E6F1EC4FC /* HomeboyCLI+QualityCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC23AFFAB50FD8AFD042E644 /* HomeboyCLI+QualityCommands.swift */; };
 		A79AD1D6F7DD14F02410D120 /* LogTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670327C19CE0F089CFF35DD1 /* LogTextView.swift */; };
-		AACC7F3153886939005FC50C /* WordPressSSHModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEFBC62BD4867D4AE7E8D6E /* WordPressSSHModule.swift */; };
 		AB378FCB8518F6BED6EEFB6F /* DisplayableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C195A8A1462489E882BC187 /* DisplayableError.swift */; };
-		AC4B413EC80B0BD0F7AABB1D /* ModuleConsoleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F014356904A59206993DA47 /* ModuleConsoleView.swift */; };
+		B1BC5D62A38657148E674B80 /* ExtensionConsoleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC2128B1137A2702EEC2F55 /* ExtensionConsoleView.swift */; };
+		B23886AC41FD2A725383EF45 /* ExtensionManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA9BAC48CD6CC681F9FD2C5 /* ExtensionManifest.swift */; };
 		B27446E0A3706D997A75D1E9 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A690A4DC66BE109010668691 /* ContentView.swift */; };
 		B9C42108AC64D21BAEEE580A /* DeployableComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A705E0F3D07B94FCE1724761 /* DeployableComponent.swift */; };
-		BBA251CB27591D879DAD4038 /* RemoteFileEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B19BDE6DDAAF5D914C29785 /* RemoteFileEditorView.swift */; };
+		BA03F27144E7C71BE3BC30E4 /* APIAuthWorkspaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807865404822DFF3A4755240 /* APIAuthWorkspaceView.swift */; };
 		C24FBE4BE4FE4BA046D565C3 /* RemotePathResolver+WordPress.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFBA996DE0C810FC22480A51 /* RemotePathResolver+WordPress.swift */; };
 		C6F738277B8D48B8F03655CA /* bandcamp_scraper.cpython-314.pyc in Resources */ = {isa = PBXBuildFile; fileRef = 75262FFB3BBC6BC33A8AC4F3 /* bandcamp_scraper.cpython-314.pyc */; };
 		C727FE57ACE75A3152D4C972 /* NativeDataTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2800F57FE83EEBB76CC1F1A /* NativeDataTable.swift */; };
-		C7897C8689B4E0075B1CB0D6 /* ModuleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BD4D2024772E1CFC5F01C2 /* ModuleViewModel.swift */; };
 		CC79CDB6AF19F24E74A11202 /* CodeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88D343E94C4C34E1069813 /* CodeTextView.swift */; };
+		CC892914AFEB03C734959003 /* HomeboyCLIModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D33E39732C375690D3AC46 /* HomeboyCLIModels.swift */; };
+		CFD2A46F7153AF3F5A5F7BED /* ExtensionResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01633F1529CE4E27B3570E07 /* ExtensionResultsView.swift */; };
 		D067D1266FD0989BC9E07C43 /* CLIBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40736E67E0624C5F3AA5913C /* CLIBridge.swift */; };
 		D17F7A98F3FB9E8F40991024 /* LogContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514BD1BE8868C181AD9401CF /* LogContentView.swift */; };
+		D231806A492F0FDF219633DD /* TableDataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EA4198F67B489E4433A378 /* TableDataView.swift */; };
 		D3D2FEA38CB8A09E0ED93B73 /* APITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6FE3DEAD139D529B6724D8 /* APITypes.swift */; };
+		D94CC978855E31469979CD82 /* ExtensionContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F453DD64A8E42E312D5338B1 /* ExtensionContainerView.swift */; };
 		E1F7C14F08E1E4D8353F8064 /* CopyableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4406A9EEECAF8249580937A7 /* CopyableTextView.swift */; };
+		E450CA4C790C609575070F05 /* ConfigGapsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EC8F9095C4AC67383B9F4A /* ConfigGapsView.swift */; };
 		E6130C3BA0E6F318EAB670A3 /* ConfigurationObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FF4CDA2AE7652A449E74D8 /* ConfigurationObserver.swift */; };
 		E6403DF4F6747B97ED009C1A /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD2C75C18D0464C6428E5EE /* AppConfiguration.swift */; };
 		E832787BA1F926FB3A085E09 /* InlineErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 943FB329E82EA8D3985C41BE /* InlineErrorView.swift */; };
 		E8A0E0A1E7364CFEB6EB48AF /* SchemaResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C26B6355BFA87F894B3BFBB /* SchemaResolver.swift */; };
-		E9D7338A6D0F128987F91E83 /* CLIModuleTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1815EE5F0948B590DB303B60 /* CLIModuleTypes.swift */; };
+		EC7E0C50096E39206C199118 /* QualityViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BBAE3837D9DF6634A72AAB1 /* QualityViewModel.swift */; };
 		EEA581470DC8B48027F54228 /* InlineWarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DC18F8D8A50F464D296BB74 /* InlineWarningView.swift */; };
-		EFAD229C7AEECA77273843D0 /* ModuleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16DF708DA86DFB9E5B27FBC /* ModuleManager.swift */; };
 		F34BB35C6C33E774792043ED /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B2C9499D9E9A17D32109EF /* SettingsView.swift */; };
 		FB914712293D43F2D7D80F80 /* CreateProjectSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91949A849E1F8F3490BBEC6A /* CreateProjectSheet.swift */; };
+		FDC7A36317A54E1EE4486D4A /* GitOperationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC13102738FFBE2F5695F78 /* GitOperationsView.swift */; };
 		FE865BA85263630F8BF6A608 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2507DAC42BC6CDA2DF39CE /* AuthManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		0186B7D709C9473D9EC3F424 /* APIAuthWorkspaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIAuthWorkspaceView.swift; sourceTree = "<group>"; };
-		0354F3771ED337E0EDCAC7B5 /* ModuleResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleResultsView.swift; sourceTree = "<group>"; };
+		01633F1529CE4E27B3570E07 /* ExtensionResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionResultsView.swift; sourceTree = "<group>"; };
 		0BBA2DD3A1B1041ACA3A049F /* RemoteFileEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileEntry.swift; sourceTree = "<group>"; };
 		0CD2C75C18D0464C6428E5EE /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
-		0D4D7E7A5AB24A1D85E8A101 /* QualityModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QualityModels.swift; sourceTree = "<group>"; };
-		0D4D7E7A5AB24A1D85E8A102 /* QualityViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QualityViewModel.swift; sourceTree = "<group>"; };
-		0D4D7E7A5AB24A1D85E8A103 /* QualityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QualityView.swift; sourceTree = "<group>"; };
 		0DC18F8D8A50F464D296BB74 /* InlineWarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineWarningView.swift; sourceTree = "<group>"; };
-		1162E4091D0549D9B68608A8 /* BenchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchView.swift; sourceTree = "<group>"; };
+		0DD2E86E7655D2ED45CB0E31 /* HomeboyCLI+RigBenchReleaseCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+RigBenchReleaseCommands.swift"; sourceTree = "<group>"; };
 		13F8D60E3516F29F554438A0 /* VersionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionParser.swift; sourceTree = "<group>"; };
 		14349D465EC79FD6D1D8C70C /* DatabaseTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseTypes.swift; sourceTree = "<group>"; };
-		1682E9BF7F10ED915C606359 /* RemoteFileEditorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileEditorViewModel.swift; sourceTree = "<group>"; };
-		1815EE5F0948B590DB303B60 /* CLIModuleTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIModuleTypes.swift; sourceTree = "<group>"; };
 		20129FFBFEEBA4948B8DA194 /* WarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarningView.swift; sourceTree = "<group>"; };
-		2026B5BAE550AC7BD82744DA /* BackupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupService.swift; sourceTree = "<group>"; };
-		21BD4D2024772E1CFC5F01C2 /* ModuleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleViewModel.swift; sourceTree = "<group>"; };
-		267B4789567169ABFC9AAD53 /* ModuleManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleManifest.swift; sourceTree = "<group>"; };
-		29EDC4F278327A663263D4A7 /* DatabaseBrowserViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseBrowserViewModel.swift; sourceTree = "<group>"; };
-		2F3B4C5D6E7F8091A2B3102A /* RigsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RigsView.swift; sourceTree = "<group>"; };
-		2DA1C2F245C5FCEF82A5D2D3 /* ModuleInstallSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleInstallSheet.swift; sourceTree = "<group>"; };
+		21391AE5E442FFA2A2843821 /* SiteListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteListView.swift; sourceTree = "<group>"; };
 		2E7289F91C0EA517A3DE5DB9 /* RemoteFileBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileBrowser.swift; sourceTree = "<group>"; };
-		2EC7ED01925DBCB9195A8A4D /* TableDataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableDataView.swift; sourceTree = "<group>"; };
-		3B4C5D6E7F8091A2B3102A2F /* RigsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RigsViewModel.swift; sourceTree = "<group>"; };
+		2FC13102738FFBE2F5695F78 /* GitOperationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitOperationsView.swift; sourceTree = "<group>"; };
+		3320B46DC4876237EA4C9ACE /* GitOperationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitOperationsViewModel.swift; sourceTree = "<group>"; };
+		33EA4198F67B489E4433A378 /* TableDataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableDataView.swift; sourceTree = "<group>"; };
+		35595CC7BEFD826A8FE56039 /* RigsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RigsViewModel.swift; sourceTree = "<group>"; };
 		385944CD36C9E1B61CE23EDE /* FindableTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindableTextView.swift; sourceTree = "<group>"; };
 		3A6FE3DEAD139D529B6724D8 /* APITypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITypes.swift; sourceTree = "<group>"; };
 		3A80F92FC849ACD9591EDEFE /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		3AC2128B1137A2702EEC2F55 /* ExtensionConsoleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionConsoleView.swift; sourceTree = "<group>"; };
+		3ACB611363480EC1ED86A127 /* ExtensionInputsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionInputsView.swift; sourceTree = "<group>"; };
 		3C26B6355BFA87F894B3BFBB /* SchemaResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaResolver.swift; sourceTree = "<group>"; };
 		3CBD189DF7919CB05353FDC9 /* ServerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerConfig.swift; sourceTree = "<group>"; };
 		3D06A62D2DDC840DC6A12CC7 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
-		3E42F070FBBA9AFFEE6E6F44 /* ModuleInputsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleInputsView.swift; sourceTree = "<group>"; };
 		3E609811240E56A3A71CA778 /* ComponentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentConfiguration.swift; sourceTree = "<group>"; };
 		40736E67E0624C5F3AA5913C /* CLIBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIBridge.swift; sourceTree = "<group>"; };
-		432441A63F12FD70294090A6 /* ModuleSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleSetupView.swift; sourceTree = "<group>"; };
+		42681ABDD9AC38676CDB315E /* RemoteFileEditorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileEditorViewModel.swift; sourceTree = "<group>"; };
 		4406A9EEECAF8249580937A7 /* CopyableTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyableTextView.swift; sourceTree = "<group>"; };
+		4B800E302E25370AFEB2EAA7 /* HomeboyCLI+FileDatabaseCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+FileDatabaseCommands.swift"; sourceTree = "<group>"; };
 		4C0B9A725382C46F30D83C02 /* CLIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIError.swift; sourceTree = "<group>"; };
 		4C3C30739F765981B37603DD /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		4ED098FFBF749CD6DD355B1B /* CollapsibleSplitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleSplitView.swift; sourceTree = "<group>"; };
 		514BD1BE8868C181AD9401CF /* LogContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogContentView.swift; sourceTree = "<group>"; };
-		572D0318B7820B97ABDBC10A /* ModuleActionsBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleActionsBar.swift; sourceTree = "<group>"; };
-		5A6E91E37345CFC1CFCF9AA6 /* RemoteLogViewerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteLogViewerView.swift; sourceTree = "<group>"; };
-		5B19BDE6DDAAF5D914C29785 /* RemoteFileEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileEditorView.swift; sourceTree = "<group>"; };
-		5BEFBC62BD4867D4AE7E8D6E /* WordPressSSHModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSSHModule.swift; sourceTree = "<group>"; };
-		5F014356904A59206993DA47 /* ModuleConsoleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleConsoleView.swift; sourceTree = "<group>"; };
+		5BA9BAC48CD6CC681F9FD2C5 /* ExtensionManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionManifest.swift; sourceTree = "<group>"; };
 		60913533AA72054F3D79625C /* ArtifactVersionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactVersionParser.swift; sourceTree = "<group>"; };
+		61EC8F9095C4AC67383B9F4A /* ConfigGapsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigGapsView.swift; sourceTree = "<group>"; };
+		64DFC1DFC648B2D106BA5361 /* ExtensionsSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsSettingsTab.swift; sourceTree = "<group>"; };
 		66B3D28A100F2CAE93D7DE64 /* PinnableTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnableTabBar.swift; sourceTree = "<group>"; };
 		670327C19CE0F089CFF35DD1 /* LogTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogTextView.swift; sourceTree = "<group>"; };
-		69348F2856AF692571BB880E /* ModuleContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleContainerView.swift; sourceTree = "<group>"; };
+		6BBAE3837D9DF6634A72AAB1 /* QualityViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QualityViewModel.swift; sourceTree = "<group>"; };
 		6C195A8A1462489E882BC187 /* DisplayableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayableError.swift; sourceTree = "<group>"; };
+		70AE598B819DE3CDD73692D4 /* RemoteFileEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileEditorView.swift; sourceTree = "<group>"; };
 		75262FFB3BBC6BC33A8AC4F3 /* bandcamp_scraper.cpython-314.pyc */ = {isa = PBXFileReference; path = "bandcamp_scraper.cpython-314.pyc"; sourceTree = "<group>"; };
 		7BFAEBF8AA9E2BEC2A55EF0D /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
-		7C1D9F4B2A6E438FA112CC33 /* GitOperationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitOperationsViewModel.swift; sourceTree = "<group>"; };
 		7E6E41FFC96012F3C390C094 /* JSONValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValue.swift; sourceTree = "<group>"; };
+		807865404822DFF3A4755240 /* APIAuthWorkspaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIAuthWorkspaceView.swift; sourceTree = "<group>"; };
 		811079398986364AA0E0542A /* CLIVersionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIVersionChecker.swift; sourceTree = "<group>"; };
 		830D15DCC64EB9AF17F822E0 /* ComponentsSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentsSettingsTab.swift; sourceTree = "<group>"; };
 		833BBA3138BAD0CFB3557D6B /* Homeboy.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Homeboy.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		83B2C9499D9E9A17D32109EF /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		8974EB4ED392FD3B52D70FD3 /* GeneralSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsTab.swift; sourceTree = "<group>"; };
-		8A3C5E2D1F7B4C9A9002DD11 /* GitOperationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitOperationsView.swift; sourceTree = "<group>"; };
-		8F7BEDC81C87152DCED825A3 /* SiteListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteListView.swift; sourceTree = "<group>"; };
+		8B3683B37062C645B848E014 /* RemoteLogViewerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteLogViewerViewModel.swift; sourceTree = "<group>"; };
 		9172819247F48893F5F20EA2 /* WordPressSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSettingsTab.swift; sourceTree = "<group>"; };
 		91949A849E1F8F3490BBEC6A /* CreateProjectSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateProjectSheet.swift; sourceTree = "<group>"; };
+		941D61AD6DA0DA2420DB13B8 /* BenchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchView.swift; sourceTree = "<group>"; };
 		943FB329E82EA8D3985C41BE /* InlineErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineErrorView.swift; sourceTree = "<group>"; };
+		95BEB3F1E5A208F98850D372 /* RigsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RigsView.swift; sourceTree = "<group>"; };
 		99F53066BAD2365203BC1A21 /* DatabaseSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseSettingsTab.swift; sourceTree = "<group>"; };
 		9BAE7C655CF0B3F2D679B188 /* ConfigurationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationManager.swift; sourceTree = "<group>"; };
-		9C398F35F8687FF75D86A408 /* ModulesSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModulesSettingsTab.swift; sourceTree = "<group>"; };
-		9DAA8DDE50178FCA20E0FD11 /* DatabaseBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseBrowserView.swift; sourceTree = "<group>"; };
+		A087DAB3F4E912476EC93E01 /* HomeboyCLI+WorkspaceCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+WorkspaceCommands.swift"; sourceTree = "<group>"; };
 		A1FDE17265BB36CD42258798 /* ConsoleOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleOutput.swift; sourceTree = "<group>"; };
 		A2800F57FE83EEBB76CC1F1A /* NativeDataTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeDataTable.swift; sourceTree = "<group>"; };
 		A5D75CB92C4916A5B3A8DE34 /* ServerEditSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerEditSheet.swift; sourceTree = "<group>"; };
 		A690A4DC66BE109010668691 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		A705E0F3D07B94FCE1724761 /* DeployableComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeployableComponent.swift; sourceTree = "<group>"; };
+		A71037D397037D1741B78222 /* RemoteLogViewerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteLogViewerView.swift; sourceTree = "<group>"; };
 		A7A27F9F448DAC4DF35613F9 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		AB2507DAC42BC6CDA2DF39CE /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
+		ACBBAD050F5C69E93FA60880 /* ExtensionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionViewModel.swift; sourceTree = "<group>"; };
 		AD23DCF3987518BDD613AA7A /* SSHService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHService.swift; sourceTree = "<group>"; };
 		AD70F8136E9691D7528CB581 /* FileBrowserSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileBrowserSidebarView.swift; sourceTree = "<group>"; };
+		B07DC101287321035F10830F /* DatabaseBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseBrowserView.swift; sourceTree = "<group>"; };
+		B16E4FF8E5939CE6EF12EFA2 /* ExtensionSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionSetupView.swift; sourceTree = "<group>"; };
 		B4784FCC0B29C23649013882 /* CopyButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyButton.swift; sourceTree = "<group>"; };
 		B59036A328B5EEE5B0D5DF9C /* AppError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppError.swift; sourceTree = "<group>"; };
 		B6676A7C26F7EE42CD5B9E7A /* ConfigurationObserving.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationObserving.swift; sourceTree = "<group>"; };
+		B6A9C1C6E1C766FEF2D21DE5 /* BackupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupService.swift; sourceTree = "<group>"; };
+		B709FB776FF5A95CAE18A7D2 /* QualityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QualityView.swift; sourceTree = "<group>"; };
+		B91594B5A5CCE7AE78D16BD3 /* QueryEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryEditorView.swift; sourceTree = "<group>"; };
 		BA88D343E94C4C34E1069813 /* CodeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextView.swift; sourceTree = "<group>"; };
 		BB0EEE1B29B6CBCC9B7AE92D /* RemotePathResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotePathResolver.swift; sourceTree = "<group>"; };
+		BC23AFFAB50FD8AFD042E644 /* HomeboyCLI+QualityCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+QualityCommands.swift"; sourceTree = "<group>"; };
 		BE9B567AD7EF6AEAFF4650E3 /* SSHKeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHKeyManager.swift; sourceTree = "<group>"; };
+		BFAF5103FCB24063514E519F /* HomeboyCLI+RunCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+RunCommands.swift"; sourceTree = "<group>"; };
 		BFEA6E42C1D9292B10447CDA /* HomeboyApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeboyApp.swift; sourceTree = "<group>"; };
-		C206F8FCC7B57F9E68E99A08 /* DeployerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeployerViewModel.swift; sourceTree = "<group>"; };
 		C489D03946456721B73D70EA /* AppWarning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppWarning.swift; sourceTree = "<group>"; };
 		C503C8896286EA38288A139F /* DataTableColumn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataTableColumn.swift; sourceTree = "<group>"; };
 		C794768AF4898995F64DB92D /* ProjectConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfiguration.swift; sourceTree = "<group>"; };
@@ -209,51 +211,53 @@
 		CEFAD6C5159792F08A987DC9 /* DeploymentService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeploymentService.swift; sourceTree = "<group>"; };
 		D4847DDB6175D9E32C423C8C /* ConfigurationChangeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationChangeType.swift; sourceTree = "<group>"; };
 		D5BD1368E35CA013C4E064C8 /* CopyableContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyableContent.swift; sourceTree = "<group>"; };
+		D5F58D23C61F57585387766D /* QualityModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QualityModels.swift; sourceTree = "<group>"; };
 		D870E69E9C29278BC862CD04 /* HomeboyCLI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeboyCLI.swift; sourceTree = "<group>"; };
-		D870E69E9C29278BC862CD05 /* HomeboyCLI+FileDatabaseCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+FileDatabaseCommands.swift"; sourceTree = "<group>"; };
-		D870E69E9C29278BC862CD06 /* HomeboyCLI+QualityCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+QualityCommands.swift"; sourceTree = "<group>"; };
-		D870E69E9C29278BC862CD07 /* HomeboyCLI+RigBenchReleaseCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+RigBenchReleaseCommands.swift"; sourceTree = "<group>"; };
-		D870E69E9C29278BC862CD0B /* HomeboyCLI+RunCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+RunCommands.swift"; sourceTree = "<group>"; };
-		D870E69E9C29278BC862CD08 /* HomeboyCLI+StackCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+StackCommands.swift"; sourceTree = "<group>"; };
-		D870E69E9C29278BC862CD09 /* HomeboyCLI+WorkspaceCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+WorkspaceCommands.swift"; sourceTree = "<group>"; };
-		D870E69E9C29278BC862CD0A /* HomeboyCLIModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeboyCLIModels.swift; sourceTree = "<group>"; };
-		DF490ADD191341069884F61B /* QueryEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryEditorView.swift; sourceTree = "<group>"; };
+		D8D33E39732C375690D3AC46 /* HomeboyCLIModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeboyCLIModels.swift; sourceTree = "<group>"; };
+		DA7F7ED4B0D0B46D19BF8438 /* HomeboyCLI+StackCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+StackCommands.swift"; sourceTree = "<group>"; };
 		DF87669DD8D8EEF387C64926 /* ServersSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServersSettingsTab.swift; sourceTree = "<group>"; };
+		E0202298D08128098B45807E /* DatabaseBrowserViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseBrowserViewModel.swift; sourceTree = "<group>"; };
+		E103FB783F1B8F1CF84750F4 /* DeployerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeployerView.swift; sourceTree = "<group>"; };
+		E12EA4D980446363E3B0B3D1 /* ExtensionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionManager.swift; sourceTree = "<group>"; };
 		E134C3E1AFDFB8B9C3BFA989 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E2FF4CDA2AE7652A449E74D8 /* ConfigurationObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationObserver.swift; sourceTree = "<group>"; };
+		E32E869268148C1260D05F85 /* CLIExtensionTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIExtensionTypes.swift; sourceTree = "<group>"; };
 		E7C2AF5C1F794564BF7DC0F4 /* RemoteFileBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileBrowserView.swift; sourceTree = "<group>"; };
-		E867876A7DCD50A851E6F8D7 /* RemoteLogViewerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteLogViewerViewModel.swift; sourceTree = "<group>"; };
+		E8A3033E40F9E3B41E1E41BB /* WordPressSSHExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSSHExtension.swift; sourceTree = "<group>"; };
 		EA62EB2C6FD0532AE4CCD204 /* ProjectSwitcherView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectSwitcherView.swift; sourceTree = "<group>"; };
 		EFBA996DE0C810FC22480A51 /* RemotePathResolver+WordPress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemotePathResolver+WordPress.swift"; sourceTree = "<group>"; };
-		F16DF708DA86DFB9E5B27FBC /* ModuleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleManager.swift; sourceTree = "<group>"; };
+		F2FB01E9289515A3AC24A927 /* DeployerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeployerViewModel.swift; sourceTree = "<group>"; };
 		F3C840B787B398287BC5EEE6 /* AppPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPaths.swift; sourceTree = "<group>"; };
+		F453DD64A8E42E312D5338B1 /* ExtensionContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionContainerView.swift; sourceTree = "<group>"; };
+		F708A9D50196DF375A7477A0 /* FleetManagementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetManagementView.swift; sourceTree = "<group>"; };
+		F84CD4544E216646E96957DA /* ExtensionActionsBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionActionsBar.swift; sourceTree = "<group>"; };
 		F915FEEAF97ADD6EAADF6E4A /* DataTableConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataTableConstants.swift; sourceTree = "<group>"; };
-		F978C6E7F1C5288FF7303DF7 /* DeployerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeployerView.swift; sourceTree = "<group>"; };
+		FCE83D5EB31A4A89A0764753 /* ExtensionInstallSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionInstallSheet.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
-		03381E1786CD41871C8760AF /* Modules */ = {
+		12B88C4078F5290C35028EBB /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				F16DF708DA86DFB9E5B27FBC /* ModuleManager.swift */,
-				267B4789567169ABFC9AAD53 /* ModuleManifest.swift */,
+				E12EA4D980446363E3B0B3D1 /* ExtensionManager.swift */,
+				5BA9BAC48CD6CC681F9FD2C5 /* ExtensionManifest.swift */,
 			);
-			path = Modules;
+			path = Extensions;
 			sourceTree = "<group>";
 		};
-		26C9D5C3477F3537E1BB713A /* Deployer */ = {
+		144F0E432A914DE9F141CEFA /* Rigs */ = {
 			isa = PBXGroup;
 			children = (
-				6E9CEE5EDBA41A6C361A2074 /* Views */,
-				C206F8FCC7B57F9E68E99A08 /* DeployerViewModel.swift */,
+				95BEB3F1E5A208F98850D372 /* RigsView.swift */,
+				35595CC7BEFD826A8FE56039 /* RigsViewModel.swift */,
 			);
-			path = Deployer;
+			path = Rigs;
 			sourceTree = "<group>";
 		};
 		2DE44D1E578B8119641FCA42 /* SSH */ = {
 			isa = PBXGroup;
 			children = (
-				FD3ABA12405D5624F39CB5B6 /* Modules */,
+				437AB78A7C7E8B4AD7DFAB36 /* Extensions */,
 				CEFAD6C5159792F08A987DC9 /* DeploymentService.swift */,
 				2E7289F91C0EA517A3DE5DB9 /* RemoteFileBrowser.swift */,
 				0BBA2DD3A1B1041ACA3A049F /* RemoteFileEntry.swift */,
@@ -265,50 +269,12 @@
 			path = SSH;
 			sourceTree = "<group>";
 		};
-		2E61F67D3432F0D875C83574 /* RemoteFileEditor */ = {
+		437AB78A7C7E8B4AD7DFAB36 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				75EE510DF3652C4C817B44E5 /* Views */,
-				2026B5BAE550AC7BD82744DA /* BackupService.swift */,
-				1682E9BF7F10ED915C606359 /* RemoteFileEditorViewModel.swift */,
+				E8A3033E40F9E3B41E1E41BB /* WordPressSSHExtension.swift */,
 			);
-			path = RemoteFileEditor;
-			sourceTree = "<group>";
-		};
-		426FE25E9CC2781D94562CE8 /* RemoteLogViewer */ = {
-			isa = PBXGroup;
-			children = (
-				A21C74D4FA129A0C385785D2 /* Views */,
-				E867876A7DCD50A851E6F8D7 /* RemoteLogViewerViewModel.swift */,
-			);
-			path = RemoteLogViewer;
-			sourceTree = "<group>";
-		};
-		46F743648D562B5D67158FFF /* DatabaseBrowser */ = {
-			isa = PBXGroup;
-			children = (
-				73DE024E75BCEEAB05E11E1A /* Views */,
-				29EDC4F278327A663263D4A7 /* DatabaseBrowserViewModel.swift */,
-			);
-			path = DatabaseBrowser;
-			sourceTree = "<group>";
-		};
-		47D4D7E7A5AB24A1D85E8A00 /* Quality */ = {
-			isa = PBXGroup;
-			children = (
-				48D4D7E7A5AB24A1D85E8A00 /* Views */,
-				0D4D7E7A5AB24A1D85E8A101 /* QualityModels.swift */,
-				0D4D7E7A5AB24A1D85E8A102 /* QualityViewModel.swift */,
-			);
-			path = Quality;
-			sourceTree = "<group>";
-		};
-		48D4D7E7A5AB24A1D85E8A00 /* Views */ = {
-			isa = PBXGroup;
-			children = (
-				0D4D7E7A5AB24A1D85E8A103 /* QualityView.swift */,
-			);
-			path = Views;
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		48A84FF4933780B2CA668D49 /* Resources */ = {
@@ -317,6 +283,19 @@
 				5160882C4D72CD5AA9A7A214 /* Scripts */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		48CA5756F2D78ADA9FCD0AFD /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				F84CD4544E216646E96957DA /* ExtensionActionsBar.swift */,
+				3AC2128B1137A2702EEC2F55 /* ExtensionConsoleView.swift */,
+				F453DD64A8E42E312D5338B1 /* ExtensionContainerView.swift */,
+				3ACB611363480EC1ED86A127 /* ExtensionInputsView.swift */,
+				01633F1529CE4E27B3570E07 /* ExtensionResultsView.swift */,
+				B16E4FF8E5939CE6EF12EFA2 /* ExtensionSetupView.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		5160882C4D72CD5AA9A7A214 /* Scripts */ = {
@@ -341,8 +320,7 @@
 			children = (
 				9FEB0F1E3E336D290DB4C2DE /* App */,
 				905C0DD32197709B0759C486 /* Core */,
-				6D8B13E4C9A74F91B205EE44 /* GitOperations */,
-				E51666A5CA18CBF6D75EBA87 /* Modules */,
+				C4B4FA7115EB70E0A9AB3293 /* Extensions */,
 				48A84FF4933780B2CA668D49 /* Resources */,
 				7D4D938EF07D7C67EC4BFAEF /* ViewModels */,
 				7CD7DF7C95F543DB47F1055F /* Views */,
@@ -367,32 +345,23 @@
 			);
 			sourceTree = "<group>";
 		};
-		6E9CEE5EDBA41A6C361A2074 /* Views */ = {
+		7154965DA052C9E6BFBF6023 /* RemoteFileEditor */ = {
 			isa = PBXGroup;
 			children = (
-				F978C6E7F1C5288FF7303DF7 /* DeployerView.swift */,
+				D68FA905F9B9100BD1A516EB /* Views */,
+				B6A9C1C6E1C766FEF2D21DE5 /* BackupService.swift */,
+				42681ABDD9AC38676CDB315E /* RemoteFileEditorViewModel.swift */,
 			);
-			path = Views;
+			path = RemoteFileEditor;
 			sourceTree = "<group>";
 		};
-		6D8B13E4C9A74F91B205EE44 /* GitOperations */ = {
+		7277CD6F1C65F994BF298B92 /* GitOperations */ = {
 			isa = PBXGroup;
 			children = (
-				94F1C7A8D3E24B55A609EE66 /* Views */,
-				7C1D9F4B2A6E438FA112CC33 /* GitOperationsViewModel.swift */,
+				D7018249446FF48B95ADAA4B /* Views */,
+				3320B46DC4876237EA4C9ACE /* GitOperationsViewModel.swift */,
 			);
-			path = Extensions/GitOperations;
-			sourceTree = "<group>";
-		};
-		73DE024E75BCEEAB05E11E1A /* Views */ = {
-			isa = PBXGroup;
-			children = (
-				9DAA8DDE50178FCA20E0FD11 /* DatabaseBrowserView.swift */,
-				DF490ADD191341069884F61B /* QueryEditorView.swift */,
-				8F7BEDC81C87152DCED825A3 /* SiteListView.swift */,
-				2EC7ED01925DBCB9195A8A4D /* TableDataView.swift */,
-			);
-			path = Views;
+			path = GitOperations;
 			sourceTree = "<group>";
 		};
 		74EB364D0CFB168C58CAF209 /* API */ = {
@@ -408,26 +377,18 @@
 			isa = PBXGroup;
 			children = (
 				40736E67E0624C5F3AA5913C /* CLIBridge.swift */,
-				1815EE5F0948B590DB303B60 /* CLIModuleTypes.swift */,
+				E32E869268148C1260D05F85 /* CLIExtensionTypes.swift */,
 				811079398986364AA0E0542A /* CLIVersionChecker.swift */,
-				D870E69E9C29278BC862CD05 /* HomeboyCLI+FileDatabaseCommands.swift */,
-				D870E69E9C29278BC862CD06 /* HomeboyCLI+QualityCommands.swift */,
-				D870E69E9C29278BC862CD07 /* HomeboyCLI+RigBenchReleaseCommands.swift */,
-				D870E69E9C29278BC862CD0B /* HomeboyCLI+RunCommands.swift */,
-				D870E69E9C29278BC862CD08 /* HomeboyCLI+StackCommands.swift */,
-				D870E69E9C29278BC862CD09 /* HomeboyCLI+WorkspaceCommands.swift */,
 				D870E69E9C29278BC862CD04 /* HomeboyCLI.swift */,
-				D870E69E9C29278BC862CD0A /* HomeboyCLIModels.swift */,
+				4B800E302E25370AFEB2EAA7 /* HomeboyCLI+FileDatabaseCommands.swift */,
+				BC23AFFAB50FD8AFD042E644 /* HomeboyCLI+QualityCommands.swift */,
+				0DD2E86E7655D2ED45CB0E31 /* HomeboyCLI+RigBenchReleaseCommands.swift */,
+				BFAF5103FCB24063514E519F /* HomeboyCLI+RunCommands.swift */,
+				DA7F7ED4B0D0B46D19BF8438 /* HomeboyCLI+StackCommands.swift */,
+				A087DAB3F4E912476EC93E01 /* HomeboyCLI+WorkspaceCommands.swift */,
+				D8D33E39732C375690D3AC46 /* HomeboyCLIModels.swift */,
 			);
 			path = CLI;
-			sourceTree = "<group>";
-		};
-		75EE510DF3652C4C817B44E5 /* Views */ = {
-			isa = PBXGroup;
-			children = (
-				5B19BDE6DDAAF5D914C29785 /* RemoteFileEditorView.swift */,
-			);
-			path = Views;
 			sourceTree = "<group>";
 		};
 		7AE0A313AE35403617204739 /* Database */ = {
@@ -443,10 +404,10 @@
 			isa = PBXGroup;
 			children = (
 				8007D7D3CCEF3F80C36AA686 /* Components */,
-				E900FE3D44D913C0F5C320A7 /* Modules */,
-				4C5D6E7F8091A2B3102A2F3B /* Rigs */,
+				48CA5756F2D78ADA9FCD0AFD /* Extensions */,
+				144F0E432A914DE9F141CEFA /* Rigs */,
 				F08C0BC0AC87CDDCAA5955CF /* Settings */,
-				1162E4091D0549D9B68608A8 /* BenchView.swift */,
+				941D61AD6DA0DA2420DB13B8 /* BenchView.swift */,
 				3A80F92FC849ACD9591EDEFE /* LoginView.swift */,
 				EA62EB2C6FD0532AE4CCD204 /* ProjectSwitcherView.swift */,
 				E7C2AF5C1F794564BF7DC0F4 /* RemoteFileBrowserView.swift */,
@@ -459,32 +420,36 @@
 		7D4D938EF07D7C67EC4BFAEF /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
-				21BD4D2024772E1CFC5F01C2 /* ModuleViewModel.swift */,
+				ACBBAD050F5C69E93FA60880 /* ExtensionViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
 		};
-		4C5D6E7F8091A2B3102A2F3B /* Rigs */ = {
+		7E3B409500EA8610E421094F /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				2F3B4C5D6E7F8091A2B3102A /* RigsView.swift */,
-				3B4C5D6E7F8091A2B3102A2F /* RigsViewModel.swift */,
+				B07DC101287321035F10830F /* DatabaseBrowserView.swift */,
+				B91594B5A5CCE7AE78D16BD3 /* QueryEditorView.swift */,
+				21391AE5E442FFA2A2843821 /* SiteListView.swift */,
+				33EA4198F67B489E4433A378 /* TableDataView.swift */,
 			);
-			path = Rigs;
+			path = Views;
 			sourceTree = "<group>";
 		};
 		8007D7D3CCEF3F80C36AA686 /* Components */ = {
 			isa = PBXGroup;
 			children = (
 				E458125E00E4AA130D4F530D /* Table */,
-				0186B7D709C9473D9EC3F424 /* APIAuthWorkspaceView.swift */,
+				807865404822DFF3A4755240 /* APIAuthWorkspaceView.swift */,
 				BA88D343E94C4C34E1069813 /* CodeTextView.swift */,
 				4ED098FFBF749CD6DD355B1B /* CollapsibleSplitView.swift */,
+				61EC8F9095C4AC67383B9F4A /* ConfigGapsView.swift */,
 				4406A9EEECAF8249580937A7 /* CopyableTextView.swift */,
 				91949A849E1F8F3490BBEC6A /* CreateProjectSheet.swift */,
 				7BFAEBF8AA9E2BEC2A55EF0D /* ErrorView.swift */,
 				AD70F8136E9691D7528CB581 /* FileBrowserSidebarView.swift */,
 				385944CD36C9E1B61CE23EDE /* FindableTextView.swift */,
+				F708A9D50196DF375A7477A0 /* FleetManagementView.swift */,
 				943FB329E82EA8D3985C41BE /* InlineErrorView.swift */,
 				0DC18F8D8A50F464D296BB74 /* InlineWarningView.swift */,
 				514BD1BE8868C181AD9401CF /* LogContentView.swift */,
@@ -493,6 +458,16 @@
 				20129FFBFEEBA4948B8DA194 /* WarningView.swift */,
 			);
 			path = Components;
+			sourceTree = "<group>";
+		};
+		9035A8A5FC0007090577B120 /* Quality */ = {
+			isa = PBXGroup;
+			children = (
+				F7D0EA84DE389AC831F6A7E1 /* Views */,
+				D5F58D23C61F57585387766D /* QualityModels.swift */,
+				6BBAE3837D9DF6634A72AAB1 /* QualityViewModel.swift */,
+			);
+			path = Quality;
 			sourceTree = "<group>";
 		};
 		905C0DD32197709B0759C486 /* Core */ = {
@@ -504,7 +479,7 @@
 				EA2D7DCF99CD5F93D88CF3E1 /* Config */,
 				951F19759C5A27A308A4C3E9 /* Copyable */,
 				7AE0A313AE35403617204739 /* Database */,
-				03381E1786CD41871C8760AF /* Modules */,
+				12B88C4078F5290C35028EBB /* Extensions */,
 				2DE44D1E578B8119641FCA42 /* SSH */,
 			);
 			path = Core;
@@ -526,14 +501,6 @@
 			path = Copyable;
 			sourceTree = "<group>";
 		};
-		94F1C7A8D3E24B55A609EE66 /* Views */ = {
-			isa = PBXGroup;
-			children = (
-				8A3C5E2D1F7B4C9A9002DD11 /* GitOperationsView.swift */,
-			);
-			path = Views;
-			sourceTree = "<group>";
-		};
 		9FEB0F1E3E336D290DB4C2DE /* App */ = {
 			isa = PBXGroup;
 			children = (
@@ -543,10 +510,40 @@
 			path = App;
 			sourceTree = "<group>";
 		};
-		A21C74D4FA129A0C385785D2 /* Views */ = {
+		C4B4FA7115EB70E0A9AB3293 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				5A6E91E37345CFC1CFCF9AA6 /* RemoteLogViewerView.swift */,
+				ECD0E08804BC41614889412E /* DatabaseBrowser */,
+				EEF0E6E7C84FB1EAC125ED89 /* Deployer */,
+				7277CD6F1C65F994BF298B92 /* GitOperations */,
+				9035A8A5FC0007090577B120 /* Quality */,
+				7154965DA052C9E6BFBF6023 /* RemoteFileEditor */,
+				CF2865A95CDA271871B684F9 /* RemoteLogViewer */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		CF2865A95CDA271871B684F9 /* RemoteLogViewer */ = {
+			isa = PBXGroup;
+			children = (
+				DC7C8E9B8A6F7923262CD0EE /* Views */,
+				8B3683B37062C645B848E014 /* RemoteLogViewerViewModel.swift */,
+			);
+			path = RemoteLogViewer;
+			sourceTree = "<group>";
+		};
+		D68FA905F9B9100BD1A516EB /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				70AE598B819DE3CDD73692D4 /* RemoteFileEditorView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		D7018249446FF48B95ADAA4B /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				2FC13102738FFBE2F5695F78 /* GitOperationsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -559,6 +556,22 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		DC7C8E9B8A6F7923262CD0EE /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				A71037D397037D1741B78222 /* RemoteLogViewerView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		E44E8D50BC9A4739543F484C /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				E103FB783F1B8F1CF84750F4 /* DeployerView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		E458125E00E4AA130D4F530D /* Table */ = {
 			isa = PBXGroup;
 			children = (
@@ -567,31 +580,6 @@
 				A2800F57FE83EEBB76CC1F1A /* NativeDataTable.swift */,
 			);
 			path = Table;
-			sourceTree = "<group>";
-		};
-		E51666A5CA18CBF6D75EBA87 /* Modules */ = {
-			isa = PBXGroup;
-			children = (
-				46F743648D562B5D67158FFF /* DatabaseBrowser */,
-				26C9D5C3477F3537E1BB713A /* Deployer */,
-				47D4D7E7A5AB24A1D85E8A00 /* Quality */,
-				2E61F67D3432F0D875C83574 /* RemoteFileEditor */,
-				426FE25E9CC2781D94562CE8 /* RemoteLogViewer */,
-			);
-			path = Extensions;
-			sourceTree = "<group>";
-		};
-		E900FE3D44D913C0F5C320A7 /* Modules */ = {
-			isa = PBXGroup;
-			children = (
-				572D0318B7820B97ABDBC10A /* ModuleActionsBar.swift */,
-				5F014356904A59206993DA47 /* ModuleConsoleView.swift */,
-				69348F2856AF692571BB880E /* ModuleContainerView.swift */,
-				3E42F070FBBA9AFFEE6E6F44 /* ModuleInputsView.swift */,
-				0354F3771ED337E0EDCAC7B5 /* ModuleResultsView.swift */,
-				432441A63F12FD70294090A6 /* ModuleSetupView.swift */,
-			);
-			path = Modules;
 			sourceTree = "<group>";
 		};
 		EA2D7DCF99CD5F93D88CF3E1 /* Config */ = {
@@ -613,14 +601,32 @@
 			path = Config;
 			sourceTree = "<group>";
 		};
+		ECD0E08804BC41614889412E /* DatabaseBrowser */ = {
+			isa = PBXGroup;
+			children = (
+				7E3B409500EA8610E421094F /* Views */,
+				E0202298D08128098B45807E /* DatabaseBrowserViewModel.swift */,
+			);
+			path = DatabaseBrowser;
+			sourceTree = "<group>";
+		};
+		EEF0E6E7C84FB1EAC125ED89 /* Deployer */ = {
+			isa = PBXGroup;
+			children = (
+				E44E8D50BC9A4739543F484C /* Views */,
+				F2FB01E9289515A3AC24A927 /* DeployerViewModel.swift */,
+			);
+			path = Deployer;
+			sourceTree = "<group>";
+		};
 		F08C0BC0AC87CDDCAA5955CF /* Settings */ = {
 			isa = PBXGroup;
 			children = (
 				830D15DCC64EB9AF17F822E0 /* ComponentsSettingsTab.swift */,
 				99F53066BAD2365203BC1A21 /* DatabaseSettingsTab.swift */,
+				FCE83D5EB31A4A89A0764753 /* ExtensionInstallSheet.swift */,
+				64DFC1DFC648B2D106BA5361 /* ExtensionsSettingsTab.swift */,
 				8974EB4ED392FD3B52D70FD3 /* GeneralSettingsTab.swift */,
-				2DA1C2F245C5FCEF82A5D2D3 /* ModuleInstallSheet.swift */,
-				9C398F35F8687FF75D86A408 /* ModulesSettingsTab.swift */,
 				A5D75CB92C4916A5B3A8DE34 /* ServerEditSheet.swift */,
 				DF87669DD8D8EEF387C64926 /* ServersSettingsTab.swift */,
 				9172819247F48893F5F20EA2 /* WordPressSettingsTab.swift */,
@@ -628,12 +634,12 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
-		FD3ABA12405D5624F39CB5B6 /* Modules */ = {
+		F7D0EA84DE389AC831F6A7E1 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				5BEFBC62BD4867D4AE7E8D6E /* WordPressSSHModule.swift */,
+				B709FB776FF5A95CAE18A7D2 /* QualityView.swift */,
 			);
-			path = Modules;
+			path = Views;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -672,7 +678,6 @@
 				};
 			};
 			buildConfigurationList = F38A3A8832E3C55CBC56EF1E /* Build configuration list for PBXProject "Homeboy" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -682,6 +687,7 @@
 			mainGroup = 63DDAC24832E8D6200975064;
 			minimizedProjectReferenceProxies = 1;
 			preferredProjectObjectVersion = 77;
+			productRefGroup = DC501B7A7AB07D49F8911282 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -707,6 +713,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BA03F27144E7C71BE3BC30E4 /* APIAuthWorkspaceView.swift in Sources */,
 				5C04267FDCF7C82C4BE9B087 /* APIClient.swift in Sources */,
 				D3D2FEA38CB8A09E0ED93B73 /* APITypes.swift in Sources */,
 				E6403DF4F6747B97ED009C1A /* AppConfiguration.swift in Sources */,
@@ -715,16 +722,17 @@
 				27D41F217F00E3A8171BEC63 /* AppWarning.swift in Sources */,
 				86C712A03FB9FC626DC46371 /* ArtifactVersionParser.swift in Sources */,
 				FE865BA85263630F8BF6A608 /* AuthManager.swift in Sources */,
-				1162E40A1D0549D9B68608A8 /* BenchView.swift in Sources */,
-				1EBFEF675F781A40A250D009 /* BackupService.swift in Sources */,
+				445A81283F88E81B8C1F0710 /* BackupService.swift in Sources */,
+				1A9C5FC30453DD2AFD03062D /* BenchView.swift in Sources */,
 				D067D1266FD0989BC9E07C43 /* CLIBridge.swift in Sources */,
 				1D8C5CFC6CC66D4D2059241A /* CLIError.swift in Sources */,
-				E9D7338A6D0F128987F91E83 /* CLIModuleTypes.swift in Sources */,
+				5A7E75D51012C3ED36EA7853 /* CLIExtensionTypes.swift in Sources */,
 				761826050ADDBB5E4B00E1AC /* CLIVersionChecker.swift in Sources */,
 				CC79CDB6AF19F24E74A11202 /* CodeTextView.swift in Sources */,
 				807E4729F90F95A12FAB99B7 /* CollapsibleSplitView.swift in Sources */,
 				9CD0D78AD51869E4BCA3363C /* ComponentConfiguration.swift in Sources */,
 				8D62AD324E3C99747FA53FCB /* ComponentsSettingsTab.swift in Sources */,
+				E450CA4C790C609575070F05 /* ConfigGapsView.swift in Sources */,
 				2BDBF9B46483155A6701C845 /* ConfigurationChangeType.swift in Sources */,
 				5BD322602F64CCA4E7A54FEF /* ConfigurationManager.swift in Sources */,
 				E6130C3BA0E6F318EAB670A3 /* ConfigurationObserver.swift in Sources */,
@@ -738,31 +746,42 @@
 				FB914712293D43F2D7D80F80 /* CreateProjectSheet.swift in Sources */,
 				A051F697BD41C8D9A5298333 /* DataTableColumn.swift in Sources */,
 				A34392C1F77DDF4B0B386D8C /* DataTableConstants.swift in Sources */,
-				8DD50D5975E4E471BDE8DB3B /* DatabaseBrowserView.swift in Sources */,
-				8CC212749235B62EEE109984 /* DatabaseBrowserViewModel.swift in Sources */,
+				A28E717B2C7B1A41C6CF37F1 /* DatabaseBrowserView.swift in Sources */,
+				6D35EC810ADF631740FCC1B4 /* DatabaseBrowserViewModel.swift in Sources */,
 				2A0D8EC80F531D2458B4F000 /* DatabaseSettingsTab.swift in Sources */,
 				53E684EC9B358CC6CF15C7C2 /* DatabaseTypes.swift in Sources */,
 				B9C42108AC64D21BAEEE580A /* DeployableComponent.swift in Sources */,
-				0FE6351E7C94950D6A459978 /* DeployerView.swift in Sources */,
-				58D7EB6E82E865D5736663C0 /* DeployerViewModel.swift in Sources */,
+				36E2AEA91D720BC0FCE5D660 /* DeployerView.swift in Sources */,
+				023BC7FBF76D2C19E8B8559D /* DeployerViewModel.swift in Sources */,
 				85F4F94606B3D49BEFDC227F /* DeploymentService.swift in Sources */,
 				AB378FCB8518F6BED6EEFB6F /* DisplayableError.swift in Sources */,
-				0186B7D809C9473D9EC3F424 /* APIAuthWorkspaceView.swift in Sources */,
 				5CA76C92A6AF0C42784FD35D /* ErrorView.swift in Sources */,
+				59B9942920AA8A82C6687BA1 /* ExtensionActionsBar.swift in Sources */,
+				B1BC5D62A38657148E674B80 /* ExtensionConsoleView.swift in Sources */,
+				D94CC978855E31469979CD82 /* ExtensionContainerView.swift in Sources */,
+				5312A3BDB64264012E062616 /* ExtensionInputsView.swift in Sources */,
+				9E83D8F4A47320D0DC38B248 /* ExtensionInstallSheet.swift in Sources */,
+				9057B57BD09E3D8A025D305D /* ExtensionManager.swift in Sources */,
+				B23886AC41FD2A725383EF45 /* ExtensionManifest.swift in Sources */,
+				CFD2A46F7153AF3F5A5F7BED /* ExtensionResultsView.swift in Sources */,
+				6058DC822E13A3B7C56C64BF /* ExtensionSetupView.swift in Sources */,
+				93B2772BA952451AE39491B3 /* ExtensionViewModel.swift in Sources */,
+				585F2338D58023625EBBA0B5 /* ExtensionsSettingsTab.swift in Sources */,
 				5B3425AA6A8A9C4C9EF5E29F /* FileBrowserSidebarView.swift in Sources */,
 				85A8C46096DE6DFF3BD11E63 /* FindableTextView.swift in Sources */,
+				7399D30F167F523492E0F251 /* FleetManagementView.swift in Sources */,
 				02AD314100925D82AE384CE8 /* GeneralSettingsTab.swift in Sources */,
+				FDC7A36317A54E1EE4486D4A /* GitOperationsView.swift in Sources */,
+				0D616728E30CB0C012851F18 /* GitOperationsViewModel.swift in Sources */,
 				57C3AE0D20A591DEE69B0FF0 /* HomeboyApp.swift in Sources */,
+				7B4A55712A56BDD9EE21F504 /* HomeboyCLI+FileDatabaseCommands.swift in Sources */,
+				A40B645FCF64C59E6F1EC4FC /* HomeboyCLI+QualityCommands.swift in Sources */,
+				46238C2E19607D4410D23FA2 /* HomeboyCLI+RigBenchReleaseCommands.swift in Sources */,
+				19F0A3B40B6B6BA59A201C7F /* HomeboyCLI+RunCommands.swift in Sources */,
+				6861D39F7EB9C8E226731A6A /* HomeboyCLI+StackCommands.swift in Sources */,
+				306DE99757A1BBA6E328A8FF /* HomeboyCLI+WorkspaceCommands.swift in Sources */,
 				278021F9D228BBDA95267231 /* HomeboyCLI.swift in Sources */,
-				278021F9D228BBDA95267232 /* HomeboyCLI+FileDatabaseCommands.swift in Sources */,
-				278021F9D228BBDA95267233 /* HomeboyCLI+QualityCommands.swift in Sources */,
-				278021F9D228BBDA95267234 /* HomeboyCLI+RigBenchReleaseCommands.swift in Sources */,
-				278021F9D228BBDA95267238 /* HomeboyCLI+RunCommands.swift in Sources */,
-				278021F9D228BBDA95267235 /* HomeboyCLI+StackCommands.swift in Sources */,
-				278021F9D228BBDA95267236 /* HomeboyCLI+WorkspaceCommands.swift in Sources */,
-				278021F9D228BBDA95267237 /* HomeboyCLIModels.swift in Sources */,
-				2846F25C9D6A4E7BB401AA01 /* GitOperationsView.swift in Sources */,
-				5A7D2C4E91B8406DA0E3FB22 /* GitOperationsViewModel.swift in Sources */,
+				CC892914AFEB03C734959003 /* HomeboyCLIModels.swift in Sources */,
 				E832787BA1F926FB3A085E09 /* InlineErrorView.swift in Sources */,
 				EEA581470DC8B48027F54228 /* InlineWarningView.swift in Sources */,
 				5BDE52F8E2A18B1F50AD060A /* JSONValue.swift in Sources */,
@@ -770,36 +789,25 @@
 				D17F7A98F3FB9E8F40991024 /* LogContentView.swift in Sources */,
 				A79AD1D6F7DD14F02410D120 /* LogTextView.swift in Sources */,
 				8416680F81D345B2751765CC /* LoginView.swift in Sources */,
-				36948AE7BAD67E09B8873D53 /* ModuleActionsBar.swift in Sources */,
-				AC4B413EC80B0BD0F7AABB1D /* ModuleConsoleView.swift in Sources */,
-				8C6CA13F14113243F0E6CDC4 /* ModuleContainerView.swift in Sources */,
-				3D9711220108F7258431211E /* ModuleInputsView.swift in Sources */,
-				0BB5245A79F8709EBD8C5269 /* ModuleInstallSheet.swift in Sources */,
-				EFAD229C7AEECA77273843D0 /* ModuleManager.swift in Sources */,
-				5AAC8C88082027144361696A /* ModuleManifest.swift in Sources */,
-				8ACB39F91168D33D93F5B338 /* ModuleResultsView.swift in Sources */,
-				34B6D8FD95927DA85561881D /* ModuleSetupView.swift in Sources */,
-				C7897C8689B4E0075B1CB0D6 /* ModuleViewModel.swift in Sources */,
-				27FA9FFDA56F6C7BCAFE0296 /* ModulesSettingsTab.swift in Sources */,
 				C727FE57ACE75A3152D4C972 /* NativeDataTable.swift in Sources */,
 				76A91937D9017A5B0D9B0BA5 /* PinnableTabBar.swift in Sources */,
 				023E9AE450BF036FF40C0E76 /* ProjectConfiguration.swift in Sources */,
 				7EE844A0691D39F31A685114 /* ProjectSwitcherView.swift in Sources */,
-				0D4D7E7A5AB24A1D85E8A001 /* QualityModels.swift in Sources */,
-				0D4D7E7A5AB24A1D85E8A003 /* QualityView.swift in Sources */,
-				0D4D7E7A5AB24A1D85E8A002 /* QualityViewModel.swift in Sources */,
-				9ACBEB5DF2D256960184C815 /* QueryEditorView.swift in Sources */,
+				5CEF2659D6426FC7150A96C7 /* QualityModels.swift in Sources */,
+				9EB8E162236E90FFB9585AC9 /* QualityView.swift in Sources */,
+				EC7E0C50096E39206C199118 /* QualityViewModel.swift in Sources */,
+				A182CEC738D74B3D10F1BA6B /* QueryEditorView.swift in Sources */,
 				38D566E59E85DF4E4D14C48F /* RemoteFileBrowser.swift in Sources */,
 				22221233AC86561D48490886 /* RemoteFileBrowserView.swift in Sources */,
-				BBA251CB27591D879DAD4038 /* RemoteFileEditorView.swift in Sources */,
-				469CB781A5654E2EA41A3B30 /* RemoteFileEditorViewModel.swift in Sources */,
+				1AEFFA5D377D403DDA560237 /* RemoteFileEditorView.swift in Sources */,
+				79F089B7341476178AB41022 /* RemoteFileEditorViewModel.swift in Sources */,
 				72D058E4C987B44B3C2FE75F /* RemoteFileEntry.swift in Sources */,
-				6DA58994C9A0D94854E44A62 /* RemoteLogViewerView.swift in Sources */,
-				80D12DD221BE19316CB0BDCA /* RemoteLogViewerViewModel.swift in Sources */,
+				339E905F86E47CF88C0386B8 /* RemoteLogViewerView.swift in Sources */,
+				180E9CC06D913B4F8B55A58A /* RemoteLogViewerViewModel.swift in Sources */,
 				C24FBE4BE4FE4BA046D565C3 /* RemotePathResolver+WordPress.swift in Sources */,
 				465D0E037B7E2705A578EAF2 /* RemotePathResolver.swift in Sources */,
-				102A2F3B4C5D6E7F8091A2B3 /* RigsView.swift in Sources */,
-				1A2B3102F3B4C5D6E7F8091A /* RigsViewModel.swift in Sources */,
+				04CC8776681CF107919B5B76 /* RigsView.swift in Sources */,
+				2FA2E2EB6635082599CF1172 /* RigsViewModel.swift in Sources */,
 				58C9903BC07607162259D792 /* SSHKeyManager.swift in Sources */,
 				71419F89166E98CC7C4A3A98 /* SSHService.swift in Sources */,
 				E8A0E0A1E7364CFEB6EB48AF /* SchemaResolver.swift in Sources */,
@@ -808,11 +816,11 @@
 				790A549F1DA4887FA2EF100F /* ServersSettingsTab.swift in Sources */,
 				F34BB35C6C33E774792043ED /* SettingsView.swift in Sources */,
 				999116DB4DB5B3DF3EA9C171 /* SidebarView.swift in Sources */,
-				7CFF60E56F49FFC68A830664 /* SiteListView.swift in Sources */,
-				1E0233CF5AC026C74233786E /* TableDataView.swift in Sources */,
+				34FF9AD0FE0BE2ADE1F07752 /* SiteListView.swift in Sources */,
+				D231806A492F0FDF219633DD /* TableDataView.swift in Sources */,
 				8B8811A6AB7570F644C36FC5 /* VersionParser.swift in Sources */,
 				30856C36D38963CB5A540EFC /* WarningView.swift in Sources */,
-				AACC7F3153886939005FC50C /* WordPressSSHModule.swift in Sources */,
+				969EDDA4900E1F2620099F30 /* WordPressSSHExtension.swift in Sources */,
 				3188A425BBDAED4249534CE8 /* WordPressSettingsTab.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -893,7 +901,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.4;
-				MARKETING_VERSION = 0.10.0;
+				MARKETING_VERSION = 0.11.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.extrachill.homeboy;
 				PRODUCT_NAME = Homeboy;
 				SDKROOT = macosx;
@@ -918,7 +926,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.4;
-				MARKETING_VERSION = 0.10.0;
+				MARKETING_VERSION = 0.11.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.extrachill.homeboy;
 				PRODUCT_NAME = Homeboy;
 				SDKROOT = macosx;

--- a/Homeboy/App/ContentView.swift
+++ b/Homeboy/App/ContentView.swift
@@ -43,6 +43,26 @@ enum CoreTool: String, CaseIterable, Identifiable {
         case .settings: return "gear"
         }
     }
+
+    func isAvailable(for project: ProjectConfiguration?) -> Bool {
+        guard let project else { return self == .settings }
+
+        let hasComponents = !project.componentIds.isEmpty || !project.components.isEmpty
+        let hasRemoteTarget = project.serverId?.isEmpty == false && project.basePath?.isEmpty == false
+
+        switch self {
+        case .settings:
+            return true
+        case .deployer, .bench, .release, .rigs, .stackManager, .git, .quality:
+            return hasComponents
+        case .remoteFileEditor, .remoteLogViewer:
+            return hasRemoteTarget
+        case .databaseBrowser:
+            return project.isWordPress || !project.database.name.isEmpty
+        case .apiAuth:
+            return project.api.enabled || project.isWordPress
+        }
+    }
 }
 
 struct ContentView: View {
@@ -60,13 +80,34 @@ struct ContentView: View {
                     detailView
                 }
             } else {
-                // Placeholder while waiting for project creation sheet
-                Color.clear
+                ContentUnavailableView(
+                    configManager.needsProjectCreation ? "No Homeboy Projects" : "Loading Homeboy Project",
+                    systemImage: configManager.needsProjectCreation ? "folder.badge.plus" : "hourglass",
+                    description: Text(
+                        configManager.needsProjectCreation
+                            ? "Create a project to start using Homeboy Desktop."
+                            : "Reading project configuration from the Homeboy CLI."
+                    )
+                )
             }
         }
         .sheet(isPresented: $configManager.needsProjectCreation) {
             CreateProjectSheet(isFirstProject: true)
         }
+        .onChange(of: configManager.activeProject?.id) { _, _ in
+            ensureSelectedItemIsAvailable()
+        }
+    }
+
+    private func ensureSelectedItemIsAvailable() {
+        guard case .coreTool(let tool) = selectedItem,
+              !tool.isAvailable(for: configManager.activeProject) else {
+            return
+        }
+
+        selectedItem = CoreTool.allCases.first { $0 != .settings && $0.isAvailable(for: configManager.activeProject) }
+            .map(NavigationItem.coreTool)
+            ?? .coreTool(.settings)
     }
     
     /// Views are kept mounted in a ZStack to preserve state (including running processes)

--- a/Homeboy/Core/CLI/HomeboyCLIModels.swift
+++ b/Homeboy/Core/CLI/HomeboyCLIModels.swift
@@ -22,6 +22,19 @@ struct ProjectShowOutput: Decodable {
     let command: String
     let project: ProjectConfigCLI?
     let projectId: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case command, project, projectId, entity, id
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        command = try container.decode(String.self, forKey: .command)
+        project = try container.decodeIfPresent(ProjectConfigCLI.self, forKey: .project)
+            ?? container.decodeIfPresent(ProjectConfigCLI.self, forKey: .entity)
+        projectId = try container.decodeIfPresent(String.self, forKey: .projectId)
+            ?? container.decodeIfPresent(String.self, forKey: .id)
+    }
 }
 
 /// Project configuration matching CLI's Project struct (no wrapper)
@@ -30,6 +43,7 @@ struct ProjectConfigCLI: Decodable {
     let serverId: String?
     let basePath: String?
     let tablePrefix: String?
+    let extensions: [String: JSONValue]
     let changelogNextSectionLabel: String?
     let changelogNextSectionAliases: [String]?
     let componentIds: [String]
@@ -45,7 +59,7 @@ struct ProjectConfigCLI: Decodable {
     let sharedTables: [String]
 
     private enum CodingKeys: String, CodingKey {
-        case domain, serverId, basePath, tablePrefix
+        case domain, serverId, basePath, tablePrefix, extensions
         case changelogNextSectionLabel, changelogNextSectionAliases
         case componentIds, components, componentOverrides, services
         case remoteFiles, remoteLogs, database, tools, api, subTargets, sharedTables
@@ -58,6 +72,7 @@ struct ProjectConfigCLI: Decodable {
         serverId = try container.decodeIfPresent(String.self, forKey: .serverId)
         basePath = try container.decodeIfPresent(String.self, forKey: .basePath)
         tablePrefix = try container.decodeIfPresent(String.self, forKey: .tablePrefix)
+        extensions = try container.decodeIfPresent([String: JSONValue].self, forKey: .extensions) ?? [:]
         changelogNextSectionLabel = try container.decodeIfPresent(String.self, forKey: .changelogNextSectionLabel)
         changelogNextSectionAliases = try container.decodeIfPresent([String].self, forKey: .changelogNextSectionAliases)
         components = try container.decodeIfPresent([ProjectComponentAttachmentCLI].self, forKey: .components) ?? []
@@ -328,6 +343,197 @@ struct ServerRecordCLI: Decodable, Identifiable {
     var id: String { host }
 }
 
+// MARK: - Fleet CLI Output Models
+
+struct Fleet: Decodable, Identifiable, Hashable {
+    let id: String
+    let projectIds: [String]
+    let description: String?
+    let componentOverrides: [String: ProjectComponentOverrides]
+    let priorityLabels: [String]?
+
+    private enum CodingKeys: String, CodingKey {
+        case id, projectIds, description, componentOverrides, priorityLabels
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        projectIds = try container.decodeIfPresent([String].self, forKey: .projectIds) ?? []
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        componentOverrides = try container.decodeIfPresent([String: ProjectComponentOverrides].self, forKey: .componentOverrides) ?? [:]
+        priorityLabels = try container.decodeIfPresent([String].self, forKey: .priorityLabels)
+    }
+
+    static func == (lhs: Fleet, rhs: Fleet) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}
+
+struct FleetOutput: Decodable {
+    let command: String
+    let id: String?
+    let entity: Fleet?
+    let entities: [Fleet]?
+    let updatedFields: [String]?
+    let deleted: [String]?
+
+    var fleet: Fleet? { entity }
+    var fleets: [Fleet]? { entities }
+}
+
+typealias FleetListOutput = FleetOutput
+
+struct FleetProjectsOutput: Decodable {
+    let command: String
+    let id: String?
+    let projects: [ProjectListItem]?
+}
+
+struct FleetComponentsOutput: Decodable {
+    let command: String
+    let id: String?
+    let components: [String: [String]]?
+}
+
+struct FleetStatusOutput: Decodable {
+    let command: String
+    let id: String?
+    let status: FleetStatusResult?
+}
+
+struct FleetStatusResult: Decodable {
+    let projects: [FleetProjectStatus]
+    let summary: FleetStatusSummary
+}
+
+struct FleetProjectStatus: Decodable, Identifiable {
+    let projectId: String
+    let serverId: String?
+    let components: [FleetComponentStatus]
+    let health: JSONValue?
+
+    var id: String { projectId }
+}
+
+struct FleetComponentStatus: Decodable, Identifiable {
+    let componentId: String
+    let localVersion: String?
+    let remoteVersion: String?
+    let versionSource: String
+    let drift: String
+    let unreleasedCommits: UInt32
+
+    var id: String { componentId }
+}
+
+struct FleetStatusSummary: Decodable {
+    let projects: FleetProjectSummary
+    let components: FleetComponentSummary
+    let servers: FleetServerSummary
+    let warnings: [FleetWarning]?
+}
+
+struct FleetProjectSummary: Decodable {
+    let total: UInt32
+    let healthy: UInt32
+    let warning: UInt32
+    let unreachable: UInt32
+}
+
+struct FleetComponentSummary: Decodable {
+    let total: UInt32
+    let current: UInt32
+    let needsUpdate: UInt32
+    let needsRelease: UInt32
+    let docsOnly: UInt32
+    let unknown: UInt32
+}
+
+struct FleetServerSummary: Decodable {
+    let total: UInt32
+    let healthy: UInt32
+    let warning: UInt32
+    let unreachable: UInt32
+    let servicesUp: UInt32
+    let servicesDown: UInt32
+}
+
+struct FleetWarning: Decodable, Identifiable {
+    let serverId: String
+    let projectId: String
+    let message: String
+
+    var id: String { "\(serverId):\(projectId):\(message)" }
+}
+
+struct FleetCheckOutput: Decodable {
+    let command: String
+    let id: String?
+    let check: [FleetProjectCheck]?
+    let summary: FleetCheckSummary?
+}
+
+struct FleetProjectCheck: Decodable, Identifiable {
+    let projectId: String
+    let serverId: String?
+    let status: String
+    let error: String?
+    let components: [FleetComponentCheck]
+
+    var id: String { projectId }
+}
+
+struct FleetComponentCheck: Decodable, Identifiable {
+    let componentId: String
+    let localVersion: String?
+    let remoteVersion: String?
+    let status: String
+
+    var id: String { componentId }
+}
+
+struct FleetCheckSummary: Decodable {
+    let totalProjects: UInt32
+    let projectsChecked: UInt32
+    let projectsFailed: UInt32
+    let componentsUpToDate: UInt32
+    let componentsNeedsUpdate: UInt32
+    let componentsUnknown: UInt32
+}
+
+struct FleetExecOutput: Decodable {
+    let command: String
+    let id: String?
+    let exec: [FleetExecProjectResult]?
+    let execSummary: FleetExecSummary?
+}
+
+struct FleetExecProjectResult: Decodable, Identifiable {
+    let projectId: String
+    let serverId: String?
+    let basePath: String?
+    let command: String
+    let status: String
+    let stdout: String?
+    let stderr: String?
+    let exitCode: Int32?
+    let error: String?
+
+    var id: String { projectId }
+}
+
+struct FleetExecSummary: Decodable {
+    let total: UInt32
+    let succeeded: UInt32
+    let failed: UInt32
+    let skipped: UInt32
+}
+
 // MARK: - Component CLI Output Models
 
 struct ComponentOutput: Decodable {
@@ -466,6 +672,350 @@ struct BenchScenarioDelta: Decodable, Identifiable {
     let p95DeltaPct: Double?
     let regression: Bool
     let improvement: Bool
+}
+
+// MARK: - Rig CLI Output Models
+
+struct RigListOutput: Decodable {
+    let command: String
+    let rigs: [RigListItem]?
+}
+
+struct RigListItem: Decodable, Identifiable {
+    let id: String
+    let declaredId: String?
+    let description: String?
+    let componentCount: Int
+    let serviceCount: Int
+    let pipelines: [String]
+    let source: RigSourceSummary?
+}
+
+struct RigSourceSummary: Decodable {
+    let source: String
+    let packagePath: String
+    let rigPath: String
+    let linked: Bool
+    let sourceRevision: String?
+}
+
+struct RigShowOutput: Decodable {
+    let command: String
+    let rig: RigSpec?
+}
+
+struct RigSpec: Decodable, Identifiable {
+    let id: String
+    let description: String?
+    let components: [String: RigComponent]
+    let services: [String: JSONValue]?
+    let symlinks: [JSONValue]?
+    let pipeline: [String: [RigPipelineStepSpec]]?
+}
+
+struct RigComponent: Decodable {
+    let path: String
+    let branch: String?
+}
+
+struct RigPipelineStepSpec: Decodable {
+    let kind: String
+    let label: String?
+}
+
+struct RigStatusOutput: Decodable {
+    let command: String
+    let rigId: String
+    let description: String
+    let services: [RigServiceStatus]
+    let symlinks: [JSONValue]
+    let lastUp: String?
+    let lastCheck: String?
+    let lastCheckResult: String?
+    let materialized: JSONValue?
+}
+
+struct RigServiceStatus: Decodable, Identifiable {
+    let id: String
+    let kind: String
+    let status: String
+    let pid: UInt32?
+    let port: UInt16?
+    let logPath: String
+    let startedAt: String?
+}
+
+struct RigCommandResult<T: Decodable> {
+    let success: Bool
+    let data: T
+    let rawOutput: String
+    let errorOutput: String
+    let exitCode: Int32
+}
+
+struct RigCheckOutput: Decodable {
+    let command: String
+    let rigId: String
+    let pipeline: RigPipelineResult
+    let success: Bool
+}
+
+struct RigLifecycleOutput: Decodable {
+    let command: String
+    let rigId: String
+    let pipeline: RigPipelineResult?
+    let stopped: [String]?
+    let success: Bool
+}
+
+struct RigPipelineResult: Decodable {
+    let name: String
+    let steps: [RigPipelineStep]
+    let passed: Int?
+    let failed: Int?
+}
+
+struct RigPipelineStep: Decodable, Identifiable {
+    let kind: String
+    let label: String
+    let status: String
+    let error: String?
+
+    var id: String { "\(kind):\(label)" }
+}
+
+// MARK: - Release / Build CLI Output Models
+
+struct ChangesOutput: Decodable {
+    let componentId: String?
+    let baselineRef: String?
+    let baselineSource: String?
+    let latestTag: String?
+    let path: String?
+    let commits: [ChangeCommit]
+    let uncommitted: UncommittedChanges?
+    let changelog: ChangeChangelog?
+}
+
+struct ChangeCommit: Decodable, Identifiable {
+    let hash: String
+    let subject: String
+    let category: String?
+
+    var id: String { hash }
+}
+
+struct UncommittedChanges: Decodable {
+    let hasChanges: Bool
+    let staged: [String]?
+    let unstaged: [String]?
+    let untracked: [String]?
+}
+
+struct ChangeChangelog: Decodable {
+    let path: String?
+    let unreleasedEntries: Int?
+}
+
+struct VersionShowOutput: Decodable {
+    let command: String?
+    let componentId: String?
+    let version: String?
+    let path: String?
+    let targets: [ComponentRecordCLI.VersionTargetCLI]?
+}
+
+struct ReleaseOutput: Decodable {
+    let command: String?
+    let result: ReleaseResult?
+}
+
+struct ReleaseResult: Decodable {
+    let componentId: String?
+    let dryRun: Bool?
+    let bumpType: String?
+    let currentVersion: String?
+    let nextVersion: String?
+    let releasableCommits: Int?
+    let skippedReason: String?
+}
+
+struct BuildOutput: Decodable {
+    let command: String
+    let componentId: String
+    let buildCommand: String
+    let stdout: String?
+    let stderr: String?
+    let success: Bool
+}
+
+// MARK: - Stack CLI Output Models
+
+struct StackListOutput: Decodable {
+    let command: String
+    let stacks: [StackListItem]?
+}
+
+struct StackListItem: Decodable, Identifiable, Hashable {
+    let id: String
+    let description: String
+    let component: String
+    let componentPath: String
+    let base: String
+    let target: String
+    let prCount: Int
+}
+
+struct StackShowOutput: Decodable {
+    let command: String
+    let stack: StackSpec?
+}
+
+struct StackSpec: Decodable, Identifiable {
+    let id: String
+    let description: String
+    let component: String
+    let componentPath: String
+    let base: StackGitRef
+    let target: StackGitRef
+    let prs: [StackPrEntry]
+}
+
+struct StackGitRef: Decodable {
+    let remote: String
+    let branch: String
+}
+
+struct StackPrEntry: Decodable, Identifiable {
+    let repo: String
+    let number: Int
+    let note: String?
+
+    var id: String { "\(repo)#\(number)" }
+}
+
+struct StackStatusOutput: Decodable {
+    let command: String
+    let success: Bool?
+    let stackId: String
+    let componentPath: String
+    let base: String
+    let target: String
+    let targetAhead: Int
+    let targetBehind: Int
+    let mergedCount: Int
+    let prs: [StackPullRequestStatus]
+
+    private enum CodingKeys: String, CodingKey {
+        case command, success, stackId, componentPath, base, target, targetAhead, targetBehind, mergedCount, prs
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        command = try container.decode(String.self, forKey: .command)
+        success = try container.decodeIfPresent(Bool.self, forKey: .success)
+        stackId = try container.decode(String.self, forKey: .stackId)
+        componentPath = try container.decode(String.self, forKey: .componentPath)
+        base = try container.decode(String.self, forKey: .base)
+        target = try container.decode(String.self, forKey: .target)
+        targetAhead = try container.decodeIfPresent(Int.self, forKey: .targetAhead) ?? 0
+        targetBehind = try container.decodeIfPresent(Int.self, forKey: .targetBehind) ?? 0
+        mergedCount = try container.decode(Int.self, forKey: .mergedCount)
+        prs = try container.decode([StackPullRequestStatus].self, forKey: .prs)
+    }
+}
+
+struct StackPullRequestStatus: Decodable, Identifiable {
+    let repo: String
+    let number: Int
+    let note: String?
+    let title: String?
+    let url: String?
+    let upstreamState: String
+    let localState: String
+    let reviewDecision: String?
+    let mergedAt: String?
+    let candidateForDrop: Bool
+    let error: String?
+
+    var id: String { "\(repo)#\(number)" }
+
+    private enum CodingKeys: String, CodingKey {
+        case repo, number, note, title, url, upstreamState, localState, reviewDecision, mergedAt, candidateForDrop, error
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        repo = try container.decode(String.self, forKey: .repo)
+        number = try container.decode(Int.self, forKey: .number)
+        note = try container.decodeIfPresent(String.self, forKey: .note)
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        url = try container.decodeIfPresent(String.self, forKey: .url)
+        upstreamState = try container.decodeIfPresent(String.self, forKey: .upstreamState) ?? "UNKNOWN"
+        localState = try container.decodeIfPresent(String.self, forKey: .localState) ?? "unknown"
+        reviewDecision = try container.decodeIfPresent(String.self, forKey: .reviewDecision)
+        mergedAt = try container.decodeIfPresent(String.self, forKey: .mergedAt)
+        candidateForDrop = try container.decodeIfPresent(Bool.self, forKey: .candidateForDrop) ?? false
+        error = try container.decodeIfPresent(String.self, forKey: .error)
+    }
+}
+
+struct StackInspectOutput: Decodable {
+    let command: String
+    let componentId: String
+    let path: String
+    let branch: String
+    let base: String
+    let baseAutoDetected: Bool
+    let commits: [StackInspectCommit]
+    let mergedCount: Int
+    let success: Bool
+}
+
+struct StackInspectCommit: Decodable, Identifiable {
+    let sha: String
+    let shortSha: String
+    let subject: String
+    let author: String
+    let date: String
+    let pr: StackInspectPullRequest?
+    let prLookupNote: String?
+
+    var id: String { sha }
+}
+
+struct StackInspectPullRequest: Decodable {
+    let number: Int
+    let state: String
+    let title: String
+    let url: String
+}
+
+// MARK: - Undo CLI Output Models
+
+struct UndoOutput: Decodable {
+    let command: String
+    let snapshotId: String?
+    let label: String?
+    let filesRestored: Int?
+    let filesRemoved: Int?
+    let errors: [String]?
+    let id: String?
+    let deleted: Bool?
+}
+
+struct UndoListOutput: Decodable {
+    let command: String
+    let snapshots: [UndoSnapshot]?
+}
+
+struct UndoSnapshot: Decodable, Identifiable {
+    let id: String
+    let label: String
+    let root: String
+    let fileCount: Int
+    let createdAt: UInt64
+    let age: String
 }
 
 // MARK: - Run History CLI Output Models

--- a/Homeboy/Core/Config/ProjectConfiguration.swift
+++ b/Homeboy/Core/Config/ProjectConfiguration.swift
@@ -227,7 +227,7 @@ struct ProjectConfiguration: Codable, Identifiable {
         self.serverId = config.serverId
         self.basePath = config.basePath
         self.tablePrefix = config.tablePrefix
-        self.extensions = []  // CLI doesn't provide extensions in config
+        self.extensions = config.extensions.keys.sorted()
 
         // Convert CLI remote files (generate UUIDs since CLI doesn't provide them)
         self.remoteFiles = RemoteFileConfig(

--- a/Homeboy/Core/Extensions/ExtensionManager.swift
+++ b/Homeboy/Core/Extensions/ExtensionManager.swift
@@ -98,7 +98,12 @@ class ExtensionManager: ObservableObject, ConfigurationObserving {
         error = nil
 
         do {
-            let response = try await CLIBridge.shared.execute(["extension", "list"])
+            var args = ["extension", "list"]
+            if let projectId = ConfigurationManager.shared.activeProject?.id {
+                args.append(contentsOf: ["--project", projectId])
+            }
+
+            let response = try await CLIBridge.shared.execute(args)
             let result = try response.decodeResponse(CLIExtensionListData.self)
 
             guard result.success, let data = result.data else {
@@ -120,8 +125,8 @@ class ExtensionManager: ObservableObject, ConfigurationObserving {
             // Load manifests from CLI-reported paths
             var loadedExtensions: [LoadedExtension] = []
             for entry in visibleEntries {
-                if let extension = loadManifest(from: entry) {
-                    loadedExtensions.append(extension)
+                if let loadedExtension = loadManifest(from: entry) {
+                    loadedExtensions.append(loadedExtension)
                 }
             }
 

--- a/Homeboy/Core/Extensions/ExtensionManifest.swift
+++ b/Homeboy/Core/Extensions/ExtensionManifest.swift
@@ -50,7 +50,7 @@ struct ExtensionManifest: Codable, Identifiable {
     var defaultPinnedLogs: [String]? { platform?.defaultPinnedLogs }
 
     /// Database config (from platform group)
-    var database: DatabaseConfig? { platform?.database }
+    var database: ExtensionDatabaseConfig? { platform?.database }
 
     /// Discovery config (from platform group)
     var discovery: DiscoveryConfig? { platform?.discovery }
@@ -346,7 +346,7 @@ struct PlatformConfig: Codable {
     let configSchema: [String: ConfigSchemaItem]?
     let defaultPinnedFiles: [String]?
     let defaultPinnedLogs: [String]?
-    let database: DatabaseConfig?
+    let database: ExtensionDatabaseConfig?
     let discovery: DiscoveryConfig?
     let commands: [PlatformCommand]?
 }
@@ -360,7 +360,7 @@ struct ConfigSchemaItem: Codable {
 }
 
 /// Database configuration for platform extensions
-struct DatabaseConfig: Codable {
+struct ExtensionDatabaseConfig: Codable {
     let tables: [DatabaseTableConfig]?
     let views: [DatabaseViewConfig]?
 }

--- a/Homeboy/Extensions/Quality/QualityModels.swift
+++ b/Homeboy/Extensions/Quality/QualityModels.swift
@@ -137,3 +137,40 @@ struct QualityTriageRepo: Decodable {
     let provider: String
     let url: String?
 }
+
+struct AuditOutput: Decodable {
+    let command: String?
+    let componentId: String?
+    let passed: Bool?
+    let status: String?
+    let findings: [AuditFinding]?
+    let summary: JSONValue?
+}
+
+struct AuditFinding: Decodable, Identifiable {
+    let rule: String?
+    let message: String
+    let file: String?
+    let line: Int?
+    let severity: String?
+
+    var id: String { [rule, file, line.map(String.init), message].compactMap { $0 }.joined(separator: ":") }
+}
+
+struct RefactorPlanOutput: Decodable {
+    let command: String?
+    let componentId: String?
+    let plan: JSONValue?
+    let findings: [AuditFinding]?
+    let summary: JSONValue?
+}
+
+struct RefactorResult: Decodable {
+    let command: String?
+    let componentId: String?
+    let success: Bool?
+    let changed: [String]?
+    let filesChanged: [String]?
+    let summary: JSONValue?
+    let result: JSONValue?
+}

--- a/Homeboy/ViewModels/ExtensionViewModel.swift
+++ b/Homeboy/ViewModels/ExtensionViewModel.swift
@@ -31,7 +31,7 @@ class ExtensionViewModel: ObservableObject, ConfigurationObserving {
     
     /// Whether this extension is a CLI extension with subtarget support
     var isCLIExtension: Bool {
-        extension?.manifest.runtime?.type == .cli
+        currentExtension?.manifest.runtime?.type == .cli
     }
     
     /// Whether the current project has subtargets (for showing site selector)
@@ -70,14 +70,14 @@ class ExtensionViewModel: ObservableObject, ConfigurationObserving {
     }
     
     /// Initialize input values from extension manifest
-    func initializeInputValues(from extension: LoadedExtension) {
+    func initializeInputValues(from currentExtension: LoadedExtension) {
         // Set default network site for CLI extensions
-        if extension.manifest.runtime?.type == .cli {
-            selectedNetworkSite = extension.manifest.runtime?.defaultSite ?? "main"
+        if currentExtension.manifest.runtime?.type == .cli {
+            selectedNetworkSite = currentExtension.manifest.runtime?.defaultSite ?? "main"
         }
         
         // Set default input values
-        for input in extension.manifest.inputs ?? [] {
+        for input in currentExtension.manifest.inputs ?? [] {
             if let defaultValue = input.default {
                 inputValues[input.id] = defaultValue.stringValue
             } else {
@@ -88,7 +88,7 @@ class ExtensionViewModel: ObservableObject, ConfigurationObserving {
     
     // MARK: - Extension Execution
     
-    func run(extension: LoadedExtension) {
+    func run(extension currentExtension: LoadedExtension) {
         guard !isRunning && !isSettingUp else { return }
         
         consoleOutput = ""
@@ -100,7 +100,7 @@ class ExtensionViewModel: ObservableObject, ConfigurationObserving {
         
         Task {
             await ExtensionManager.shared.runExtension(
-                extensionId: extension.id,
+                extensionId: currentExtension.id,
                 inputs: inputValues,
                 onOutput: { [weak self] line in
                     Task { @MainActor in
@@ -110,7 +110,7 @@ class ExtensionViewModel: ObservableObject, ConfigurationObserving {
             )
 
             let output = parseScriptOutput(from: consoleOutput)
-            handleRunResult(output, extension: extension)
+            handleRunResult(output, extension: currentExtension)
         }
     }
     
@@ -137,7 +137,7 @@ class ExtensionViewModel: ObservableObject, ConfigurationObserving {
         }
     }
 
-    private func handleRunResult(_ result: Result<ScriptOutput, Error>, extension: LoadedExtension) {
+    private func handleRunResult(_ result: Result<ScriptOutput, Error>, extension currentExtension: LoadedExtension) {
         isRunning = false
         
         switch result {
@@ -145,7 +145,7 @@ class ExtensionViewModel: ObservableObject, ConfigurationObserving {
             if output.success {
                 results = output.results ?? []
                 // Auto-select all rows if selectable
-                if extension.manifest.output?.selectable == true {
+                if currentExtension.manifest.output?.selectable == true {
                     selectedRows = Set(results.indices)
                 }
                 if let errors = output.errors, !errors.isEmpty {
@@ -170,7 +170,7 @@ class ExtensionViewModel: ObservableObject, ConfigurationObserving {
     
     // MARK: - Extension Setup
     
-    func setup(extension: LoadedExtension) {
+    func setup(extension currentExtension: LoadedExtension) {
         guard !isSettingUp && !isRunning else { return }
         
         isSettingUp = true
@@ -179,8 +179,8 @@ class ExtensionViewModel: ObservableObject, ConfigurationObserving {
         
         Task {
             do {
-                try await ExtensionManager.shared.setupExtension(extensionId: extension.id)
-                ExtensionManager.shared.updateExtensionState(extensionId: extension.id, state: .ready)
+                try await ExtensionManager.shared.setupExtension(extensionId: currentExtension.id)
+                ExtensionManager.shared.updateExtensionState(extensionId: currentExtension.id, state: .ready)
             } catch {
                 self.error = error.toDisplayableError(source: "Extension: \(extensionId)")
             }
@@ -216,21 +216,23 @@ class ExtensionViewModel: ObservableObject, ConfigurationObserving {
     
     // MARK: - Actions
     
-    func performAction(_ action: ActionConfig, extension: LoadedExtension) async {
+    func performAction(_ action: ActionConfig, extension currentExtension: LoadedExtension) async {
         isPerformingAction = true
         actionResult = nil
         
         switch action.type {
         case .builtin:
-            performBuiltinAction(action, extension: extension)
+            performBuiltinAction(action, extension: currentExtension)
         case .api:
-            await performAPIAction(action, extension: extension)
+            await performAPIAction(action, extension: currentExtension)
+        case .command:
+            actionResult = "Command actions are not implemented in the desktop runner yet."
         }
         
         isPerformingAction = false
     }
     
-    private func performBuiltinAction(_ action: ActionConfig, extension: LoadedExtension) {
+    private func performBuiltinAction(_ action: ActionConfig, extension currentExtension: LoadedExtension) {
         guard let builtin = action.builtin else { return }
         
         switch builtin {
@@ -243,7 +245,7 @@ class ExtensionViewModel: ObservableObject, ConfigurationObserving {
             actionResult = "Copied \(values.count) values to clipboard"
             
         case .exportCsv:
-            exportToCsv(extension: extension)
+            exportToCsv(extension: currentExtension)
             
         case .copyJson:
             let encoder = JSONEncoder()
@@ -257,10 +259,10 @@ class ExtensionViewModel: ObservableObject, ConfigurationObserving {
         }
     }
     
-    private func exportToCsv(extension: LoadedExtension) {
+    private func exportToCsv(extension currentExtension: LoadedExtension) {
         guard !results.isEmpty else { return }
         
-        let columns = extension.manifest.output?.schema.items?.keys.sorted() ?? []
+        let columns = currentExtension.manifest.output?.schema.items?.keys.sorted() ?? []
         guard !columns.isEmpty else { return }
         
         var csv = columns.joined(separator: ",") + "\n"
@@ -278,7 +280,7 @@ class ExtensionViewModel: ObservableObject, ConfigurationObserving {
         // Show save panel
         let panel = NSSavePanel()
         panel.allowedContentTypes = [.commaSeparatedText]
-        panel.nameFieldStringValue = "\(extension.id)-export.csv"
+        panel.nameFieldStringValue = "\(currentExtension.id)-export.csv"
         
         if panel.runModal() == .OK, let url = panel.url {
             do {
@@ -290,7 +292,7 @@ class ExtensionViewModel: ObservableObject, ConfigurationObserving {
         }
     }
     
-    private func performAPIAction(_ action: ActionConfig, extension: LoadedExtension) async {
+    private func performAPIAction(_ action: ActionConfig, extension currentExtension: LoadedExtension) async {
         guard let endpoint = action.endpoint,
               let method = action.method else {
             error = AppError("Invalid API action configuration", source: "Extension: \(extensionId)")
@@ -316,7 +318,7 @@ class ExtensionViewModel: ObservableObject, ConfigurationObserving {
         var payload: [String: Any] = [:]
         if let payloadTemplate = action.payload {
             for (key, value) in payloadTemplate {
-                payload[key] = interpolateValue(value, extension: extension)
+                payload[key] = interpolateValue(value, extension: currentExtension)
             }
         }
         
@@ -360,7 +362,7 @@ class ExtensionViewModel: ObservableObject, ConfigurationObserving {
     }
     
     /// Interpolates template values like {{selected}} and {{settings.key}}
-    private func interpolateValue(_ value: PayloadValue, extension: LoadedExtension) -> Any {
+    private func interpolateValue(_ value: PayloadValue, extension currentExtension: LoadedExtension) -> Any {
         switch value {
         case .string(let template):
             if template == "{{selected}}" {
@@ -404,7 +406,7 @@ class ExtensionViewModel: ObservableObject, ConfigurationObserving {
     // MARK: - Console
     
     func copyConsoleOutput() {
-        let extensionName = extension?.name ?? extensionId
+        let extensionName = currentExtension?.name ?? extensionId
         ConsoleOutput(consoleOutput, source: "Extension: \(extensionName)").copyToClipboard()
     }
     

--- a/Homeboy/Views/Components/ConfigGapsView.swift
+++ b/Homeboy/Views/Components/ConfigGapsView.swift
@@ -63,7 +63,7 @@ struct ConfigGapsView: View {
             }
         }
         .padding()
-        .background(Color(.systemBackground))
+        .background(Color(nsColor: .windowBackgroundColor))
         .cornerRadius(8)
         .shadow(radius: 1)
     }
@@ -112,7 +112,7 @@ struct ConfigGapRow: View {
                         .foregroundColor(.secondary)
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)
-                        .background(Color(.systemGray6))
+                        .background(Color(nsColor: .controlBackgroundColor))
                         .cornerRadius(4)
                 }
 
@@ -159,7 +159,7 @@ struct ConfigGapRow: View {
             }
         }
         .padding()
-        .background(Color(.secondarySystemBackground))
+        .background(Color(nsColor: .controlBackgroundColor))
         .cornerRadius(8)
         .opacity(isFixed ? 0.7 : 1.0)
     }

--- a/Homeboy/Views/Components/FleetManagementView.swift
+++ b/Homeboy/Views/Components/FleetManagementView.swift
@@ -226,13 +226,13 @@ struct FleetCreateSheet: View {
             Form {
                 Section("Fleet Details") {
                     TextField("ID", text: $id)
-                        .textInputAutocapitalization(.never)
+                        .textFieldStyle(.roundedBorder)
                     TextField("Description (optional)", text: $description)
                 }
 
                 Section("Projects") {
                     TextField("Project IDs (comma-separated)", text: $projectIds)
-                        .textInputAutocapitalization(.never)
+                        .textFieldStyle(.roundedBorder)
                 }
 
                 if let error = errorMessage {
@@ -243,7 +243,6 @@ struct FleetCreateSheet: View {
                 }
             }
             .navigationTitle("New Fleet")
-            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }

--- a/Homeboy/Views/Extensions/ExtensionActionsBar.swift
+++ b/Homeboy/Views/Extensions/ExtensionActionsBar.swift
@@ -8,7 +8,7 @@ struct ExtensionActionsBar: View {
     
     var body: some View {
         HStack {
-            ForEach(extension.manifest.actions ?? []) { action in
+            ForEach(currentExtension.manifest.actions ?? []) { action in
                 actionButton(for: action)
             }
             
@@ -33,7 +33,7 @@ struct ExtensionActionsBar: View {
         
         Button {
             Task {
-                await viewModel.performAction(action, extension: extension)
+                await viewModel.performAction(action, extension: currentExtension)
             }
         } label: {
             HStack(spacing: 4) {
@@ -54,7 +54,7 @@ struct ExtensionActionsBar: View {
         }
         
         // Check row selection for selectable outputs
-        if extension.manifest.output?.selectable == true && viewModel.selectedRows.isEmpty {
+        if currentExtension.manifest.output?.selectable == true && viewModel.selectedRows.isEmpty {
             return (false, "Select rows first")
         }
         

--- a/Homeboy/Views/Extensions/ExtensionContainerView.swift
+++ b/Homeboy/Views/Extensions/ExtensionContainerView.swift
@@ -40,17 +40,17 @@ struct ExtensionContainerView: View {
     }
     
     @ViewBuilder
-    private func extensionContent(_ extension: LoadedExtension) -> some View {
+    private func extensionContent(_ currentExtension: LoadedExtension) -> some View {
         VStack(spacing: 0) {
             // Header
-            ExtensionHeaderView(extension: extension, viewModel: viewModel)
+            ExtensionHeaderView(currentExtension: currentExtension, viewModel: viewModel)
             
             Divider()
             
             // Main content based on extension state
-            switch extension.state {
+            switch currentExtension.state {
             case .needsSetup:
-                ExtensionSetupView(extension: extension, viewModel: viewModel)
+                ExtensionSetupView(currentExtension: currentExtension, viewModel: viewModel)
                 
             case .installing:
                 VStack {
@@ -68,7 +68,7 @@ struct ExtensionContainerView: View {
                     )
                     CopyButton.warning(
                         "Missing requirements: \(requirements.joined(separator: ", "))",
-                        source: "Extension: \(extension.name)"
+                        source: "Extension: \(currentExtension.name)"
                     )
                 }
                 
@@ -79,14 +79,14 @@ struct ExtensionContainerView: View {
                         systemImage: "exclamationmark.triangle",
                         description: Text(message)
                     )
-                    CopyButton.error(message, source: "Extension: \(extension.name)")
+                    CopyButton.error(message, source: "Extension: \(currentExtension.name)")
                 }
                 
             case .ready:
-                if let _ = extension.manifest.runtime {
-                    ExtensionReadyView(extension: extension, viewModel: viewModel)
+                if let _ = currentExtension.manifest.runtime {
+                    ExtensionReadyView(currentExtension: currentExtension, viewModel: viewModel)
                 } else {
-                    PlatformExtensionView(extension: extension)
+                    PlatformExtensionView(currentExtension: currentExtension)
                 }
             }
         }
@@ -103,7 +103,7 @@ struct PlatformExtensionView: View {
     var body: some View {
         VStack(spacing: 0) {
             // Actions grid
-            if let actions = extension.manifest.actions, !actions.isEmpty {
+            if let actions = currentExtension.manifest.actions, !actions.isEmpty {
                 VStack(alignment: .leading, spacing: 12) {
                     Text("Actions")
                         .font(.headline)
@@ -172,7 +172,7 @@ struct PlatformExtensionView: View {
         defer { isRunning = false }
         
         do {
-            let args = ["extension", "action", extension.id, action.id]
+            let args = ["extension", "action", currentExtension.id, action.id]
             let response = try await CLIBridge.shared.execute(args)
             actionOutput += "$ \(command)\n\(response.output)\n\n"
         } catch {
@@ -189,14 +189,14 @@ struct ExtensionHeaderView: View {
     
     var body: some View {
         HStack {
-            Image(systemName: extension.icon)
+            Image(systemName: currentExtension.icon)
                 .font(.title2)
                 .foregroundColor(.accentColor)
             
             VStack(alignment: .leading, spacing: 2) {
-                Text(extension.name)
+                Text(currentExtension.name)
                     .font(.headline)
-                Text(extension.manifest.description)
+                Text(currentExtension.manifest.description)
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
@@ -227,7 +227,7 @@ struct ExtensionReadyView: View {
             // Left side: Inputs + Console
             VStack(spacing: 0) {
                 // Input form
-                ExtensionInputsView(extension: extension, viewModel: viewModel)
+                ExtensionInputsView(currentExtension: currentExtension, viewModel: viewModel)
                 
                 Divider()
                 
@@ -255,13 +255,13 @@ struct ExtensionReadyView: View {
             .frame(minWidth: 300)
             
             // Right side: Results (if table display)
-            if extension.manifest.output?.display == .table && !viewModel.results.isEmpty {
+            if currentExtension.manifest.output?.display == .table && !viewModel.results.isEmpty {
                 VStack(spacing: 0) {
-                    ExtensionResultsView(extension: extension, viewModel: viewModel)
+                    ExtensionResultsView(currentExtension: currentExtension, viewModel: viewModel)
                     
                     Divider()
                     
-                    ExtensionActionsBar(extension: extension, viewModel: viewModel)
+                    ExtensionActionsBar(currentExtension: currentExtension, viewModel: viewModel)
                 }
                 .frame(minWidth: 400)
             }

--- a/Homeboy/Views/Extensions/ExtensionInputsView.swift
+++ b/Homeboy/Views/Extensions/ExtensionInputsView.swift
@@ -20,13 +20,13 @@ struct ExtensionInputsView: View {
                 }
             }
             
-            ForEach(extension.manifest.inputs ?? []) { input in
+            ForEach(currentExtension.manifest.inputs ?? []) { input in
                 inputField(for: input)
             }
             
             HStack {
                 Button {
-                    viewModel.run(extension: extension)
+                    viewModel.run(extension: currentExtension)
                 } label: {
                     HStack {
                         if viewModel.isRunning {

--- a/Homeboy/Views/Extensions/ExtensionResultsView.swift
+++ b/Homeboy/Views/Extensions/ExtensionResultsView.swift
@@ -9,7 +9,7 @@ struct ExtensionResultsView: View {
     @State private var sortDescriptor: DataTableSortDescriptor<IndexedRow>?
     
     private var columnNames: [String] {
-        extension.manifest.output?.schema.items?.keys.sorted() ?? []
+        currentExtension.manifest.output?.schema.items?.keys.sorted() ?? []
     }
     
     var body: some View {
@@ -39,7 +39,7 @@ struct ExtensionResultsView: View {
             
             Spacer()
             
-            if extension.manifest.output?.selectable == true {
+            if currentExtension.manifest.output?.selectable == true {
                 Text("\(viewModel.selectedRows.count) selected")
                     .font(.caption)
                     .foregroundColor(.secondary)

--- a/Homeboy/Views/Extensions/ExtensionSetupView.swift
+++ b/Homeboy/Views/Extensions/ExtensionSetupView.swift
@@ -13,7 +13,7 @@ struct ExtensionSetupView: View {
                     ProgressView()
                         .scaleEffect(1.5)
                     
-                    Text("Setting up \(extension.name)...")
+                    Text("Setting up \(currentExtension.name)...")
                         .font(.headline)
                     
                     Text("Installing Python dependencies and Playwright browsers")
@@ -44,7 +44,7 @@ struct ExtensionSetupView: View {
                         .frame(maxWidth: 400)
                     
                     // Dependencies list
-                    if let dependencies = extension.manifest.runtime?.dependencies, !dependencies.isEmpty {
+                    if let dependencies = currentExtension.manifest.runtime?.dependencies, !dependencies.isEmpty {
                         VStack(alignment: .leading, spacing: 4) {
                             Text("Dependencies:")
                                 .font(.caption)
@@ -58,7 +58,7 @@ struct ExtensionSetupView: View {
                         .cornerRadius(8)
                     }
                     
-                    if let browsers = extension.manifest.runtime?.playwrightBrowsers, !browsers.isEmpty {
+                    if let browsers = currentExtension.manifest.runtime?.playwrightBrowsers, !browsers.isEmpty {
                         VStack(alignment: .leading, spacing: 4) {
                             Text("Playwright Browsers:")
                                 .font(.caption)
@@ -73,7 +73,7 @@ struct ExtensionSetupView: View {
                     }
                     
                     Button {
-                        viewModel.setup(extension: extension)
+                        viewModel.setup(extension: currentExtension)
                     } label: {
                         HStack {
                             Image(systemName: "arrow.down.circle")

--- a/Homeboy/Views/Settings/ComponentsSettingsTab.swift
+++ b/Homeboy/Views/Settings/ComponentsSettingsTab.swift
@@ -306,8 +306,8 @@ struct AddEditComponentSheet: View {
             localPath: localPath,
             remotePath: remotePath,
             buildArtifact: buildArtifact.isEmpty ? nil : buildArtifact,
-            versionTargets: versionTargets,
-            buildCommand: nil
+            buildCommand: nil,
+            versionTargets: versionTargets
         )
 
         Task {

--- a/Homeboy/Views/SidebarView.swift
+++ b/Homeboy/Views/SidebarView.swift
@@ -47,27 +47,27 @@ struct SidebarView: View {
                                 .help("Manage extensions in Settings")
                         }
                     } else {
-                        ForEach(extensionManager.extensions) { extension in
+                        ForEach(extensionManager.extensions) { loadedExtension in
                             HStack {
-                                Label(extension.name, systemImage: extension.icon)
-                                    .foregroundColor(extension.isDisabled ? .secondary : .primary)
+                                Label(loadedExtension.name, systemImage: loadedExtension.icon)
+                                    .foregroundColor(loadedExtension.isDisabled ? .secondary : .primary)
 
                                 Spacer()
 
                                 // Status indicator
-                                if extension.isDisabled {
+                                if loadedExtension.isDisabled {
                                     Image(systemName: "exclamationmark.triangle.fill")
                                         .foregroundColor(.gray)
                                         .font(.caption)
                                         .contextMenu {
                                             Button("Copy Warning") {
                                                 AppWarning(
-                                                    "Missing requirements: \(extension.missingComponents.joined(separator: ", "))",
-                                                    source: "Extension: \(extension.name)"
+                                                    "Missing requirements: \(loadedExtension.missingComponents.joined(separator: ", "))",
+                                                    source: "Extension: \(loadedExtension.name)"
                                                 ).copyToClipboard()
                                             }
                                         }
-                                } else if extension.state == .needsSetup {
+                                } else if loadedExtension.state == .needsSetup {
                                     Image(systemName: "exclamationmark.circle.fill")
                                         .foregroundColor(.orange)
                                         .font(.caption)
@@ -75,14 +75,14 @@ struct SidebarView: View {
                                             Button("Copy Warning") {
                                                 AppWarning(
                                                     "Setup Required",
-                                                    source: "Extension: \(extension.name)"
+                                                    source: "Extension: \(loadedExtension.name)"
                                                 ).copyToClipboard()
                                             }
                                         }
                                 }
                             }
-                            .tag(NavigationItem.extensionItem(extension.id))
-                            .help(extension.isDisabled ? "Requires: \(extension.missingComponents.joined(separator: ", "))" : extension.name)
+                            .tag(NavigationItem.extensionItem(loadedExtension.id))
+                            .help(loadedExtension.isDisabled ? "Requires: \(loadedExtension.missingComponents.joined(separator: ", "))" : loadedExtension.name)
                         }
                     }
                 } header: {
@@ -117,13 +117,34 @@ struct SidebarView: View {
                 }
             }
         }
+        .onChange(of: config.activeProject?.id) { _, _ in
+            ensureSelectionIsVisible()
+        }
+        .onChange(of: extensionManager.extensions.map(\.id)) { _, _ in
+            ensureSelectionIsVisible()
+        }
+    }
+
+    private func ensureSelectionIsVisible() {
+        switch selectedItem {
+        case .coreTool(let tool):
+            if !coreTools.contains(tool), tool != .settings {
+                selectedItem = coreTools.first.map(NavigationItem.coreTool) ?? .coreTool(.settings)
+            }
+        case .extensionItem(let id):
+            if !extensionManager.extensions.contains(where: { $0.id == id }) {
+                selectedItem = coreTools.first.map(NavigationItem.coreTool) ?? .coreTool(.settings)
+            }
+        case nil:
+            selectedItem = coreTools.first.map(NavigationItem.coreTool) ?? .coreTool(.settings)
+        }
     }
     
     /// Core tools to display in the sidebar.
     /// All tools are universal - Database Browser shows config prompt if not configured.
     /// Settings is shown in a separate section below.
     private var coreTools: [CoreTool] {
-        CoreTool.allCases.filter { $0 != .settings }
+        CoreTool.allCases.filter { $0 != .settings && $0.isAvailable(for: config.activeProject) }
     }
 }
 


### PR DESCRIPTION
## Summary
- Scope extension discovery to the active project via `homeboy extension list --project <id>`.
- Filter sidebar tools from active project capabilities and keep selection valid across project switches.
- Update Desktop CLI models and macOS SwiftUI compatibility so current Homeboy CLI output builds and decodes correctly.

## Testing
- `DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer" xcodebuild -project Homeboy.xcodeproj -scheme Homeboy -configuration Debug -derivedDataPath .build/DerivedData build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and applying the Desktop Swift fixes, running local build verification, and preparing the PR.