### PR TITLE
Add CLI command browser

### DIFF
--- a/Homeboy.xcodeproj/project.pbxproj
+++ b/Homeboy.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		9EB8E162236E90FFB9585AC9 /* QualityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B709FB776FF5A95CAE18A7D2 /* QualityView.swift */; };
 		A051F697BD41C8D9A5298333 /* DataTableColumn.swift in Sources */ = {isa = PBXBuildFile; fileRef = C503C8896286EA38288A139F /* DataTableColumn.swift */; };
 		A182CEC738D74B3D10F1BA6B /* QueryEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91594B5A5CCE7AE78D16BD3 /* QueryEditorView.swift */; };
+		A1F7848D131CBFFFEEB239D8 /* CommandBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD4DD433928D5A580EB66C8 /* CommandBrowserView.swift */; };
 		A28E717B2C7B1A41C6CF37F1 /* DatabaseBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B07DC101287321035F10830F /* DatabaseBrowserView.swift */; };
 		A34392C1F77DDF4B0B386D8C /* DataTableConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = F915FEEAF97ADD6EAADF6E4A /* DataTableConstants.swift */; };
 		A40B645FCF64C59E6F1EC4FC /* HomeboyCLI+QualityCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC23AFFAB50FD8AFD042E644 /* HomeboyCLI+QualityCommands.swift */; };
@@ -205,6 +206,7 @@
 		BA88D343E94C4C34E1069813 /* CodeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextView.swift; sourceTree = "<group>"; };
 		BB0EEE1B29B6CBCC9B7AE92D /* RemotePathResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotePathResolver.swift; sourceTree = "<group>"; };
 		BC23AFFAB50FD8AFD042E644 /* HomeboyCLI+QualityCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+QualityCommands.swift"; sourceTree = "<group>"; };
+		BCD4DD433928D5A580EB66C8 /* CommandBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBrowserView.swift; sourceTree = "<group>"; };
 		BE9B567AD7EF6AEAFF4650E3 /* SSHKeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHKeyManager.swift; sourceTree = "<group>"; };
 		BFAF5103FCB24063514E519F /* HomeboyCLI+RunCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+RunCommands.swift"; sourceTree = "<group>"; };
 		BFEA6E42C1D9292B10447CDA /* HomeboyApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeboyApp.swift; sourceTree = "<group>"; };
@@ -416,6 +418,7 @@
 		7CD7DF7C95F543DB47F1055F /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				92301854AF9D7FCE0328DB48 /* CommandBrowser */,
 				8007D7D3CCEF3F80C36AA686 /* Components */,
 				48CA5756F2D78ADA9FCD0AFD /* Extensions */,
 				144F0E432A914DE9F141CEFA /* Rigs */,
@@ -497,6 +500,14 @@
 				2DE44D1E578B8119641FCA42 /* SSH */,
 			);
 			path = Core;
