### PR TITLE
Protect unsaved file edits from refresh

### DIFF
--- a/Homeboy/Extensions/RemoteFileEditor/RemoteFileEditorViewModel.swift
+++ b/Homeboy/Extensions/RemoteFileEditor/RemoteFileEditorViewModel.swift
@@ -48,6 +48,11 @@ class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
         return openFiles.firstIndex { $0.id == id }
     }
 
+    var canRefreshSelectedFile: Bool {
+        guard let selectedFile else { return false }
+        return !selectedFile.hasUnsavedChanges && !isLoading && !isSaving
+    }
+
     // MARK: - Initialization
 
     init(browser: RemoteFileBrowser? = nil) {
@@ -104,6 +109,7 @@ class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
     /// Fetches the currently selected file from the server via CLI
     func fetchSelectedFile() async {
         guard let index = selectedFileIndex else { return }
+        guard !openFiles[index].hasUnsavedChanges else { return }
         guard cli.isInstalled else {
             error = AppError("Homeboy CLI is not installed. Install via Settings → CLI.", source: "File Editor")
             return

--- a/Homeboy/Extensions/RemoteFileEditor/Views/RemoteFileEditorView.swift
+++ b/Homeboy/Extensions/RemoteFileEditor/Views/RemoteFileEditorView.swift
@@ -190,7 +190,7 @@ struct RemoteFileEditorView: View {
             } label: {
                 Label("Refresh", systemImage: "arrow.clockwise")
             }
-            .disabled(viewModel.isLoading || viewModel.isSaving)
+            .disabled(!viewModel.canRefreshSelectedFile)
             
             Spacer()
             

--- a/tests/FileLogDBContractTests.swift
+++ b/tests/FileLogDBContractTests.swift
@@ -190,6 +190,25 @@ func testRemoteFileEditorModelAndPathShape(testDir: String) throws {
     }
     print("[PASS] View model centralizes relative path conversion")
 
+    guard viewModelSource.contains("var canRefreshSelectedFile: Bool")
+        && viewModelSource.contains("return !selectedFile.hasUnsavedChanges && !isLoading && !isSaving") else {
+        throw NSError(domain: "ContractTest", code: 83,
+            userInfo: [NSLocalizedDescriptionKey: "Remote File Editor does not disable refresh while the selected file has unsaved changes"])
+    }
+    print("[PASS] Refresh availability excludes unsaved selected files")
+
+    guard viewModelSource.contains("guard !openFiles[index].hasUnsavedChanges else { return }") else {
+        throw NSError(domain: "ContractTest", code: 84,
+            userInfo: [NSLocalizedDescriptionKey: "Remote File Editor refresh path can still overwrite unsaved selected file content"])
+    }
+    print("[PASS] Fetch path refuses to overwrite unsaved selected file content")
+
+    guard viewSource.contains(".disabled(!viewModel.canRefreshSelectedFile)") else {
+        throw NSError(domain: "ContractTest", code: 85,
+            userInfo: [NSLocalizedDescriptionKey: "Remote File Editor refresh button is not bound to refresh safety state"])
+    }
+    print("[PASS] Refresh button is bound to refresh safety state")
+
     guard viewModelSource.contains("openFiles[index].fileSize = oldFile.fileSize") else {
         throw NSError(domain: "ContractTest", code: 81,
             userInfo: [NSLocalizedDescriptionKey: "RemoteFileEditor rename path does not preserve fileSize"])


### PR DESCRIPTION
## Summary
- Disable Remote File Editor refresh while the selected file has unsaved changes.
- Guard the fetch path itself so non-toolbar refresh triggers cannot overwrite dirty local content.
- Add contract coverage for refresh availability, fetch safety, and button wiring.

## Tests
- `DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer" xcodegen generate --spec project.yml`
- `DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer" xcodebuild -project Homeboy.xcodeproj -scheme Homeboy -configuration Debug -derivedDataPath .build/DerivedData build`
- `swift tests/ContractTests.swift tests`

Closes #72.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the refresh safety guard, UI disabled state, contract assertions, and ran the requested verification commands for Chris to review.