### PR TITLE
Refactor file editor pin CLI contracts

### DIFF
--- a/Homeboy.xcodeproj/project.pbxproj
+++ b/Homeboy.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		A79AD1D6F7DD14F02410D120 /* LogTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670327C19CE0F089CFF35DD1 /* LogTextView.swift */; };
 		AB378FCB8518F6BED6EEFB6F /* DisplayableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C195A8A1462489E882BC187 /* DisplayableError.swift */; };
 		B1BC5D62A38657148E674B80 /* ExtensionConsoleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC2128B1137A2702EEC2F55 /* ExtensionConsoleView.swift */; };
+		B1E8E656BDC1765CCF41A683 /* HomeboyCLI+ProjectPinCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FC07381EEBE0370CD636213 /* HomeboyCLI+ProjectPinCommands.swift */; };
 		B23886AC41FD2A725383EF45 /* ExtensionManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA9BAC48CD6CC681F9FD2C5 /* ExtensionManifest.swift */; };
 		B27446E0A3706D997A75D1E9 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A690A4DC66BE109010668691 /* ContentView.swift */; };
 		B6AC1E19666E9FC9AF76D431 /* CommandBrowserCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19D0AC4BB8035D3A38DF8F83 /* CommandBrowserCatalog.swift */; };
@@ -178,6 +179,7 @@
 		75262FFB3BBC6BC33A8AC4F3 /* bandcamp_scraper.cpython-314.pyc */ = {isa = PBXFileReference; path = "bandcamp_scraper.cpython-314.pyc"; sourceTree = "<group>"; };
 		7BFAEBF8AA9E2BEC2A55EF0D /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
 		7E6E41FFC96012F3C390C094 /* JSONValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValue.swift; sourceTree = "<group>"; };
+		7FC07381EEBE0370CD636213 /* HomeboyCLI+ProjectPinCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+ProjectPinCommands.swift"; sourceTree = "<group>"; };
 		807865404822DFF3A4755240 /* APIAuthWorkspaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIAuthWorkspaceView.swift; sourceTree = "<group>"; };
 		811079398986364AA0E0542A /* CLIVersionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIVersionChecker.swift; sourceTree = "<group>"; };
 		830D15DCC64EB9AF17F822E0 /* ComponentsSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentsSettingsTab.swift; sourceTree = "<group>"; };
@@ -423,6 +425,7 @@
 				C3B52F387CC902FB445FC922 /* HomeboyCLI+CommandBrowserCommands.swift */,
 				4B800E302E25370AFEB2EAA7 /* HomeboyCLI+FileDatabaseCommands.swift */,
 				9CB4FFA7533765478562751F /* HomeboyCLI+LogCommands.swift */,
+				7FC07381EEBE0370CD636213 /* HomeboyCLI+ProjectPinCommands.swift */,
 				BC23AFFAB50FD8AFD042E644 /* HomeboyCLI+QualityCommands.swift */,
 				0DD2E86E7655D2ED45CB0E31 /* HomeboyCLI+RigBenchReleaseCommands.swift */,
 				BFAF5103FCB24063514E519F /* HomeboyCLI+RunCommands.swift */,
@@ -835,6 +838,7 @@
 				D5421FF656190A21F439C40A /* HomeboyCLI+CommandBrowserCommands.swift in Sources */,
 				7B4A55712A56BDD9EE21F504 /* HomeboyCLI+FileDatabaseCommands.swift in Sources */,
 				A744C6D0692C0EF9B142E839 /* HomeboyCLI+LogCommands.swift in Sources */,
+				B1E8E656BDC1765CCF41A683 /* HomeboyCLI+ProjectPinCommands.swift in Sources */,
 				A40B645FCF64C59E6F1EC4FC /* HomeboyCLI+QualityCommands.swift in Sources */,
 				46238C2E19607D4410D23FA2 /* HomeboyCLI+RigBenchReleaseCommands.swift in Sources */,
 				19F0A3B40B6B6BA59A201C7F /* HomeboyCLI+RunCommands.swift in Sources */,