+			sourceTree = "<group>";
+		};
+		92301854AF9D7FCE0328DB48 /* CommandBrowser */ = {
+			isa = PBXGroup;
+			children = (
+				BCD4DD433928D5A580EB66C8 /* CommandBrowserView.swift */,
+			);
+			path = CommandBrowser;
 			sourceTree = "<group>";
 		};
 		951F19759C5A27A308A4C3E9 /* Copyable */ = {
@@ -744,6 +755,7 @@
 				761826050ADDBB5E4B00E1AC /* CLIVersionChecker.swift in Sources */,
 				CC79CDB6AF19F24E74A11202 /* CodeTextView.swift in Sources */,
 				807E4729F90F95A12FAB99B7 /* CollapsibleSplitView.swift in Sources */,
+				A1F7848D131CBFFFEEB239D8 /* CommandBrowserView.swift in Sources */,
 				9CD0D78AD51869E4BCA3363C /* ComponentConfiguration.swift in Sources */,
 				8D62AD324E3C99747FA53FCB /* ComponentsSettingsTab.swift in Sources */,
 				E450CA4C790C609575070F05 /* ConfigGapsView.swift in Sources */,

--- a/Homeboy/App/ContentView.swift
+++ b/Homeboy/App/ContentView.swift
@@ -12,6 +12,7 @@ enum NavigationItem: Hashable {
 /// Database Browser is shown if project type supports it.
 /// Settings is shown in a separate section.
 enum CoreTool: String, CaseIterable, Identifiable {
+    case commandBrowser = "Commands"
     case deployer = "Deployer"
     case bench = "Bench"
     case runHistory = "Run History"
@@ -30,6 +31,7 @@ enum CoreTool: String, CaseIterable, Identifiable {
     
     var icon: String {
         switch self {
+        case .commandBrowser: return "terminal"
         case .deployer: return "arrow.up.to.line"
         case .bench: return "speedometer"
         case .runHistory: return "clock.arrow.circlepath"
@@ -53,6 +55,8 @@ enum CoreTool: String, CaseIterable, Identifiable {
         let hasRemoteTarget = project.serverId?.isEmpty == false && project.basePath?.isEmpty == false
 
         switch self {
+        case .commandBrowser:
+            return true
         case .settings:
             return true
         case .deployer, .bench, .runHistory, .release, .rigs, .stackManager, .git, .quality:
@@ -118,6 +122,8 @@ struct ContentView: View {
     private var detailView: some View {
         ZStack {
             // Core tools - kept mounted to preserve state
+            CommandBrowserView()
+                .opacity(selectedItem == .coreTool(.commandBrowser) ? 1 : 0)
             DeployerView()
                 .opacity(selectedItem == .coreTool(.deployer) ? 1 : 0)
             BenchView()

--- a/Homeboy/Views/CommandBrowser/CommandBrowserView.swift
+++ b/Homeboy/Views/CommandBrowser/CommandBrowserView.swift
@@ -1,0 +1,546 @@
+import AppKit
+import SwiftUI
+
+struct CommandBrowserEntry: Identifiable, Hashable {
+    enum Scope: String {
+        case global = "Global"
+        case project = "Project"
+        case component = "Component"
+        case rig = "Rig"
+        case stack = "Stack"
+        case server = "Server"
+    }
+
+    enum Risk: String {
+        case readOnly = "Read-only"
+        case guardedWrites = "Guarded writes"
+        case mutating = "Mutating"
+        case operatorOnly = "Operator"
+    }
+
+    enum DesktopCoverage: String {
+        case workflow = "Workflow UI"
+        case partial = "Partial UI"
+        case readOnly = "Read-only UI"
+        case cliOnly = "CLI-only"
+    }
+
+    let command: String
+    let summary: String
+    let scope: Scope
+    let risk: Risk
+    let coverage: DesktopCoverage
+    let workflow: CoreTool?
+
+    var id: String { command }
+    var invocation: String { "homeboy \(command)" }
+
+    func withSummary(_ summary: String) -> CommandBrowserEntry {
+        CommandBrowserEntry(
+            command: command,
+            summary: summary,
+            scope: scope,
+            risk: risk,
+            coverage: coverage,
+            workflow: workflow
+        )
+    }
+}
+
+@MainActor
+final class CommandBrowserViewModel: ObservableObject {
+    @Published var commands = CommandBrowserViewModel.catalog
+    @Published var selectedCommand: CommandBrowserEntry? = CommandBrowserViewModel.catalog.first
+    @Published var filter = ""
+    @Published var helpOutput = ""
+    @Published var runOutput = ""
+    @Published var commandInput = "homeboy --help"
+    @Published var isLoadingHelp = false
+    @Published var isRunning = false
+    @Published var error: (any DisplayableError)?
+
+    var filteredCommands: [CommandBrowserEntry] {
+        let query = filter.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else { return commands }
+        return commands.filter { entry in
+            entry.command.lowercased().contains(query)
+                || entry.summary.lowercased().contains(query)
+                || entry.scope.rawValue.lowercased().contains(query)
+                || entry.coverage.rawValue.lowercased().contains(query)
+        }
+    }
+
+    func select(_ command: CommandBrowserEntry) {
+        selectedCommand = command
+        commandInput = command.invocation + " --help"
+        loadHelp(for: command)
+    }
+
+    func loadInitialHelp() {
+        if helpOutput.isEmpty {
+            Task {
+                await refreshCatalogFromCLI()
+                if let selectedCommand {
+                    loadHelp(for: selectedCommand)
+                }
+            }
+        }
+    }
+
+    private func refreshCatalogFromCLI() async {
+        guard HomeboyCLI.shared.isInstalled else { return }
+
+        do {
+            let response = try await CLIBridge.shared.execute(["--help"], timeout: 30)
+            let discovered = Self.commands(fromHelp: response.output)
+            guard !discovered.isEmpty else { return }
+
+            let metadata = Dictionary(uniqueKeysWithValues: Self.catalog.map { ($0.command, $0) })
+            commands = discovered.map { command, summary in
+                (metadata[command] ?? Self.fallbackEntry(command: command, summary: summary)).withSummary(summary)
+            }
+            .sorted { $0.command < $1.command }
+
+            if let selectedCommand, commands.contains(where: { $0.id == selectedCommand.id }) {
+                self.selectedCommand = commands.first { $0.id == selectedCommand.id }
+            } else {
+                selectedCommand = commands.first
+                commandInput = selectedCommand.map { $0.invocation + " --help" } ?? "homeboy --help"
+            }
+        } catch {
+            self.error = error.toDisplayableError(source: "Commands")
+        }
+    }
+
+    func loadHelp(for command: CommandBrowserEntry) {
+        guard HomeboyCLI.shared.isInstalled else {
+            error = AppError("Homeboy CLI is not installed. Install via Settings -> CLI.", source: "Commands")
+            return
+        }
+
+        isLoadingHelp = true
+        error = nil
+
+        Task {
+            do {
+                let response = try await CLIBridge.shared.execute([command.command, "--help"], timeout: 30)
+                helpOutput = response.output.isEmpty ? response.errorOutput : response.output
+            } catch {
+                self.error = error.toDisplayableError(source: "Commands")
+                helpOutput = error.localizedDescription
+            }
+
+            isLoadingHelp = false
+        }
+    }
+
+    func copyCurrentCommand() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(commandInput, forType: .string)
+    }
+
+    func runCommandInput() {
+        guard HomeboyCLI.shared.isInstalled else {
+            error = AppError("Homeboy CLI is not installed. Install via Settings -> CLI.", source: "Commands")
+            return
+        }
+
+        let parsed = parseCommandLine(commandInput)
+        guard let first = parsed.first, first == "homeboy" else {
+            error = AppError("Commands must start with `homeboy`.", source: "Commands")
+            return
+        }
+
+        isRunning = true
+        error = nil
+        runOutput = "> \(commandInput)\n"
+
+        Task {
+            do {
+                let response = try await CLIBridge.shared.execute(Array(parsed.dropFirst()), timeout: 300)
+                appendRunOutput(response.output)
+                appendRunOutput(response.errorOutput)
+                appendRunOutput("exit \(response.exitCode)")
+            } catch {
+                self.error = error.toDisplayableError(source: "Commands")
+                appendRunOutput(error.localizedDescription)
+            }
+
+            isRunning = false
+        }
+    }
+
+    private func appendRunOutput(_ text: String) {
+        guard !text.isEmpty else { return }
+        if !runOutput.isEmpty && !runOutput.hasSuffix("\n") {
+            runOutput += "\n"
+        }
+        runOutput += text
+        if !runOutput.hasSuffix("\n") {
+            runOutput += "\n"
+        }
+    }
+
+    private func parseCommandLine(_ input: String) -> [String] {
+        var args: [String] = []
+        var current = ""
+        var quote: Character?
+        var isEscaped = false
+
+        for character in input {
+            if isEscaped {
+                current.append(character)
+                isEscaped = false
+                continue
+            }
+
+            if character == "\\" {
+                isEscaped = true
+                continue
+            }
+
+            if let activeQuote = quote {
+                if character == activeQuote {
+                    quote = nil
+                } else {
+                    current.append(character)
+                }
+                continue
+            }
+
+            if character == "\"" || character == "'" {
+                quote = character
+                continue
+            }
+
+            if character.isWhitespace {
+                if !current.isEmpty {
+                    args.append(current)
+                    current = ""
+                }
+                continue
+            }
+
+            current.append(character)
+        }
+
+        if !current.isEmpty {
+            args.append(current)
+        }
+
+        return args
+    }
+
+    private static func commands(fromHelp output: String) -> [(command: String, summary: String)] {
+        var isInCommands = false
+        var commands: [(String, String)] = []
+
+        for line in output.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed == "Commands:" {
+                isInCommands = true
+                continue
+            }
+            if trimmed == "Options:" {
+                break
+            }
+            guard isInCommands, !trimmed.isEmpty, !trimmed.hasPrefix("-") else { continue }
+
+            let parts = trimmed.split(maxSplits: 1, whereSeparator: { $0.isWhitespace })
+            guard let command = parts.first else { continue }
+            commands.append((String(command), parts.count > 1 ? String(parts[1]) : ""))
+        }
+
+        return commands
+    }
+
+    private static func fallbackEntry(command: String, summary: String) -> CommandBrowserEntry {
+        CommandBrowserEntry(
+            command: command,
+            summary: summary,
+            scope: .global,
+            risk: .operatorOnly,
+            coverage: .cliOnly,
+            workflow: nil
+        )
+    }
+
+    static let catalog: [CommandBrowserEntry] = [
+        .init(command: "project", summary: "Manage project/target configuration", scope: .project, risk: .guardedWrites, coverage: .workflow, workflow: .settings),
+        .init(command: "ssh", summary: "Open SSH sessions for configured servers", scope: .server, risk: .operatorOnly, coverage: .partial, workflow: nil),
+        .init(command: "server", summary: "Manage SSH server records", scope: .server, risk: .guardedWrites, coverage: .workflow, workflow: .settings),
+        .init(command: "test", summary: "Run component tests", scope: .component, risk: .readOnly, coverage: .workflow, workflow: .quality),
+        .init(command: "bench", summary: "Run performance benchmarks", scope: .component, risk: .readOnly, coverage: .workflow, workflow: .bench),
+        .init(command: "trace", summary: "Capture behavioral traces", scope: .component, risk: .readOnly, coverage: .cliOnly, workflow: nil),
+        .init(command: "observe", summary: "Persist passive observation evidence", scope: .global, risk: .readOnly, coverage: .cliOnly, workflow: nil),
+        .init(command: "lint", summary: "Run component lint checks", scope: .component, risk: .readOnly, coverage: .workflow, workflow: .quality),
+        .init(command: "db", summary: "Inspect and operate on databases", scope: .project, risk: .guardedWrites, coverage: .workflow, workflow: .databaseBrowser),
+        .init(command: "deps", summary: "Manage component dependencies", scope: .component, risk: .mutating, coverage: .cliOnly, workflow: nil),
+        .init(command: "doctor", summary: "Run local diagnostics", scope: .global, risk: .readOnly, coverage: .cliOnly, workflow: nil),
+        .init(command: "file", summary: "Read and edit remote files", scope: .project, risk: .guardedWrites, coverage: .workflow, workflow: .remoteFileEditor),
+        .init(command: "fleet", summary: "Manage groups of projects", scope: .project, risk: .guardedWrites, coverage: .partial, workflow: nil),
+        .init(command: "logs", summary: "View remote logs", scope: .project, risk: .readOnly, coverage: .workflow, workflow: .remoteLogViewer),
+        .init(command: "triage", summary: "Summarize project/component attention", scope: .global, risk: .readOnly, coverage: .workflow, workflow: .quality),
+        .init(command: "deploy", summary: "Deploy components to targets", scope: .project, risk: .mutating, coverage: .workflow, workflow: .deployer),
+        .init(command: "component", summary: "Manage standalone component records", scope: .component, risk: .guardedWrites, coverage: .workflow, workflow: .settings),
+        .init(command: "config", summary: "Manage raw Homeboy configuration", scope: .global, risk: .mutating, coverage: .cliOnly, workflow: nil),
+        .init(command: "daemon", summary: "Run the local HTTP API daemon", scope: .global, risk: .operatorOnly, coverage: .cliOnly, workflow: nil),
+        .init(command: "extension", summary: "Install, setup, and run CLI extensions", scope: .global, risk: .guardedWrites, coverage: .workflow, workflow: .settings),
+        .init(command: "status", summary: "Show actionable workspace status", scope: .global, risk: .readOnly, coverage: .workflow, workflow: nil),
+        .init(command: "docs", summary: "Display CLI documentation", scope: .global, risk: .readOnly, coverage: .cliOnly, workflow: nil),
+        .init(command: "changelog", summary: "Inspect generated changelog data", scope: .component, risk: .readOnly, coverage: .cliOnly, workflow: nil),
+        .init(command: "git", summary: "Run git workflows for components", scope: .component, risk: .mutating, coverage: .readOnly, workflow: .git),
+        .init(command: "issues", summary: "Reconcile findings with issue trackers", scope: .component, risk: .guardedWrites, coverage: .cliOnly, workflow: nil),
+        .init(command: "version", summary: "Inspect or plan component versions", scope: .component, risk: .guardedWrites, coverage: .workflow, workflow: .release),
+        .init(command: "build", summary: "Build a component", scope: .component, risk: .readOnly, coverage: .workflow, workflow: .release),
+        .init(command: "changes", summary: "Show changes since the release baseline", scope: .component, risk: .readOnly, coverage: .workflow, workflow: .release),
+        .init(command: "release", summary: "Plan or run release workflows", scope: .component, risk: .mutating, coverage: .readOnly, workflow: .release),
+        .init(command: "review", summary: "Run scoped audit/lint/test review", scope: .component, risk: .readOnly, coverage: .workflow, workflow: .quality),
+        .init(command: "audit", summary: "Detect architectural drift", scope: .component, risk: .readOnly, coverage: .workflow, workflow: .quality),
+        .init(command: "refactor", summary: "Run structural refactoring helpers", scope: .component, risk: .mutating, coverage: .partial, workflow: nil),
+        .init(command: "rig", summary: "Manage reproducible local dev environments", scope: .rig, risk: .mutating, coverage: .workflow, workflow: .rigs),
+        .init(command: "runs", summary: "Inspect persisted run history and artifacts", scope: .global, risk: .readOnly, coverage: .workflow, workflow: .runHistory),
+        .init(command: "self", summary: "Inspect the active Homeboy binary", scope: .global, risk: .readOnly, coverage: .cliOnly, workflow: nil),
+        .init(command: "stack", summary: "Manage combined-fixes branch stacks", scope: .stack, risk: .mutating, coverage: .readOnly, workflow: .stackManager),
+        .init(command: "undo", summary: "Undo recent Homeboy write operations", scope: .global, risk: .mutating, coverage: .partial, workflow: nil),
+        .init(command: "auth", summary: "Authenticate with a project API", scope: .project, risk: .guardedWrites, coverage: .workflow, workflow: .apiAuth),
+        .init(command: "api", summary: "Make API requests to a project", scope: .project, risk: .guardedWrites, coverage: .readOnly, workflow: .apiAuth),
+        .init(command: "upgrade", summary: "Upgrade Homeboy CLI", scope: .global, risk: .mutating, coverage: .workflow, workflow: .settings),
+        .init(command: "list", summary: "List available commands", scope: .global, risk: .readOnly, coverage: .cliOnly, workflow: nil),
+        .init(command: "cargo", summary: "Run Cargo through Homeboy", scope: .component, risk: .operatorOnly, coverage: .cliOnly, workflow: nil),
+        .init(command: "wp", summary: "Run WP-CLI against WordPress targets", scope: .project, risk: .operatorOnly, coverage: .cliOnly, workflow: nil)
+    ]
+}
+
+struct CommandBrowserView: View {
+    @StateObject private var viewModel = CommandBrowserViewModel()
+    @State private var selectedCommandID: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+
+            HSplitView {
+                commandList
+                    .frame(minWidth: 300, idealWidth: 360, maxWidth: 440)
+                commandDetail
+                    .frame(minWidth: 620)
+            }
+        }
+        .frame(minWidth: 960, minHeight: 640)
+        .onAppear {
+            selectedCommandID = viewModel.selectedCommand?.id
+            viewModel.loadInitialHelp()
+        }
+        .onChange(of: selectedCommandID) { _, newValue in
+            guard let newValue,
+                  let command = viewModel.commands.first(where: { $0.id == newValue }) else { return }
+            viewModel.select(command)
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Commands")
+                    .font(.title2.bold())
+                Text("GUI wrapper for the Homeboy CLI command surface")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            if viewModel.isLoadingHelp || viewModel.isRunning {
+                ProgressView()
+                    .controlSize(.small)
+            }
+        }
+        .padding()
+    }
+
+    private var commandList: some View {
+        VStack(spacing: 0) {
+            TextField("Filter commands", text: $viewModel.filter)
+                .textFieldStyle(.roundedBorder)
+                .padding()
+
+            List(selection: $selectedCommandID) {
+                ForEach(viewModel.filteredCommands) { command in
+                    CommandRow(command: command)
+                        .tag(command.id)
+                }
+            }
+            .listStyle(.sidebar)
+        }
+    }
+
+    private var commandDetail: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                if let command = viewModel.selectedCommand {
+                    commandHeader(command)
+
+                    if let error = viewModel.error {
+                        InlineErrorView(error)
+                    }
+
+                    commandRunner(command)
+                    helpSection
+                    outputSection
+                } else {
+                    ContentUnavailableView(
+                        "Select a Command",
+                        systemImage: "terminal",
+                        description: Text("Choose a Homeboy CLI command to inspect its help and run explicit invocations.")
+                    )
+                }
+            }
+            .padding()
+        }
+    }
+
+    private func commandHeader(_ command: CommandBrowserEntry) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(command.invocation)
+                .font(.largeTitle.bold().monospaced())
+                .textSelection(.enabled)
+            Text(command.summary)
+                .foregroundColor(.secondary)
+            HStack(spacing: 8) {
+                badge(command.scope.rawValue, color: .blue)
+                badge(command.risk.rawValue, color: riskColor(command.risk))
+                badge(command.coverage.rawValue, color: coverageColor(command.coverage))
+            }
+        }
+    }
+
+    private func commandRunner(_ command: CommandBrowserEntry) -> some View {
+        GroupBox("Invocation") {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Edit the exact CLI command before running. Existing workflow tabs remain the safer path for guided operations.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                TextField("homeboy ...", text: $viewModel.commandInput)
+                    .font(.system(.body, design: .monospaced))
+                    .textFieldStyle(.roundedBorder)
+
+                HStack {
+                    Button {
+                        viewModel.commandInput = command.invocation + " --help"
+                        viewModel.loadHelp(for: command)
+                    } label: {
+                        Label("Load Help", systemImage: "questionmark.circle")
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button {
+                        viewModel.copyCurrentCommand()
+                    } label: {
+                        Label("Copy", systemImage: "doc.on.doc")
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button {
+                        viewModel.runCommandInput()
+                    } label: {
+                        Label("Run", systemImage: "play.fill")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(viewModel.isRunning)
+
+                    Spacer()
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var helpSection: some View {
+        GroupBox("CLI Help") {
+            if viewModel.helpOutput.isEmpty {
+                Text("Help output will appear here.")
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                CopyableTextView(console: viewModel.helpOutput, source: "Commands", maxHeight: 260)
+            }
+        }
+    }
+
+    private var outputSection: some View {
+        GroupBox("Run Output") {
+            if viewModel.runOutput.isEmpty {
+                Text("Run output will appear here.")
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                CopyableTextView(console: viewModel.runOutput, source: "Commands", maxHeight: 320)
+            }
+        }
+    }
+
+    private func badge(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(.caption.bold())
+            .foregroundColor(color)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(color.opacity(0.12))
+            .cornerRadius(6)
+    }
+
+    private func riskColor(_ risk: CommandBrowserEntry.Risk) -> Color {
+        switch risk {
+        case .readOnly: return .green
+        case .guardedWrites: return .orange
+        case .mutating: return .red
+        case .operatorOnly: return .purple
+        }
+    }
+
+    private func coverageColor(_ coverage: CommandBrowserEntry.DesktopCoverage) -> Color {
+        switch coverage {
+        case .workflow: return .green
+        case .partial: return .orange
+        case .readOnly: return .blue
+        case .cliOnly: return .secondary
+        }
+    }
+}
+
+private struct CommandRow: View {
+    let command: CommandBrowserEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(command.command)
+                    .font(.headline.monospaced())
+                Spacer()
+                Text(command.coverage.rawValue)
+                    .font(.caption2.bold())
+                    .foregroundColor(.secondary)
+            }
+
+            Text(command.summary)
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .lineLimit(2)
+
+            HStack(spacing: 8) {
+                Text(command.scope.rawValue)
+                Text(command.risk.rawValue)
+            }
+            .font(.caption2)
+            .foregroundColor(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+#Preview {
+    CommandBrowserView()
+}

--- a/docs/CLI-PARITY.md
+++ b/docs/CLI-PARITY.md
@@ -1,6 +1,10 @@
 # Homeboy CLI Parity Matrix
 
 This matrix maps the current `homeboy` CLI command surface to Homeboy Desktop support.
+Desktop now has two layers of CLI parity:
+
+- **Guided workflow UI** for common command families with safer forms, previews, and focused output.
+- **Command Browser** for full command-surface discoverability, help output, copyable invocations, and explicit raw CLI execution.
 
 Source of truth checked for this pass: `homeboy --help` plus focused help for the workspace commands from the installed CLI on 2026-04-27, and the current desktop `main` branch.
 
@@ -10,7 +14,7 @@ Source of truth checked for this pass: `homeboy --help` plus focused help for th
 - **read-only UI**: the desktop app exposes inspection/status output only; mutating commands stay in the CLI.
 - **partial/stale**: a desktop surface exists, but some wrappers or models still need cleanup.
 - **intentionally CLI-only**: the command is terminal/operator-shaped and should not get desktop UI without a stronger product need.
-- **missing workflow**: no meaningful desktop surface exists yet.
+- **missing workflow**: no guided workflow exists yet; use the Command Browser or CLI for the raw command.
 
 ## Matrix
 
@@ -26,7 +30,7 @@ Source of truth checked for this pass: `homeboy --help` plus focused help for th
 | `homeboy file` | supported first-pass UI | Remote file editor in `Homeboy/Extensions/RemoteFileEditor/`; file wrappers in `Homeboy/Core/CLI/HomeboyCLI+WorkspaceCommands.swift`. | Core list/read/write/delete/rename/search workflows exist. Keep destructive operations guarded. | Matrix only |
 | `homeboy fleet` | partial/stale | Fleet relationships in settings/config models and `FleetManagementView`. | Basic configuration exists; fleet status/check/exec style operations are still CLI-shaped unless a dashboard is designed. | Matrix only |
 | `homeboy logs` | supported first-pass UI | Remote log viewer in `Homeboy/Extensions/RemoteLogViewer/`; log wrappers in `Homeboy/Core/CLI/HomeboyCLI+WorkspaceCommands.swift`. | Core log viewing/search exists. Pinning remains scoped to log/file workflows. | Matrix only |
-| `homeboy transfer` | missing workflow | No dedicated transfer workflow. | Keep out of File Editor for now. If needed, add a focused local/server transfer sheet with dry-run output. | Matrix only |
+| `homeboy transfer` | missing workflow | No dedicated transfer workflow. | Keep out of File Editor for now. If the command returns to the installed CLI surface, Command Browser will expose it from `homeboy --help`. | Matrix only |
 | `homeboy triage` | supported first-pass UI | Quality workspace `Run Triage` action; `qualityTriage()` wrapper. | `triage component` is surfaced. Project/fleet/rig/workspace triage plus filters (`--mine`, labels, failing checks, drilldown) remain CLI-only. | Matrix only |
 | `homeboy deploy` | supported first-pass UI | Deployer tool in `Homeboy/Extensions/Deployer/`. | Deploy remains its own guarded write workflow. Release/build planning is now separate from deployment. | Matrix only |
 | `homeboy component` | supported first-pass UI | Component settings UI and models; wrappers in `Homeboy/Core/CLI/HomeboyCLI+WorkspaceCommands.swift`. | Usable for normal component config. Bulk/JSON-pointer style edits stay CLI-only. | Matrix only |
@@ -37,7 +41,7 @@ Source of truth checked for this pass: `homeboy --help` plus focused help for th
 | `homeboy docs` | intentionally CLI-only | Static docs live under `docs/`; no in-app docs browser. | Keep command docs in CLI/browser docs. Contextual help panes can be added later without wrapping `homeboy docs`. | Matrix only |
 | `homeboy changelog` | intentionally CLI-only | No changelog UI. | Changelog generation/inspection stays CLI-only. Release planning can link to `changes`/`release --dry-run` output instead. | Matrix only |
 | `homeboy git` | read-only UI | Git workspace in `Homeboy/Extensions/GitOperations/`; `gitStatus()` wrapper plus GitHub issue/PR navigation. | Read-only `git status` is supported. `commit`, `push`, `pull`, `rebase`, `cherry-pick`, `tag`, `issue`, and `pr` writes stay CLI-only until confirmation UX exists. | Matrix only |
-| `homeboy issues` | missing workflow | No issue reconciliation UI. | Could belong in Quality or Git/GitHub later. No active desktop tracker until the workflow is designed. | Matrix only |
+| `homeboy issues` | missing workflow | Command Browser exposes the raw command surface; no issue reconciliation workflow. | Could belong in Quality or Git/GitHub later. No active desktop tracker until the workflow is designed. | Matrix only |
 | `homeboy version` | supported first-pass UI | Release workspace reads `version show` in `ReleaseWorkflowViewModel`. | Read-only version inspection is supported. `version bump` aliases release execution and remains CLI-only. | Matrix only |
 | `homeboy build` | supported first-pass UI | Release workspace `Build` action calls `homeboy build`; deployer still has deployment-specific build handling. | Component build is supported from release planning. Bulk/project build modes remain CLI-only. | Matrix only |
 | `homeboy validate` | supported first-pass UI | Quality workspace validation stage. | Direct non-mutating validation is supported. No advanced workflow beyond component/path selection. | Matrix only |
@@ -62,6 +66,7 @@ The workspace PR wave closed the old missing-workflow trackers for Bench, Rigs, 
 
 | Area | Shipped desktop surface | Intentional boundary |
 |---|---|---|
+| Commands | `CommandBrowserView` lists the CLI command catalog, shows command help, copies invocations, and runs explicit `homeboy ...` commands through the CLI bridge. | Guided workflow tabs remain the safer path for common operations; Command Browser is the escape hatch for raw CLI parity. |
 | Bench | `BenchView` lists scenarios and runs benchmarks. | Baseline/ratchet, rig comparison, multi-run/concurrency, and settings overrides remain CLI-only. |
 | Rigs | `RigsView` lists specs, shows status/check output, and confirms `up`/`down`. | Rig package install/update, sources management, stack sync, and app launcher lifecycle remain CLI-only. |
 | Stacks | `StackManagerView` lists specs, shows status, and runs read-only inspection. | Stack mutation/materialization commands remain CLI-only. |
@@ -72,9 +77,9 @@ The workspace PR wave closed the old missing-workflow trackers for Bench, Rigs, 
 
 ## Still-Missing Desktop Workflows
 
-- `homeboy transfer` has no desktop workflow.
-- `homeboy issues` has no desktop workflow.
-- `homeboy undo` has wrappers but no visible workflow.
+- `homeboy transfer` has no guided desktop workflow.
+- `homeboy issues` has no guided desktop workflow beyond the Command Browser.
+- `homeboy undo` has wrappers and Command Browser access, but no workflow-owned undo surface.
 - Advanced stack/rig/bench/release/git/API mutation flows are intentionally CLI-only until the app has specific confirmation UX for each risk profile.
 
 ## Upstream Audit Detector False-Positive History


### PR DESCRIPTION
## Summary
- Add a new Commands workspace that exposes the Homeboy CLI command surface from Desktop.
- Parse `homeboy --help` to keep the command list aligned with the installed CLI, while annotating known commands with scope, risk, coverage, and related workflow tabs.
- Let users inspect command help, copy invocations, and explicitly run `homeboy ...` commands through the existing CLI bridge.
- Update the CLI parity doc to distinguish guided workflow UI from raw command-browser parity.

## Testing
- `DEVELOPER_DIR=\"/Applications/Xcode.app/Contents/Developer\" xcodebuild -project Homeboy.xcodeproj -scheme Homeboy -configuration Debug -derivedDataPath .build/DerivedData build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Command Browser UI, CLI help parsing, navigation integration, docs update, and build verification for Chris to review.