### PR TITLE
Refactor file editor model and path handling

### DIFF
--- a/Homeboy.xcodeproj/project.pbxproj
+++ b/Homeboy.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		34FF9AD0FE0BE2ADE1F07752 /* SiteListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21391AE5E442FFA2A2843821 /* SiteListView.swift */; };
 		36E2AEA91D720BC0FCE5D660 /* DeployerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E103FB783F1B8F1CF84750F4 /* DeployerView.swift */; };
 		38D566E59E85DF4E4D14C48F /* RemoteFileBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E7289F91C0EA517A3DE5DB9 /* RemoteFileBrowser.swift */; };
+		3AE96B334740E1FD5BF12CE8 /* RemoteFileModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5E37F5EBA99C37980EFA58 /* RemoteFileModels.swift */; };
 		3CBF41346F060E438864152C /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59036A328B5EEE5B0D5DF9C /* AppError.swift */; };
 		3D5278E44CF446DC733DFDF7 /* ConsoleOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FDE17265BB36CD42258798 /* ConsoleOutput.swift */; };
 		4118594C23453F57B04D3C16 /* CommandBrowserViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE4CFBBE215C9D3D1250C8EF /* CommandBrowserViewModel.swift */; };
@@ -175,6 +176,7 @@
 		670327C19CE0F089CFF35DD1 /* LogTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogTextView.swift; sourceTree = "<group>"; };
 		6BBAE3837D9DF6634A72AAB1 /* QualityViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QualityViewModel.swift; sourceTree = "<group>"; };
 		6C195A8A1462489E882BC187 /* DisplayableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayableError.swift; sourceTree = "<group>"; };
+		6F5E37F5EBA99C37980EFA58 /* RemoteFileModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileModels.swift; sourceTree = "<group>"; };
 		70AE598B819DE3CDD73692D4 /* RemoteFileEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileEditorView.swift; sourceTree = "<group>"; };
 		75262FFB3BBC6BC33A8AC4F3 /* bandcamp_scraper.cpython-314.pyc */ = {isa = PBXFileReference; path = "bandcamp_scraper.cpython-314.pyc"; sourceTree = "<group>"; };
 		7BFAEBF8AA9E2BEC2A55EF0D /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
@@ -333,6 +335,7 @@
 			isa = PBXGroup;
 			children = (
 				0075D42A490CE7EF713A874F /* CommandBrowserEntry.swift */,
+				6F5E37F5EBA99C37980EFA58 /* RemoteFileModels.swift */,
 				3A497C117547FCCCA5F2408D /* RemoteLogModels.swift */,
 			);
 			path = Models;
@@ -866,6 +869,7 @@
 				1AEFFA5D377D403DDA560237 /* RemoteFileEditorView.swift in Sources */,
 				79F089B7341476178AB41022 /* RemoteFileEditorViewModel.swift in Sources */,
 				72D058E4C987B44B3C2FE75F /* RemoteFileEntry.swift in Sources */,
+				3AE96B334740E1FD5BF12CE8 /* RemoteFileModels.swift in Sources */,
 				64D23F8D70421EFD7A51BEF2 /* RemoteLogModels.swift in Sources */,
 				339E905F86E47CF88C0386B8 /* RemoteLogViewerView.swift in Sources */,
 				180E9CC06D913B4F8B55A58A /* RemoteLogViewerViewModel.swift in Sources */,

--- a/Homeboy/Extensions/RemoteFileEditor/RemoteFileEditorViewModel.swift
+++ b/Homeboy/Extensions/RemoteFileEditor/RemoteFileEditorViewModel.swift
@@ -3,43 +3,6 @@ import Combine
 import Foundation
 import SwiftUI
 
-/// Represents an open file tab in the Remote File Editor
-struct OpenFile: PinnableTabItem, Equatable {
-    let id: UUID
-    let path: String           // Relative path from basePath
-    var isPinned: Bool
-    var content: String = ""
-    var originalContent: String = ""
-    var fileExists: Bool = true
-    var lastFetched: Date?
-    var fileSize: Int64?       // Size in bytes
-
-    var displayName: String {
-        URL(fileURLWithPath: path).lastPathComponent
-    }
-
-    var hasUnsavedChanges: Bool {
-        content != originalContent
-    }
-
-    var formattedSize: String {
-        guard let size = fileSize else { return "" }
-        return ByteCountFormatter.string(fromByteCount: size, countStyle: .file)
-    }
-
-    init(id: UUID = UUID(), path: String, isPinned: Bool) {
-        self.id = id
-        self.path = path
-        self.isPinned = isPinned
-    }
-
-    init(from pinned: PinnedRemoteFile) {
-        self.id = pinned.id
-        self.path = pinned.path
-        self.isPinned = true
-    }
-}
-
 @MainActor
 class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
 
@@ -237,6 +200,10 @@ class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
             await fetchSelectedFile()
         }
     }