--- a/Homeboy/Core/CLI/HomeboyCLI+LogCommands.swift
+++ b/Homeboy/Core/CLI/HomeboyCLI+LogCommands.swift
@@ -47,39 +47,4 @@ extension HomeboyCLI {
         return try await cli.executeCommand(args, dataType: LogsOutput.self, source: "Logs Search", timeout: 60)
     }
 
-    func logPinAdd(projectId: String, path: String, tailLines: Int) async throws -> ProjectPinOutput {
-        try await projectPin(
-            ["project", "pin", "add", "--type", "log", "--tail", String(tailLines), projectId, path],
-            source: "Log Pin Add"
-        )
-    }
-
-    func logPinRemove(projectId: String, path: String) async throws -> ProjectPinOutput {
-        try await projectPin(
-            ["project", "pin", "remove", projectId, path, "--type", "log"],
-            source: "Log Pin Remove"
-        )
-    }
-
-    func logPinUpdateTail(projectId: String, path: String, tailLines: Int, previousTailLines: Int) async throws -> ProjectPinOutput {
-        _ = try await logPinRemove(projectId: projectId, path: path)
-        do {
-            return try await logPinAdd(projectId: projectId, path: path, tailLines: tailLines)
-        } catch {
-            _ = try? await logPinAdd(projectId: projectId, path: path, tailLines: previousTailLines)
-            throw error
-        }
-    }
-
-    private func projectPin(_ args: [String], source: String) async throws -> ProjectPinOutput {
-        let output: ProjectPinReportOutput = try await cli.executeCommand(
-            args,
-            dataType: ProjectPinReportOutput.self,
-            source: source
-        )
-        guard let pin = output.pin else {
-            throw CLIBridgeError.invalidResponse("\(source) response missing pin payload")
-        }
-        return pin
-    }
 }

--- a/Homeboy/Core/CLI/HomeboyCLI+ProjectPinCommands.swift
+++ b/Homeboy/Core/CLI/HomeboyCLI+ProjectPinCommands.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+@MainActor
+extension HomeboyCLI {
+    func logPinAdd(projectId: String, path: String, tailLines: Int) async throws -> ProjectPinOutput {
+        try await projectPin(
+            ["project", "pin", "add", "--type", "log", "--tail", String(tailLines), projectId, path],
+            source: "Log Pin Add"
+        )
+    }
+
+    func logPinRemove(projectId: String, path: String) async throws -> ProjectPinOutput {
+        try await projectPin(
+            ["project", "pin", "remove", projectId, path, "--type", "log"],
+            source: "Log Pin Remove"
+        )
+    }
+
+    func logPinUpdateTail(projectId: String, path: String, tailLines: Int, previousTailLines: Int) async throws -> ProjectPinOutput {
+        _ = try await logPinRemove(projectId: projectId, path: path)
+        do {
+            return try await logPinAdd(projectId: projectId, path: path, tailLines: tailLines)
+        } catch {
+            _ = try? await logPinAdd(projectId: projectId, path: path, tailLines: previousTailLines)
+            throw error
+        }
+    }
+
+    func filePinAdd(projectId: String, path: String) async throws -> ProjectPinOutput {
+        try await projectPin(
+            ["project", "pin", "add", projectId, path, "--type", "file"],
+            source: "File Pin Add"
+        )
+    }
+
+    func filePinRemove(projectId: String, path: String) async throws -> ProjectPinOutput {
+        try await projectPin(
+            ["project", "pin", "remove", projectId, path, "--type", "file"],
+            source: "File Pin Remove"
+        )
+    }
+
+    func filePinUpdatePath(projectId: String, oldPath: String, newPath: String) async throws -> ProjectPinOutput {
+        _ = try await filePinRemove(projectId: projectId, path: oldPath)
+        do {
+            return try await filePinAdd(projectId: projectId, path: newPath)
+        } catch {
+            _ = try? await filePinAdd(projectId: projectId, path: oldPath)
+            throw error
+        }
+    }
+
+    private func projectPin(_ args: [String], source: String) async throws -> ProjectPinOutput {
+        let output: ProjectPinReportOutput = try await cli.executeCommand(
+            args,
+            dataType: ProjectPinReportOutput.self,
+            source: source
+        )
+        guard let pin = output.pin else {
+            throw CLIBridgeError.invalidResponse("\(source) response missing pin payload")
+        }
+        return pin
+    }
+}

