### PR TITLE
Refactor log viewer CLI contracts

### DIFF
--- a/Homeboy.xcodeproj/project.pbxproj
+++ b/Homeboy.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		5CEF2659D6426FC7150A96C7 /* QualityModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F58D23C61F57585387766D /* QualityModels.swift */; };
 		6058DC822E13A3B7C56C64BF /* ExtensionSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B16E4FF8E5939CE6EF12EFA2 /* ExtensionSetupView.swift */; };
 		61876E7ACDA5C3D7A5D2E40F /* AppPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C840B787B398287BC5EEE6 /* AppPaths.swift */; };
+		64D23F8D70421EFD7A51BEF2 /* RemoteLogModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A497C117547FCCCA5F2408D /* RemoteLogModels.swift */; };
 		6861D39F7EB9C8E226731A6A /* HomeboyCLI+StackCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7F7ED4B0D0B46D19BF8438 /* HomeboyCLI+StackCommands.swift */; };
 		6D35EC810ADF631740FCC1B4 /* DatabaseBrowserViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0202298D08128098B45807E /* DatabaseBrowserViewModel.swift */; };
 		71419F89166E98CC7C4A3A98 /* SSHService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD23DCF3987518BDD613AA7A /* SSHService.swift */; };
@@ -92,6 +93,7 @@
 		A34392C1F77DDF4B0B386D8C /* DataTableConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = F915FEEAF97ADD6EAADF6E4A /* DataTableConstants.swift */; };
 		A387D3BAF65EFBE5A44AA37C /* CommandBrowserEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0075D42A490CE7EF713A874F /* CommandBrowserEntry.swift */; };
 		A40B645FCF64C59E6F1EC4FC /* HomeboyCLI+QualityCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC23AFFAB50FD8AFD042E644 /* HomeboyCLI+QualityCommands.swift */; };
+		A744C6D0692C0EF9B142E839 /* HomeboyCLI+LogCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CB4FFA7533765478562751F /* HomeboyCLI+LogCommands.swift */; };
 		A79AD1D6F7DD14F02410D120 /* LogTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670327C19CE0F089CFF35DD1 /* LogTextView.swift */; };
 		AB378FCB8518F6BED6EEFB6F /* DisplayableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C195A8A1462489E882BC187 /* DisplayableError.swift */; };
 		B1BC5D62A38657148E674B80 /* ExtensionConsoleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC2128B1137A2702EEC2F55 /* ExtensionConsoleView.swift */; };
@@ -146,6 +148,7 @@
 		33EA4198F67B489E4433A378 /* TableDataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableDataView.swift; sourceTree = "<group>"; };
 		35595CC7BEFD826A8FE56039 /* RigsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RigsViewModel.swift; sourceTree = "<group>"; };
 		385944CD36C9E1B61CE23EDE /* FindableTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindableTextView.swift; sourceTree = "<group>"; };
+		3A497C117547FCCCA5F2408D /* RemoteLogModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteLogModels.swift; sourceTree = "<group>"; };
 		3A6FE3DEAD139D529B6724D8 /* APITypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITypes.swift; sourceTree = "<group>"; };
 		3A80F92FC849ACD9591EDEFE /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		3AC2128B1137A2702EEC2F55 /* ExtensionConsoleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionConsoleView.swift; sourceTree = "<group>"; };
@@ -190,6 +193,7 @@
 		95BEB3F1E5A208F98850D372 /* RigsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RigsView.swift; sourceTree = "<group>"; };
 		99F53066BAD2365203BC1A21 /* DatabaseSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseSettingsTab.swift; sourceTree = "<group>"; };
 		9BAE7C655CF0B3F2D679B188 /* ConfigurationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationManager.swift; sourceTree = "<group>"; };
+		9CB4FFA7533765478562751F /* HomeboyCLI+LogCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+LogCommands.swift"; sourceTree = "<group>"; };
 		A087DAB3F4E912476EC93E01 /* HomeboyCLI+WorkspaceCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+WorkspaceCommands.swift"; sourceTree = "<group>"; };
 		A1FDE17265BB36CD42258798 /* ConsoleOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleOutput.swift; sourceTree = "<group>"; };
 		A2800F57FE83EEBB76CC1F1A /* NativeDataTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeDataTable.swift; sourceTree = "<group>"; };
@@ -327,6 +331,7 @@
 			isa = PBXGroup;
 			children = (
 				0075D42A490CE7EF713A874F /* CommandBrowserEntry.swift */,