+
+    func openFileFromBrowser(path: String) {
+        openFile(path: relativeFilePath(for: path))
+    }
     
     /// Attempts to close a file tab
     func closeFile(_ id: UUID) {
@@ -352,14 +319,7 @@ class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
 
     /// Handle a file being deleted from the sidebar - close its tab if open
     func handleFileDeleted(_ path: String) {
-        // Convert absolute path to relative if needed
-        let basePath = ConfigurationManager.shared.safeActiveProject.basePath
-        let relativePath: String
-        if let base = basePath, path.hasPrefix(base) {
-            relativePath = String(path.dropFirst(base.count + 1))
-        } else {
-            relativePath = path
-        }
+        let relativePath = relativeFilePath(for: path)
 
         if let file = openFiles.first(where: { $0.path == relativePath }) {
             performClose(file.id)
@@ -368,18 +328,8 @@ class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
 
     /// Handle a file being renamed from the sidebar - update the tab if open
     func handleFileRenamed(from oldPath: String, to newPath: String) {
-        // Convert absolute paths to relative if needed
-        let basePath = ConfigurationManager.shared.safeActiveProject.basePath
-        let oldRelative: String
-        let newRelative: String
-
-        if let base = basePath {
-            oldRelative = oldPath.hasPrefix(base) ? String(oldPath.dropFirst(base.count + 1)) : oldPath
-            newRelative = newPath.hasPrefix(base) ? String(newPath.dropFirst(base.count + 1)) : newPath
-        } else {
-            oldRelative = oldPath
-            newRelative = newPath
-        }
+        let oldRelative = relativeFilePath(for: oldPath)
+        let newRelative = relativeFilePath(for: newPath)
 
         if let index = openFiles.firstIndex(where: { $0.path == oldRelative }) {
             // Update the file path
@@ -389,6 +339,7 @@ class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
             openFiles[index].originalContent = oldFile.originalContent
             openFiles[index].fileExists = oldFile.fileExists
             openFiles[index].lastFetched = oldFile.lastFetched
+            openFiles[index].fileSize = oldFile.fileSize
 
             // Update pinned files via CLI if this was pinned
             if oldFile.isPinned && cli.isInstalled {
@@ -401,6 +352,27 @@ class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
                 }
             }
         }
+    }
+
+    private func relativeFilePath(for path: String) -> String {
+        guard path.hasPrefix("/") else { return path }
+
+        guard let basePath = ConfigurationManager.shared.safeActiveProject.basePath,
+              !basePath.isEmpty else {
+            return path
+        }
+
+        let normalizedBase = URL(fileURLWithPath: basePath).standardizedFileURL.path
+        let normalizedPath = URL(fileURLWithPath: path).standardizedFileURL.path
+        guard normalizedPath == normalizedBase || normalizedPath.hasPrefix(normalizedBase + "/") else {
+            return path
+        }
+
+        if normalizedPath == normalizedBase {
+            return URL(fileURLWithPath: normalizedPath).lastPathComponent
+        }
+
+        return String(normalizedPath.dropFirst(normalizedBase.count + 1))
     }
     
     // MARK: - Utility

--- a/Homeboy/Extensions/RemoteFileEditor/Views/RemoteFileEditorView.swift
+++ b/Homeboy/Extensions/RemoteFileEditor/Views/RemoteFileEditorView.swift
@@ -75,12 +75,7 @@ struct RemoteFileEditorView: View {
     // MARK: - Open File from Browser
     
     private func openFileFromBrowser(_ path: String) {
-        // Convert absolute path to relative from basePath
-        let basePath = ConfigurationManager.shared.safeActiveProject.basePath ?? ""
-        let relativePath = path.hasPrefix(basePath)
-            ? String(path.dropFirst(basePath.count + 1))
-            : path
-        viewModel.openFile(path: relativePath)
+        viewModel.openFileFromBrowser(path: path)
     }
     
     // MARK: - Editor Content

--- a/Homeboy/Models/RemoteFileModels.swift
+++ b/Homeboy/Models/RemoteFileModels.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Represents an open file tab in the Remote File Editor.
+struct OpenFile: PinnableTabItem, Equatable {
+    let id: UUID
+    let path: String
+    var isPinned: Bool
+    var content: String = ""
+    var originalContent: String = ""
+    var fileExists: Bool = true
+    var lastFetched: Date?
+    var fileSize: Int64?
+
+    var displayName: String {
+        URL(fileURLWithPath: path).lastPathComponent
+    }
+
+    var hasUnsavedChanges: Bool {
+        content != originalContent
+    }
+
+    var formattedSize: String {
+        guard let fileSize else { return "" }
+        return ByteCountFormatter.string(fromByteCount: fileSize, countStyle: .file)
+    }
+
+    init(id: UUID = UUID(), path: String, isPinned: Bool) {
+        self.id = id
+        self.path = path
+        self.isPinned = isPinned
+    }
+
+    init(from pinned: PinnedRemoteFile) {
+        self.id = pinned.id
+        self.path = pinned.path
+        self.isPinned = true
+    }
+}

--- a/tests/FileLogDBContractTests.swift
+++ b/tests/FileLogDBContractTests.swift
@@ -6,6 +6,7 @@ func runFileLogDBContractTests(testDir: String, fixturesDir: String, decoder: JS
     try testDbDescribe(fixturesDir: fixturesDir, decoder: decoder)
     try testRemoteLogViewerPinCommandShape(testDir: testDir)
     try testRemoteFileEditorPinCommandShape(testDir: testDir)
+    try testRemoteFileEditorModelAndPathShape(testDir: testDir)
 }
 
 func testDbDescribe(fixturesDir: String, decoder: JSONDecoder) throws {
@@ -148,6 +149,58 @@ func testRemoteFileEditorPinCommandShape(testDir: String) throws {
             userInfo: [NSLocalizedDescriptionKey: "RemoteFileEditorViewModel still builds raw project pin commands instead of using HomeboyCLI wrappers"])
     }
     print("[PASS] View model uses typed HomeboyCLI file pin wrappers")
+
+    print("")
+}
+
+func testRemoteFileEditorModelAndPathShape(testDir: String) throws {
+    print("Test: Remote File Editor model and path shape")
+    print("---------------------------------------------")
+
+    let root = URL(fileURLWithPath: testDir).deletingLastPathComponent()
+    let modelPath = root.appendingPathComponent("Homeboy/Models/RemoteFileModels.swift")
+    let viewModelPath = root.appendingPathComponent("Homeboy/Extensions/RemoteFileEditor/RemoteFileEditorViewModel.swift")
+    let viewPath = root.appendingPathComponent("Homeboy/Extensions/RemoteFileEditor/Views/RemoteFileEditorView.swift")
+
+    let modelSource = try String(contentsOf: modelPath, encoding: .utf8)
+    let viewModelSource = try String(contentsOf: viewModelPath, encoding: .utf8)
+    let viewSource = try String(contentsOf: viewPath, encoding: .utf8)
+
+    guard modelSource.contains("struct OpenFile: PinnableTabItem, Equatable") else {
+        throw NSError(domain: "ContractTest", code: 77,
+            userInfo: [NSLocalizedDescriptionKey: "OpenFile model is not defined in Homeboy/Models/RemoteFileModels.swift"])
+    }
+    print("[PASS] OpenFile lives in shared model file")
+
+    guard !viewModelSource.contains("struct OpenFile") else {
+        throw NSError(domain: "ContractTest", code: 78,
+            userInfo: [NSLocalizedDescriptionKey: "RemoteFileEditorViewModel still owns the OpenFile model"])
+    }
+    print("[PASS] View model no longer owns OpenFile")
+
+    guard viewSource.contains("viewModel.openFileFromBrowser(path: path)") else {
+        throw NSError(domain: "ContractTest", code: 79,
+            userInfo: [NSLocalizedDescriptionKey: "RemoteFileEditorView still normalizes browser paths locally"])
+    }
+    print("[PASS] Browser path normalization is delegated to the view model")
+
+    guard viewModelSource.contains("private func relativeFilePath(for path: String) -> String") else {
+        throw NSError(domain: "ContractTest", code: 80,
+            userInfo: [NSLocalizedDescriptionKey: "RemoteFileEditorViewModel does not expose a centralized relative path helper"])
+    }
+    print("[PASS] View model centralizes relative path conversion")
+
+    guard viewModelSource.contains("openFiles[index].fileSize = oldFile.fileSize") else {
+        throw NSError(domain: "ContractTest", code: 81,
+            userInfo: [NSLocalizedDescriptionKey: "RemoteFileEditor rename path does not preserve fileSize"])
+    }
+    print("[PASS] Rename preserves file size metadata")
+
+    guard !viewModelSource.contains("dropFirst(base.count") && !viewSource.contains("dropFirst(basePath.count") else {
+        throw NSError(domain: "ContractTest", code: 82,
+            userInfo: [NSLocalizedDescriptionKey: "Remote File Editor still contains duplicated prefix-drop path conversion"])
+    }
+    print("[PASS] Duplicated prefix-drop path conversion is absent")
 
     print("")
 }


### PR DESCRIPTION
## Summary
- Move `OpenFile` into a shared Remote File model file, matching the Remote Log model split.
- Centralize Remote File Editor browser path normalization in the view model instead of duplicating it in the view and sidebar handlers.
- Preserve file size metadata when an open file tab is renamed.

## Testing
- `DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer" xcodegen generate --spec project.yml`
- `DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer" xcodebuild -project Homeboy.xcodeproj -scheme Homeboy -configuration Debug -derivedDataPath .build/DerivedData build`
- `swift tests/ContractTests.swift tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Refactored Remote File Editor model/path ownership, added contract coverage, and ran local verification. Chris directed the next cleanup slice.