--- a/Homeboy/Core/CLI/HomeboyCLIModels.swift
+++ b/Homeboy/Core/CLI/HomeboyCLIModels.swift
@@ -222,6 +222,7 @@ struct FileOutput: Decodable {
     let recursive: Bool?
     let entries: [FileListEntry]?
     let content: String?
+    let size: Int64?
     let bytesWritten: Int?
     let exitCode: Int32?
     let success: Bool?

--- a/Homeboy/Extensions/RemoteFileEditor/RemoteFileEditorViewModel.swift
+++ b/Homeboy/Extensions/RemoteFileEditor/RemoteFileEditorViewModel.swift
@@ -40,26 +40,6 @@ struct OpenFile: PinnableTabItem, Equatable {
     }
 }
 
-// MARK: - CLI Response Types
-
-private struct CLIResponse<T: Decodable>: Decodable {
-    let success: Bool
-    let data: T?
-}
-
-/// Response from `file read --json`
-private struct FileReadResponse: Decodable {
-    let path: String
-    let size: Int64?
-    let content: String
-}
-
-/// Response from `file write --json`
-private struct FileWriteResponse: Decodable {
-    let path: String
-    let bytesWritten: Int
-}
-
 @MainActor
 class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
 
@@ -87,7 +67,7 @@ class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
 
     // MARK: - CLI Bridge
 
-    private let cli = CLIBridge.shared
+    private let cli = HomeboyCLI.shared
 
     private var projectId: String {
         ConfigurationManager.shared.safeActiveProject.id
@@ -167,44 +147,35 @@ class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
         }
 
         isLoading = true
+        defer { isLoading = false }
         error = nil
 
         let file = openFiles[index]
 
         do {
-            // homeboy file read <project> <path> --json
-            let args = ["file", "read", projectId, file.path]
-            let response = try await cli.execute(args, timeout: 60)
-
-            if response.success {
-                // Parse JSON response through CLIResponse wrapper
-                let decoder = JSONDecoder()
-                decoder.keyDecodingStrategy = .convertFromSnakeCase
-                if let data = response.output.data(using: .utf8),
-                   let wrapper = try? decoder.decode(CLIResponse<FileReadResponse>.self, from: data),
-                   let fileContent = wrapper.data {
-                    openFiles[index].content = fileContent.content
-                    openFiles[index].originalContent = fileContent.content
-                    openFiles[index].fileSize = fileContent.size
-                    openFiles[index].fileExists = true
-                    openFiles[index].lastFetched = Date()
-                }
+            let output = try await cli.fileRead(projectId: projectId, path: file.path)
+            guard let currentIndex = openFiles.firstIndex(where: { $0.id == file.id }) else { return }
+            if let content = output.content {
+                openFiles[currentIndex].content = content
+                openFiles[currentIndex].originalContent = content
+                openFiles[currentIndex].fileSize = output.size
+                openFiles[currentIndex].fileExists = true
+                openFiles[currentIndex].lastFetched = Date()
+            }
+        } catch let cliError as CLIBridgeError {
+            guard let currentIndex = openFiles.firstIndex(where: { $0.id == file.id }) else { return }
+            if let structuredError = cliError.cliError,
+               structuredError.code == "file_not_found" {
+                openFiles[currentIndex].fileExists = false
+                openFiles[currentIndex].content = ""
+                openFiles[currentIndex].originalContent = ""
+                openFiles[currentIndex].fileSize = nil
             } else {
-                // Check if error indicates file not found
-                if response.errorOutput.contains("not found") || response.errorOutput.contains("No such file") {
-                    openFiles[index].fileExists = false
-                    openFiles[index].content = ""
-                    openFiles[index].originalContent = ""
-                    openFiles[index].fileSize = nil
-                } else {
-                    self.error = AppError(response.errorOutput, source: "File Editor", path: file.displayName)
-                }
+                self.error = cliError.cliError ?? AppError(cliError.localizedDescription, source: "File Editor", path: file.displayName)
             }
         } catch {
             self.error = error.toDisplayableError(source: "File Editor", path: file.displayName)
         }
-
-        isLoading = false
     }
 
     /// Saves the currently selected file to the server via CLI