+				3A497C117547FCCCA5F2408D /* RemoteLogModels.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -417,6 +422,7 @@
 				D870E69E9C29278BC862CD04 /* HomeboyCLI.swift */,
 				C3B52F387CC902FB445FC922 /* HomeboyCLI+CommandBrowserCommands.swift */,
 				4B800E302E25370AFEB2EAA7 /* HomeboyCLI+FileDatabaseCommands.swift */,
+				9CB4FFA7533765478562751F /* HomeboyCLI+LogCommands.swift */,
 				BC23AFFAB50FD8AFD042E644 /* HomeboyCLI+QualityCommands.swift */,
 				0DD2E86E7655D2ED45CB0E31 /* HomeboyCLI+RigBenchReleaseCommands.swift */,
 				BFAF5103FCB24063514E519F /* HomeboyCLI+RunCommands.swift */,
@@ -828,6 +834,7 @@
 				57C3AE0D20A591DEE69B0FF0 /* HomeboyApp.swift in Sources */,
 				D5421FF656190A21F439C40A /* HomeboyCLI+CommandBrowserCommands.swift in Sources */,
 				7B4A55712A56BDD9EE21F504 /* HomeboyCLI+FileDatabaseCommands.swift in Sources */,
+				A744C6D0692C0EF9B142E839 /* HomeboyCLI+LogCommands.swift in Sources */,
 				A40B645FCF64C59E6F1EC4FC /* HomeboyCLI+QualityCommands.swift in Sources */,
 				46238C2E19607D4410D23FA2 /* HomeboyCLI+RigBenchReleaseCommands.swift in Sources */,
 				19F0A3B40B6B6BA59A201C7F /* HomeboyCLI+RunCommands.swift in Sources */,
@@ -855,6 +862,7 @@
 				1AEFFA5D377D403DDA560237 /* RemoteFileEditorView.swift in Sources */,
 				79F089B7341476178AB41022 /* RemoteFileEditorViewModel.swift in Sources */,
 				72D058E4C987B44B3C2FE75F /* RemoteFileEntry.swift in Sources */,
+				64D23F8D70421EFD7A51BEF2 /* RemoteLogModels.swift in Sources */,
 				339E905F86E47CF88C0386B8 /* RemoteLogViewerView.swift in Sources */,
 				180E9CC06D913B4F8B55A58A /* RemoteLogViewerViewModel.swift in Sources */,
 				C24FBE4BE4FE4BA046D565C3 /* RemotePathResolver+WordPress.swift in Sources */,

--- a/Homeboy/Core/CLI/HomeboyCLI+FileDatabaseCommands.swift
+++ b/Homeboy/Core/CLI/HomeboyCLI+FileDatabaseCommands.swift
@@ -52,30 +52,6 @@ extension HomeboyCLI {
         )
     }
 
