### PR TITLE
Discard stale remote file browser results

### DIFF
--- a/Homeboy/Core/SSH/RemoteFileBrowser.swift
+++ b/Homeboy/Core/SSH/RemoteFileBrowser.swift
@@ -33,6 +33,14 @@ class RemoteFileBrowser: ObservableObject {
     private var projectId: String
     private var startingPath: String?
     private let cli = HomeboyCLI.shared
+    private var requestGeneration = 0
+    private var activeListRequest: FileListRequest?
+
+    private struct FileListRequest: Equatable {
+        let generation: Int
+        let projectId: String
+        let path: String
+    }
 
     /// Initialize with a project ID and optional starting path
     init(projectId: String, startingPath: String? = nil) {
@@ -51,6 +59,8 @@ class RemoteFileBrowser: ObservableObject {
 
     /// Reconnect with new project context
     func reconnect(projectId: String, startingPath: String?) async {
+        requestGeneration += 1
+        activeListRequest = nil
         self.projectId = projectId
         self.startingPath = startingPath
         await connect()
@@ -63,11 +73,15 @@ class RemoteFileBrowser: ObservableObject {
 
     /// Navigate to a specific path
     func goToPath(_ path: String) async {
+        requestGeneration += 1
+        let request = FileListRequest(generation: requestGeneration, projectId: projectId, path: path)
+        activeListRequest = request
         isLoading = true
         error = nil
 
         do {
-            let output = try await cli.fileList(projectId: projectId, path: path)
+            let output = try await cli.fileList(projectId: request.projectId, path: request.path)
+            guard activeListRequest == request else { return }
             currentPath = path
             entries = (output.entries ?? []).map { entry in
                 RemoteFileEntry(
@@ -84,10 +98,13 @@ class RemoteFileBrowser: ObservableObject {
                 pathHistory.append(path)
             }
         } catch {
+            guard activeListRequest == request else { return }
             self.error = error.toDisplayableError(source: "Remote File Browser", path: path)
         }
 
-        isLoading = false
+        if activeListRequest == request {
+            isLoading = false
+        }
     }
     
     /// Navigate to parent directory

--- a/tests/FileLogDBContractTests.swift
+++ b/tests/FileLogDBContractTests.swift
@@ -7,6 +7,7 @@ func runFileLogDBContractTests(testDir: String, fixturesDir: String, decoder: JS
     try testRemoteLogViewerPinCommandShape(testDir: testDir)
     try testRemoteFileEditorPinCommandShape(testDir: testDir)
     try testRemoteFileEditorModelAndPathShape(testDir: testDir)
+    try testRemoteFileBrowserStaleRequestGuard(testDir: testDir)
 }
 
 func testDbDescribe(fixturesDir: String, decoder: JSONDecoder) throws {
@@ -201,6 +202,72 @@ func testRemoteFileEditorModelAndPathShape(testDir: String) throws {
             userInfo: [NSLocalizedDescriptionKey: "Remote File Editor still contains duplicated prefix-drop path conversion"])
     }
     print("[PASS] Duplicated prefix-drop path conversion is absent")
+
+    print("")
+}
+
+func testRemoteFileBrowserStaleRequestGuard(testDir: String) throws {
+    print("Test: Remote File Browser stale request guard")
+    print("---------------------------------------------")
+
+    let browserPath = URL(fileURLWithPath: testDir)
+        .deletingLastPathComponent()
+        .appendingPathComponent("Homeboy/Core/SSH/RemoteFileBrowser.swift")
+    let browserSource = try String(contentsOf: browserPath, encoding: .utf8)
+    let goToPathSource = try sourceSlice(
+        browserSource,
+        from: "func goToPath(_ path: String) async {",
+        to: "    /// Navigate to parent directory"
+    )
+
+    try assertContains(
+        browserSource,
+        "private var requestGeneration = 0",
+        message: "RemoteFileBrowser does not track file-list request generations"
+    )
+    print("[PASS] Browser tracks request generations")
+
+    try assertContains(
+        browserSource,
+        "private var activeListRequest: FileListRequest?",
+        message: "RemoteFileBrowser does not retain the active file-list request identity"
+    )
+    print("[PASS] Browser retains active request identity")
+
+    try assertContains(
+        browserSource,
+        "activeListRequest = nil",
+        message: "RemoteFileBrowser reconnect does not invalidate in-flight file-list requests"
+    )
+    print("[PASS] Reconnect invalidates in-flight requests")
+
+    try assertContains(
+        goToPathSource,
+        "let request = FileListRequest(generation: requestGeneration, projectId: projectId, path: path)",
+        message: "goToPath does not capture generation, project, and path before awaiting file list"
+    )
+    print("[PASS] Navigation captures generation/project/path")
+
+    try assertContains(
+        goToPathSource,
+        "guard activeListRequest == request else { return }\n            currentPath = path",
+        message: "goToPath can still apply stale file-list entries after a newer request wins"
+    )
+    print("[PASS] Stale success results are discarded before mutating entries")
+
+    try assertContains(
+        goToPathSource,
+        "guard activeListRequest == request else { return }\n            self.error = error.toDisplayableError",
+        message: "goToPath can still show stale errors after a newer request wins"
+    )
+    print("[PASS] Stale errors are discarded")
+
+    try assertContains(
+        goToPathSource,
+        "if activeListRequest == request {\n            isLoading = false\n        }",
+        message: "goToPath can still clear loading state for a newer in-flight request"
+    )
+    print("[PASS] Loading state is cleared only by the active request")
 
     print("")
 }


### PR DESCRIPTION
## Summary
- Adds generation/project/path request identity tracking to `RemoteFileBrowser` so stale `file list` completions cannot overwrite newer navigation or reconnect state.
- Keeps loading/error updates scoped to the active request.
- Adds contract coverage for the stale-request guard shape.

## Tests
- `DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer" xcodegen generate --spec project.yml`
- `DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer" xcodebuild -project Homeboy.xcodeproj -scheme Homeboy -configuration Debug -derivedDataPath .build/DerivedData build`
- `swift tests/ContractTests.swift tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the request-token implementation and contract coverage; Chris remains responsible for review and testing.

Closes #73