@@ -216,28 +187,21 @@ class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
         }
 
         isSaving = true
+        defer { isSaving = false }
         error = nil
 
         let file = openFiles[index]
 
         do {
-            // homeboy file write <project> <path> --json (content via stdin)
-            let args = ["file", "write", projectId, file.path]
-            let response = try await cli.executeWithStdin(args, stdin: file.content, timeout: 60)
-
-            if response.success {
-                // Update state
-                openFiles[index].originalContent = file.content
-                openFiles[index].fileExists = true
-                openFiles[index].lastFetched = Date()
-            } else {
-                self.error = AppError("Failed to save: \(response.errorOutput)", source: "File Editor", path: file.displayName)
+            _ = try await cli.fileWrite(projectId: projectId, path: file.path, content: file.content)
+            if let currentIndex = openFiles.firstIndex(where: { $0.id == file.id }) {
+                openFiles[currentIndex].originalContent = file.content
+                openFiles[currentIndex].fileExists = true
+                openFiles[currentIndex].lastFetched = Date()
             }
         } catch {
             self.error = AppError("Failed to save: \(error.localizedDescription)", source: "File Editor", path: file.displayName)
         }
-
-        isSaving = false
     }
     
     // MARK: - Tab Management
@@ -326,14 +290,9 @@ class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
 
         Task {
             do {
-                // homeboy project pin add <project> <path> --type file --json
-                let args = ["project", "pin", "add", projectId, file.path, "--type", "file"]
-                let response = try await cli.execute(args, timeout: 30)
-
-                if response.success {
-                    openFiles[index].isPinned = true
-                } else {
-                    self.error = AppError("Failed to pin file: \(response.errorOutput)", source: "File Editor")
+                _ = try await cli.filePinAdd(projectId: projectId, path: file.path)
+                if let currentIndex = openFiles.firstIndex(where: { $0.id == file.id }) {
+                    openFiles[currentIndex].isPinned = true
                 }
             } catch {
                 self.error = AppError("Failed to pin file: \(error.localizedDescription)", source: "File Editor")
@@ -353,14 +312,9 @@ class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
 
         Task {
             do {
-                // homeboy project pin remove <project> <path> --type file --json
-                let args = ["project", "pin", "remove", projectId, file.path, "--type", "file"]
-                let response = try await cli.execute(args, timeout: 30)
-
-                if response.success {
-                    openFiles[index].isPinned = false
-                } else {
-                    self.error = AppError("Failed to unpin file: \(response.errorOutput)", source: "File Editor")
+                _ = try await cli.filePinRemove(projectId: projectId, path: file.path)
+                if let currentIndex = openFiles.firstIndex(where: { $0.id == file.id }) {
+                    openFiles[currentIndex].isPinned = false
                 }
             } catch {
                 self.error = AppError("Failed to unpin file: \(error.localizedDescription)", source: "File Editor")
@@ -440,15 +394,7 @@ class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
             if oldFile.isPinned && cli.isInstalled {
                 Task {
                     do {
-                        // Remove old pin
-                        let removeArgs = ["project", "pin", "remove", projectId, oldRelative, "--type", "file"]
-                        let removeResponse = try await cli.execute(removeArgs, timeout: 30)
-
-                        if removeResponse.success {
-                            // Add new pin
-                            let addArgs = ["project", "pin", "add", projectId, newRelative, "--type", "file"]
-                            _ = try await cli.execute(addArgs, timeout: 30)
-                        }
+                        _ = try await cli.filePinUpdatePath(projectId: projectId, oldPath: oldRelative, newPath: newRelative)
                     } catch {
                         // Non-critical error - file is still renamed locally
                     }

--- a/tests/FileLogDBContractTests.swift
+++ b/tests/FileLogDBContractTests.swift
@@ -5,6 +5,7 @@ import Foundation
 func runFileLogDBContractTests(testDir: String, fixturesDir: String, decoder: JSONDecoder) throws {
     try testDbDescribe(fixturesDir: fixturesDir, decoder: decoder)
     try testRemoteLogViewerPinCommandShape(testDir: testDir)
+    try testRemoteFileEditorPinCommandShape(testDir: testDir)
 }
 
 func testDbDescribe(fixturesDir: String, decoder: JSONDecoder) throws {
@@ -79,7 +80,7 @@ func testRemoteLogViewerPinCommandShape(testDir: String) throws {
         .appendingPathComponent("Homeboy/Extensions/RemoteLogViewer/RemoteLogViewerViewModel.swift")
     let cliPath = URL(fileURLWithPath: testDir)
         .deletingLastPathComponent()
-        .appendingPathComponent("Homeboy/Core/CLI/HomeboyCLI+LogCommands.swift")
+        .appendingPathComponent("Homeboy/Core/CLI/HomeboyCLI+ProjectPinCommands.swift")
 
     let viewModelSource = try String(contentsOf: viewModelPath, encoding: .utf8)
     let cliSource = try String(contentsOf: cliPath, encoding: .utf8)
@@ -110,6 +111,43 @@ func testRemoteLogViewerPinCommandShape(testDir: String) throws {
             userInfo: [NSLocalizedDescriptionKey: "RemoteLogViewer still contains old positional-first project pin add syntax"])
     }
     print("[PASS] Old positional-first log pin syntax is absent")
+
+    print("")
+}
+
+func testRemoteFileEditorPinCommandShape(testDir: String) throws {
+    print("Test: Remote File Editor pin command shape")
+    print("------------------------------------------")
+
+    let viewModelPath = URL(fileURLWithPath: testDir)
+        .deletingLastPathComponent()
+        .appendingPathComponent("Homeboy/Extensions/RemoteFileEditor/RemoteFileEditorViewModel.swift")
+    let cliPath = URL(fileURLWithPath: testDir)
+        .deletingLastPathComponent()
+        .appendingPathComponent("Homeboy/Core/CLI/HomeboyCLI+ProjectPinCommands.swift")
+
+    let viewModelSource = try String(contentsOf: viewModelPath, encoding: .utf8)
+    let cliSource = try String(contentsOf: cliPath, encoding: .utf8)
+    let currentAddCommand = #"["project", "pin", "add", projectId, path, "--type", "file"]"#
+    let currentRemoveCommand = #"["project", "pin", "remove", projectId, path, "--type", "file"]"#
+
+    guard cliSource.contains(currentAddCommand) else {
+        throw NSError(domain: "ContractTest", code: 74,
+            userInfo: [NSLocalizedDescriptionKey: "File CLI wrapper pin command does not use current homeboy project pin add syntax"])
+    }
+    print("[PASS] File pin command uses current add syntax")
+
+    guard cliSource.contains(currentRemoveCommand) else {
+        throw NSError(domain: "ContractTest", code: 75,
+            userInfo: [NSLocalizedDescriptionKey: "File CLI wrapper unpin command does not use current homeboy project pin remove syntax"])
+    }
+    print("[PASS] File unpin command uses current remove syntax")
+
+    guard !viewModelSource.contains("[\"project\", \"pin\"") else {
+        throw NSError(domain: "ContractTest", code: 76,
+            userInfo: [NSLocalizedDescriptionKey: "RemoteFileEditorViewModel still builds raw project pin commands instead of using HomeboyCLI wrappers"])
+    }
+    print("[PASS] View model uses typed HomeboyCLI file pin wrappers")
 
     print("")
 }


### PR DESCRIPTION
## Summary
- Move project pin command construction into shared typed HomeboyCLI helpers for both log and file pins.
- Refactor Remote File Editor to use HomeboyCLI file read/write and file pin wrappers instead of raw CLIBridge command arrays.
- Add contract coverage that guards Remote File Editor against rebuilding raw project pin commands.

## Testing
- `DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer" xcodegen generate --spec project.yml`
- `DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer" xcodebuild -project Homeboy.xcodeproj -scheme Homeboy -configuration Debug -derivedDataPath .build/DerivedData build`
- `swift tests/ContractTests.swift tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Refactored the Remote File Editor CLI contract path, updated contract tests, and ran local verification. Chris reviewed and directed the PR creation.