-    func logsList(projectId: String) async throws -> LogsOutput {
-        try await cli.executeCommand(
-            ["logs", "list", projectId],
-            dataType: LogsOutput.self,
-            source: "Logs List"
-        )
-    }
-
-    func logsShow(projectId: String, path: String, lines: Int?) async throws -> LogsOutput {
-        var args = ["logs", "show", projectId, path]
-        if let lines {
-            args.append(contentsOf: ["-n", String(lines)])
-        }
-        return try await cli.executeCommand(args, dataType: LogsOutput.self, source: "Logs Show")
-    }
-
-    func logsClear(projectId: String, path: String) async throws -> LogsOutput {
-        try await cli.executeCommand(
-            ["logs", "clear", projectId, path],
-            dataType: LogsOutput.self,
-            source: "Logs Clear"
-        )
-    }
-
     func sshCommand(projectId: String, command: String) async throws -> CLIBridgeResponse {
         try await cli.execute(["ssh", projectId, command], timeout: 30)
     }
@@ -204,29 +180,6 @@ extension HomeboyCLI {
             args.append("-i")
         }
         return try await cli.executeCommand(args, dataType: FileGrepOutput.self, source: "File Grep", timeout: 60)
-    }
-
-    // MARK: - Logs Search
-
-    func logsSearch(
-        projectId: String,
-        path: String,
-        pattern: String,
-        caseInsensitive: Bool = false,
-        lines: Int? = nil,
-        context: Int? = nil
-    ) async throws -> LogsOutput {
-        var args = ["logs", "search", projectId, path, pattern]
-        if caseInsensitive {
-            args.append("-i")
-        }
-        if let lines {
-            args.append(contentsOf: ["-n", String(lines)])
-        }
-        if let context {
-            args.append(contentsOf: ["-C", String(context)])
-        }
-        return try await cli.executeCommand(args, dataType: LogsOutput.self, source: "Logs Search", timeout: 60)
     }
 
 }

--- a/Homeboy/Core/CLI/HomeboyCLI+LogCommands.swift
+++ b/Homeboy/Core/CLI/HomeboyCLI+LogCommands.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+@MainActor
+extension HomeboyCLI {
+    func logsList(projectId: String) async throws -> LogsOutput {
+        try await cli.executeCommand(
+            ["logs", "list", projectId],
+            dataType: LogsOutput.self,
+            source: "Logs List"
+        )
+    }
+
+    func logsShow(projectId: String, path: String, lines: Int) async throws -> LogsOutput {
+        try await cli.executeCommand(
+            ["logs", "show", projectId, path, "-n", String(lines)],
+            dataType: LogsOutput.self,
+            source: "Logs Show"
+        )
+    }
+
+    func logsClear(projectId: String, path: String) async throws -> LogsOutput {
+        try await cli.executeCommand(
+            ["logs", "clear", projectId, path],
+            dataType: LogsOutput.self,
+            source: "Logs Clear"
+        )
+    }
+
+    func logsSearch(
+        projectId: String,
+        path: String,
+        pattern: String,
+        caseInsensitive: Bool = false,
+        lines: Int? = nil,
+        context: Int? = nil
+    ) async throws -> LogsOutput {
+        var args = ["logs", "search", projectId, path, pattern]
+        if caseInsensitive {
+            args.append("-i")
+        }
+        if let lines {
+            args.append(contentsOf: ["-n", String(lines)])
+        }
+        if let context {
+            args.append(contentsOf: ["-C", String(context)])
+        }
+        return try await cli.executeCommand(args, dataType: LogsOutput.self, source: "Logs Search", timeout: 60)
+    }
+
+    func logPinAdd(projectId: String, path: String, tailLines: Int) async throws -> ProjectPinOutput {
+        try await projectPin(
+            ["project", "pin", "add", "--type", "log", "--tail", String(tailLines), projectId, path],
+            source: "Log Pin Add"
+        )
+    }
+
+    func logPinRemove(projectId: String, path: String) async throws -> ProjectPinOutput {
+        try await projectPin(
+            ["project", "pin", "remove", projectId, path, "--type", "log"],
+            source: "Log Pin Remove"
+        )
+    }
+
+    func logPinUpdateTail(projectId: String, path: String, tailLines: Int, previousTailLines: Int) async throws -> ProjectPinOutput {
+        _ = try await logPinRemove(projectId: projectId, path: path)
+        do {
+            return try await logPinAdd(projectId: projectId, path: path, tailLines: tailLines)
+        } catch {
+            _ = try? await logPinAdd(projectId: projectId, path: path, tailLines: previousTailLines)
+            throw error
+        }
+    }
+
+    private func projectPin(_ args: [String], source: String) async throws -> ProjectPinOutput {
+        let output: ProjectPinReportOutput = try await cli.executeCommand(
+            args,
+            dataType: ProjectPinReportOutput.self,
+            source: source
+        )
+        guard let pin = output.pin else {
+            throw CLIBridgeError.invalidResponse("\(source) response missing pin payload")
+        }
+        return pin
+    }
+}

--- a/Homeboy/Core/CLI/HomeboyCLIModels.swift
+++ b/Homeboy/Core/CLI/HomeboyCLIModels.swift
@@ -248,6 +248,33 @@ struct LogsOutput: Decodable {
     let searchResult: LogSearchResult?
 }
 
+struct ProjectPinReportOutput: Decodable {
+    let command: String
+    let id: String?
+    let pin: ProjectPinOutput?
+}
+
+struct ProjectPinOutput: Decodable {
+    let action: String
+    let projectId: String
+    let type: String
+    let items: [ProjectPinListItem]?
+    let added: ProjectPinChange?
+    let removed: ProjectPinChange?
+}
+
+struct ProjectPinListItem: Decodable {
+    let path: String
+    let label: String?
+    let displayName: String
+    let tailLines: Int?
+}
+
+struct ProjectPinChange: Decodable {
+    let path: String
+    let type: String
+}
+
 // MARK: - File Search Types
 
 struct FileFindOutput: Decodable {

--- a/Homeboy/Extensions/RemoteLogViewer/RemoteLogViewerViewModel.swift
+++ b/Homeboy/Extensions/RemoteLogViewer/RemoteLogViewerViewModel.swift
@@ -1,52 +1,6 @@
 import AppKit
 import Combine
 import Foundation
-import SwiftUI
-
-/// Represents an open log tab in the Remote Log Viewer
-struct OpenLog: PinnableTabItem, Equatable {
-    let id: UUID
-    let path: String           // Relative path from basePath
-    var isPinned: Bool
-    var content: String = ""
-    var fileExists: Bool = true
-    var lastFetched: Date?
-    var tailLines: Int
-
-    var displayName: String {
-        URL(fileURLWithPath: path).lastPathComponent
-    }
-
-    init(id: UUID = UUID(), path: String, isPinned: Bool, tailLines: Int = 100) {
-        self.id = id
-        self.path = path
-        self.isPinned = isPinned
-        self.tailLines = tailLines
-    }
-
-    init(from pinned: PinnedRemoteLog) {
-        self.id = pinned.id
-        self.path = pinned.path
-        self.isPinned = true
-        self.tailLines = pinned.tailLines
-    }
-}
-
-// MARK: - CLI Response Types
-
-/// Response from `logs list --json`
-private struct LogsListResponse: Decodable {
-    let label: String
-    let path: String
-    let tailLines: Int
-}
-
-/// Response from `logs clear --json`
-private struct LogsClearResponse: Decodable {
-    let success: Bool
-    let path: String
-    let label: String
-}
 
 @MainActor
 class RemoteLogViewerViewModel: ObservableObject, ConfigurationObserving {
@@ -63,7 +17,7 @@ class RemoteLogViewerViewModel: ObservableObject, ConfigurationObserving {
 
     // MARK: - CLI Bridge
 
-    private let cli = CLIBridge.shared
+    private let cli = HomeboyCLI.shared
 
     private var projectId: String {
         ConfigurationManager.shared.safeActiveProject.id
@@ -71,7 +25,7 @@ class RemoteLogViewerViewModel: ObservableObject, ConfigurationObserving {
 
     // MARK: - Tail Options
 
-    static let tailOptions = [50, 100, 500, 1000, 0]  // 0 = All
+    static let tailOptions = [50, 100, 500, 1000]
 
     // MARK: - Computed Properties
 
@@ -102,11 +56,7 @@ class RemoteLogViewerViewModel: ObservableObject, ConfigurationObserving {
             selectedLogId = nil
             error = nil
             loadPinnedLogs()
-            if selectedLogId != nil {
-                Task {
-                    await fetchSelectedLog()
-                }
-            }
+            Task { await fetchSelectedLog() }
         case .projectModified(_, let fields):
             // Reload pinned logs if remoteLogs changed
             if fields.contains(.remoteLogs) {
@@ -139,30 +89,33 @@ class RemoteLogViewerViewModel: ObservableObject, ConfigurationObserving {
         }
 
         isLoading = true
+        defer { isLoading = false }
         error = nil
 
         let log = openLogs[index]
 
         do {
-            let output = try await HomeboyCLI.shared.logsShow(
+            let output = try await cli.logsShow(
                 projectId: projectId,
                 path: log.path,
-                lines: log.tailLines > 0 ? log.tailLines : nil
+                lines: log.tailLines
             )
 
+            guard let currentIndex = openLogs.firstIndex(where: { $0.id == log.id }) else { return }
             if let logData = output.log {
-                openLogs[index].content = logData.content
-                openLogs[index].fileExists = true
-                openLogs[index].lastFetched = Date()
+                openLogs[currentIndex].content = logData.content
+                openLogs[currentIndex].fileExists = true
+                openLogs[currentIndex].lastFetched = Date()
             } else {
-                openLogs[index].fileExists = false
-                openLogs[index].content = ""
+                openLogs[currentIndex].fileExists = false
+                openLogs[currentIndex].content = ""
             }
         } catch let cliError as CLIBridgeError {
+            guard let currentIndex = openLogs.firstIndex(where: { $0.id == log.id }) else { return }
             if let structuredError = cliError.cliError,
                structuredError.code == "file_not_found" {
-                openLogs[index].fileExists = false
-                openLogs[index].content = ""
+                openLogs[currentIndex].fileExists = false
+                openLogs[currentIndex].content = ""
             } else {
                 self.error = cliError.cliError ?? AppError(cliError.localizedDescription, source: "Log Viewer", path: log.displayName)
             }
@@ -170,7 +123,6 @@ class RemoteLogViewerViewModel: ObservableObject, ConfigurationObserving {
             self.error = error.toDisplayableError(source: "Log Viewer", path: log.displayName)
         }
 
-        isLoading = false
     }
 
     /// Clears the currently selected log file via CLI
@@ -182,19 +134,20 @@ class RemoteLogViewerViewModel: ObservableObject, ConfigurationObserving {
         }
 
         isLoading = true
+        defer { isLoading = false }
         error = nil
 
         let log = openLogs[index]
 
         do {
-            _ = try await HomeboyCLI.shared.logsClear(projectId: projectId, path: log.path)
-            openLogs[index].content = ""
-            openLogs[index].lastFetched = Date()
+            _ = try await cli.logsClear(projectId: projectId, path: log.path)
+            guard let currentIndex = openLogs.firstIndex(where: { $0.id == log.id }) else { return }
+            openLogs[currentIndex].content = ""
+            openLogs[currentIndex].lastFetched = Date()
         } catch {
             self.error = error.toDisplayableError(source: "Log Viewer", path: log.displayName)
         }
 
-        isLoading = false
     }
     
     // MARK: - Tab Management
@@ -236,10 +189,15 @@ class RemoteLogViewerViewModel: ObservableObject, ConfigurationObserving {
         guard let index = openLogs.firstIndex(where: { $0.id == id }) else { return }
         
         let log = openLogs[index]
-        
-        // If pinned, unpin first
+
         if log.isPinned {
-            unpinLog(id)
+            Task {
+                do {
+                    try await unpinLog(path: log.path)
+                } catch {
+                    self.error = AppError("Failed to unpin log: \(error.localizedDescription)", source: "Log Viewer")
+                }
+            }
         }
         
         openLogs.remove(at: index)
@@ -255,36 +213,25 @@ class RemoteLogViewerViewModel: ObservableObject, ConfigurationObserving {
     /// Updates tail lines for the selected log
     func setTailLines(_ lines: Int) {
         guard let index = selectedLogIndex else { return }
+        let tailLines = max(1, lines)
         let oldLines = openLogs[index].tailLines
-        openLogs[index].tailLines = lines
+        openLogs[index].tailLines = tailLines
 
         // If pinned, update config via CLI (remove and re-add with new tail lines)
         if openLogs[index].isPinned && cli.isInstalled {
             let log = openLogs[index]
             Task {
                 do {
-                    // Remove old pin
-                    let removeArgs = ["project", "pin", "remove", projectId, log.path, "--type", "log"]
-                    let removeResponse = try await cli.execute(removeArgs, timeout: 30)
-
-                    if removeResponse.success {
-                        // Re-add with new tail lines
-                        let addArgs = ["project", "pin", "add", "--type", "log", "--tail", String(lines), projectId, log.path]
-                        let addResponse = try await cli.execute(addArgs, timeout: 30)
-
-                        if !addResponse.success {
-                            // Rollback local state
-                            openLogs[index].tailLines = oldLines
-                            self.error = AppError("Failed to update tail lines: \(addResponse.errorOutput)", source: "Log Viewer")
-                        }
-                    } else {
-                        // Rollback local state
-                        openLogs[index].tailLines = oldLines
-                        self.error = AppError("Failed to update tail lines: \(removeResponse.errorOutput)", source: "Log Viewer")
-                    }
+                    _ = try await cli.logPinUpdateTail(
+                        projectId: projectId,
+                        path: log.path,
+                        tailLines: tailLines,
+                        previousTailLines: oldLines
+                    )
                 } catch {
-                    // Rollback local state
-                    openLogs[index].tailLines = oldLines
+                    if let currentIndex = openLogs.firstIndex(where: { $0.id == log.id }) {
+                        openLogs[currentIndex].tailLines = oldLines
+                    }
                     self.error = AppError("Failed to update tail lines: \(error.localizedDescription)", source: "Log Viewer")
                 }
             }
@@ -310,14 +257,9 @@ class RemoteLogViewerViewModel: ObservableObject, ConfigurationObserving {
 
         Task {
             do {
-                // homeboy project pin add --type log --tail <lines> <project> <path>
-                let args = ["project", "pin", "add", "--type", "log", "--tail", String(log.tailLines), projectId, log.path]
-                let response = try await cli.execute(args, timeout: 30)
-
-                if response.success {
-                    openLogs[index].isPinned = true
-                } else {
-                    self.error = AppError("Failed to pin log: \(response.errorOutput)", source: "Log Viewer")
+                _ = try await cli.logPinAdd(projectId: projectId, path: log.path, tailLines: log.tailLines)
+                if let currentIndex = openLogs.firstIndex(where: { $0.id == log.id }) {
+                    openLogs[currentIndex].isPinned = true
                 }
             } catch {
                 self.error = AppError("Failed to pin log: \(error.localizedDescription)", source: "Log Viewer")
@@ -337,14 +279,9 @@ class RemoteLogViewerViewModel: ObservableObject, ConfigurationObserving {
 
         Task {
             do {
-                // homeboy project pin remove <project> <path> --type log --json
-                let args = ["project", "pin", "remove", projectId, log.path, "--type", "log"]
-                let response = try await cli.execute(args, timeout: 30)
-
-                if response.success {
-                    openLogs[index].isPinned = false
-                } else {
-                    self.error = AppError("Failed to unpin log: \(response.errorOutput)", source: "Log Viewer")
+                _ = try await unpinLog(path: log.path)
+                if let currentIndex = openLogs.firstIndex(where: { $0.id == log.id }) {
+                    openLogs[currentIndex].isPinned = false
                 }
             } catch {
                 self.error = AppError("Failed to unpin log: \(error.localizedDescription)", source: "Log Viewer")
@@ -359,6 +296,35 @@ class RemoteLogViewerViewModel: ObservableObject, ConfigurationObserving {
         guard let log = selectedLog else { return }
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(log.content, forType: .string)
+    }
+
+    func openLogFromBrowser(path: String) {
+        openLog(path: relativeLogPath(for: path))
+    }
+
+    private func unpinLog(path: String) async throws {
+        _ = try await cli.logPinRemove(projectId: projectId, path: path)
+    }
+
+    private func relativeLogPath(for path: String) -> String {
+        guard path.hasPrefix("/") else { return path }
+
+        guard let basePath = ConfigurationManager.shared.safeActiveProject.basePath,
+              !basePath.isEmpty else {
+            return path
+        }
+
+        let normalizedBase = URL(fileURLWithPath: basePath).standardizedFileURL.path
+        let normalizedPath = URL(fileURLWithPath: path).standardizedFileURL.path
+        guard normalizedPath == normalizedBase || normalizedPath.hasPrefix(normalizedBase + "/") else {
+            return path
+        }
+
+        if normalizedPath == normalizedBase {
+            return URL(fileURLWithPath: normalizedPath).lastPathComponent
+        }
+
+        return String(normalizedPath.dropFirst(normalizedBase.count + 1))
     }
     
     func lastFetchedFormatted(for log: OpenLog) -> String {

--- a/Homeboy/Extensions/RemoteLogViewer/Views/RemoteLogViewerView.swift
+++ b/Homeboy/Extensions/RemoteLogViewer/Views/RemoteLogViewerView.swift
@@ -38,12 +38,7 @@ struct RemoteLogViewerView: View {
     // MARK: - Open Log from Browser
     
     private func openLogFromBrowser(_ path: String) {
-        // Convert absolute path to relative from basePath
-        let basePath = ConfigurationManager.shared.safeActiveProject.basePath ?? ""
-        let relativePath = path.hasPrefix(basePath)
-            ? String(path.dropFirst(basePath.count + 1))
-            : path
-        viewModel.openLog(path: relativePath)
+        viewModel.openLogFromBrowser(path: path)
     }
     
     // MARK: - Log Viewer Content

--- a/Homeboy/Models/RemoteLogModels.swift
+++ b/Homeboy/Models/RemoteLogModels.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Represents an open log tab in the Remote Log Viewer.
+struct OpenLog: PinnableTabItem, Equatable {
+    let id: UUID
+    let path: String
+    var isPinned: Bool
+    var content: String = ""
+    var fileExists: Bool = true
+    var lastFetched: Date?
+    var tailLines: Int
+
+    var displayName: String {
+        URL(fileURLWithPath: path).lastPathComponent
+    }
+
+    init(id: UUID = UUID(), path: String, isPinned: Bool, tailLines: Int = 100) {
+        self.id = id
+        self.path = path
+        self.isPinned = isPinned
+        self.tailLines = max(1, tailLines)
+    }
+
+    init(from pinned: PinnedRemoteLog) {
+        self.id = pinned.id
+        self.path = pinned.path
+        self.isPinned = true
+        self.tailLines = max(1, pinned.tailLines)
+    }
+}

--- a/tests/FileLogDBContractTests.swift
+++ b/tests/FileLogDBContractTests.swift
@@ -74,29 +74,39 @@ func testRemoteLogViewerPinCommandShape(testDir: String) throws {
     print("Test: Remote Log Viewer pin command shape")
     print("-----------------------------------------")
 
-    let sourcePath = URL(fileURLWithPath: testDir)
+    let viewModelPath = URL(fileURLWithPath: testDir)
         .deletingLastPathComponent()
         .appendingPathComponent("Homeboy/Extensions/RemoteLogViewer/RemoteLogViewerViewModel.swift")
+    let cliPath = URL(fileURLWithPath: testDir)
+        .deletingLastPathComponent()
+        .appendingPathComponent("Homeboy/Core/CLI/HomeboyCLI+LogCommands.swift")
 
-    let source = try String(contentsOf: sourcePath, encoding: .utf8)
-    let currentPinCommand = #"["project", "pin", "add", "--type", "log", "--tail", String(log.tailLines), projectId, log.path]"#
-    let currentTailUpdateCommand = #"["project", "pin", "add", "--type", "log", "--tail", String(lines), projectId, log.path]"#
+    let viewModelSource = try String(contentsOf: viewModelPath, encoding: .utf8)
+    let cliSource = try String(contentsOf: cliPath, encoding: .utf8)
+    let currentPinCommand = #"["project", "pin", "add", "--type", "log", "--tail", String(tailLines), projectId, path]"#
+    let currentTailUpdateCommand = #"["project", "pin", "add", "--type", "log", "--tail", String(tailLines), projectId, path]"#
     let oldPositionalFirstCommand = #"["project", "pin", "add", projectId, log.path, "--type", "log", "--tail"#
 
-    guard source.contains(currentPinCommand) else {
+    guard cliSource.contains(currentPinCommand) else {
         throw NSError(domain: "ContractTest", code: 70,
-            userInfo: [NSLocalizedDescriptionKey: "RemoteLogViewer pin command does not use current homeboy project pin add syntax"])
+            userInfo: [NSLocalizedDescriptionKey: "Log CLI wrapper pin command does not use current homeboy project pin add syntax"])
     }
     print("[PASS] Pin command puts --type/--tail before project/path")
 
-    guard source.contains(currentTailUpdateCommand) else {
+    guard cliSource.contains(currentTailUpdateCommand) else {
         throw NSError(domain: "ContractTest", code: 71,
-            userInfo: [NSLocalizedDescriptionKey: "RemoteLogViewer tail update command does not preserve current pin syntax"])
+            userInfo: [NSLocalizedDescriptionKey: "Log CLI wrapper tail update command does not preserve current pin syntax"])
     }
     print("[PASS] Tail-line update command preserves --tail before project/path")
 
-    guard !source.contains(oldPositionalFirstCommand) else {
+    guard !viewModelSource.contains("[\"project\", \"pin\"") else {
         throw NSError(domain: "ContractTest", code: 72,
+            userInfo: [NSLocalizedDescriptionKey: "RemoteLogViewerViewModel still builds raw project pin commands instead of using HomeboyCLI wrappers"])
+    }
+    print("[PASS] View model uses typed HomeboyCLI log pin wrappers")
+
+    guard !cliSource.contains(oldPositionalFirstCommand) else {
+        throw NSError(domain: "ContractTest", code: 73,
             userInfo: [NSLocalizedDescriptionKey: "RemoteLogViewer still contains old positional-first project pin add syntax"])
     }
     print("[PASS] Old positional-first log pin syntax is absent")


### PR DESCRIPTION
## Summary
- Move Remote Log Viewer log/pin command construction into typed HomeboyCLI helpers.
- Move OpenLog into a shared model file and remove dead response types from the view model.
- Tighten log viewer async updates and contract tests around current log pin syntax.

## Testing
- `DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer" xcodegen generate --spec project.yml`
- `DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer" xcodebuild -project Homeboy.xcodeproj -scheme Homeboy -configuration Debug -derivedDataPath .build/DerivedData build`
- `swift tests/ContractTests.swift tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Refactored the log viewer CLI contract code, updated contract tests, and ran local verification. Chris reviewed and directed the PR creation.