### PR TITLE
Fix pinned close and log tail picker cleanup

### DIFF
--- a/Homeboy/Core/SSH/RemoteFileBrowser.swift
+++ b/Homeboy/Core/SSH/RemoteFileBrowser.swift
@@ -33,6 +33,14 @@ class RemoteFileBrowser: ObservableObject {
     private var projectId: String
     private var startingPath: String?
     private let cli = HomeboyCLI.shared
+    private var requestGeneration = 0
+    private var activeListRequest: FileListRequest?
+
+    private struct FileListRequest: Equatable {
+        let generation: Int
+        let projectId: String
+        let path: String
+    }
 
     /// Initialize with a project ID and optional starting path
     init(projectId: String, startingPath: String? = nil) {
@@ -51,6 +59,8 @@ class RemoteFileBrowser: ObservableObject {
 
     /// Reconnect with new project context
     func reconnect(projectId: String, startingPath: String?) async {
+        requestGeneration += 1
+        activeListRequest = nil
         self.projectId = projectId
         self.startingPath = startingPath
         await connect()
@@ -63,11 +73,15 @@ class RemoteFileBrowser: ObservableObject {
 
     /// Navigate to a specific path
     func goToPath(_ path: String) async {
+        requestGeneration += 1
+        let request = FileListRequest(generation: requestGeneration, projectId: projectId, path: path)
+        activeListRequest = request
         isLoading = true
         error = nil
 
         do {
-            let output = try await cli.fileList(projectId: projectId, path: path)
+            let output = try await cli.fileList(projectId: request.projectId, path: request.path)
+            guard activeListRequest == request else { return }
             currentPath = path
             entries = (output.entries ?? []).map { entry in
                 RemoteFileEntry(
@@ -84,10 +98,13 @@ class RemoteFileBrowser: ObservableObject {
                 pathHistory.append(path)
             }
         } catch {
+            guard activeListRequest == request else { return }
             self.error = error.toDisplayableError(source: "Remote File Browser", path: path)
         }
 
-        isLoading = false
+        if activeListRequest == request {
+            isLoading = false
+        }
     }
     
     /// Navigate to parent directory

--- a/Homeboy/Extensions/RemoteFileEditor/RemoteFileEditorViewModel.swift
+++ b/Homeboy/Extensions/RemoteFileEditor/RemoteFileEditorViewModel.swift
@@ -48,6 +48,11 @@ class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
         return openFiles.firstIndex { $0.id == id }
     }
 
+    var canRefreshSelectedFile: Bool {
+        guard let selectedFile else { return false }
+        return !selectedFile.hasUnsavedChanges && !isLoading && !isSaving
+    }
+
     // MARK: - Initialization
 
     init(browser: RemoteFileBrowser? = nil) {
@@ -104,6 +109,7 @@ class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
     /// Fetches the currently selected file from the server via CLI
     func fetchSelectedFile() async {
         guard let index = selectedFileIndex else { return }
+        guard !openFiles[index].hasUnsavedChanges else { return }
         guard cli.isInstalled else {
             error = AppError("Homeboy CLI is not installed. Install via Settings → CLI.", source: "File Editor")
             return

--- a/Homeboy/Extensions/RemoteFileEditor/RemoteFileEditorViewModel.swift
+++ b/Homeboy/Extensions/RemoteFileEditor/RemoteFileEditorViewModel.swift
@@ -236,13 +236,31 @@ class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
         
         let file = openFiles[index]
         
-        // If pinned, just unpin instead of closing
         if file.isPinned {
-            unpinFile(id)
+            guard cli.isInstalled else {
+                error = AppError("Homeboy CLI is not installed. Install via Settings → CLI.", source: "File Editor")
+                return
+            }
+
+            Task {
+                do {
+                    _ = try await cli.filePinRemove(projectId: projectId, path: file.path)
+                    closeOpenFileTab(id)
+                } catch {
+                    self.error = AppError("Failed to unpin file: \(error.localizedDescription)", source: "File Editor")
+                }
+            }
+            return
         }
-        
+
+        closeOpenFileTab(id)
+    }
+
+    private func closeOpenFileTab(_ id: UUID) {
+        guard let index = openFiles.firstIndex(where: { $0.id == id }) else { return }
+
         openFiles.remove(at: index)
-        
+
         // Select another tab if needed
         if selectedFileId == id {
             selectedFileId = openFiles.first?.id

--- a/Homeboy/Extensions/RemoteFileEditor/RemoteFileEditorViewModel.swift
+++ b/Homeboy/Extensions/RemoteFileEditor/RemoteFileEditorViewModel.swift
@@ -230,13 +230,31 @@ class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
         
         let file = openFiles[index]
         
-        // If pinned, just unpin instead of closing
         if file.isPinned {
-            unpinFile(id)
+            guard cli.isInstalled else {
+                error = AppError("Homeboy CLI is not installed. Install via Settings → CLI.", source: "File Editor")
+                return
+            }
+
+            Task {
+                do {
+                    _ = try await cli.filePinRemove(projectId: projectId, path: file.path)
+                    closeOpenFileTab(id)
+                } catch {
+                    self.error = AppError("Failed to unpin file: \(error.localizedDescription)", source: "File Editor")
+                }
+            }
+            return
         }
-        
+
+        closeOpenFileTab(id)
+    }
+
+    private func closeOpenFileTab(_ id: UUID) {
+        guard let index = openFiles.firstIndex(where: { $0.id == id }) else { return }
+
         openFiles.remove(at: index)
-        
+
         // Select another tab if needed
         if selectedFileId == id {
             selectedFileId = openFiles.first?.id

--- a/Homeboy/Extensions/RemoteFileEditor/Views/RemoteFileEditorView.swift
+++ b/Homeboy/Extensions/RemoteFileEditor/Views/RemoteFileEditorView.swift
@@ -190,7 +190,7 @@ struct RemoteFileEditorView: View {
             } label: {
                 Label("Refresh", systemImage: "arrow.clockwise")
             }
-            .disabled(viewModel.isLoading || viewModel.isSaving)
+            .disabled(!viewModel.canRefreshSelectedFile)
             
             Spacer()
             

--- a/Homeboy/Extensions/RemoteLogViewer/RemoteLogViewerViewModel.swift
+++ b/Homeboy/Extensions/RemoteLogViewer/RemoteLogViewerViewModel.swift
@@ -191,17 +191,30 @@ class RemoteLogViewerViewModel: ObservableObject, ConfigurationObserving {
         let log = openLogs[index]
 
         if log.isPinned {
+            guard cli.isInstalled else {
+                error = AppError("Homeboy CLI is not installed. Install via Settings → CLI.", source: "Log Viewer")
+                return
+            }
+
             Task {
                 do {
                     try await unpinLog(path: log.path)
+                    closeOpenLogTab(id)
                 } catch {
                     self.error = AppError("Failed to unpin log: \(error.localizedDescription)", source: "Log Viewer")
                 }
             }
+            return
         }
-        
+
+        closeOpenLogTab(id)
+    }
+
+    private func closeOpenLogTab(_ id: UUID) {
+        guard let index = openLogs.firstIndex(where: { $0.id == id }) else { return }
+
         openLogs.remove(at: index)
-        
+
         // Select another tab if needed
         if selectedLogId == id {
             selectedLogId = openLogs.first?.id

--- a/Homeboy/Extensions/RemoteLogViewer/Views/RemoteLogViewerView.swift
+++ b/Homeboy/Extensions/RemoteLogViewer/Views/RemoteLogViewerView.swift
@@ -134,7 +134,7 @@ struct RemoteLogViewerView: View {
                 set: { viewModel.setTailLines($0) }
             )) {
                 ForEach(RemoteLogViewerViewModel.tailOptions, id: \.self) { count in
-                    Text(count == 0 ? "All" : "\(count)").tag(count)
+                    Text("\(count)").tag(count)
                 }
             }
             .frame(width: 100)

--- a/tests/FileLogDBContractTests.swift
+++ b/tests/FileLogDBContractTests.swift
@@ -190,6 +190,25 @@ func testRemoteFileEditorModelAndPathShape(testDir: String) throws {
     }
     print("[PASS] View model centralizes relative path conversion")
 
+    guard viewModelSource.contains("var canRefreshSelectedFile: Bool")
+        && viewModelSource.contains("return !selectedFile.hasUnsavedChanges && !isLoading && !isSaving") else {
+        throw NSError(domain: "ContractTest", code: 83,
+            userInfo: [NSLocalizedDescriptionKey: "Remote File Editor does not disable refresh while the selected file has unsaved changes"])
+    }
+    print("[PASS] Refresh availability excludes unsaved selected files")
+
+    guard viewModelSource.contains("guard !openFiles[index].hasUnsavedChanges else { return }") else {
+        throw NSError(domain: "ContractTest", code: 84,
+            userInfo: [NSLocalizedDescriptionKey: "Remote File Editor refresh path can still overwrite unsaved selected file content"])
+    }
+    print("[PASS] Fetch path refuses to overwrite unsaved selected file content")
+
+    guard viewSource.contains(".disabled(!viewModel.canRefreshSelectedFile)") else {
+        throw NSError(domain: "ContractTest", code: 85,
+            userInfo: [NSLocalizedDescriptionKey: "Remote File Editor refresh button is not bound to refresh safety state"])
+    }
+    print("[PASS] Refresh button is bound to refresh safety state")
+
     guard viewModelSource.contains("openFiles[index].fileSize = oldFile.fileSize") else {
         throw NSError(domain: "ContractTest", code: 81,
             userInfo: [NSLocalizedDescriptionKey: "RemoteFileEditor rename path does not preserve fileSize"])

--- a/tests/FileLogDBContractTests.swift
+++ b/tests/FileLogDBContractTests.swift
@@ -8,6 +8,8 @@ func runFileLogDBContractTests(testDir: String, fixturesDir: String, decoder: JS
     try testRemoteFileEditorPinCommandShape(testDir: testDir)
     try testRemoteFileEditorModelAndPathShape(testDir: testDir)
     try testRemoteFileBrowserStaleRequestGuard(testDir: testDir)
+    try testPinnedTabClosePreservesVisibleStateUntilUnpinSucceeds(testDir: testDir)
+    try testRemoteLogTailPickerOnlyShowsSupportedCounts(testDir: testDir)
 }
 
 func testDbDescribe(fixturesDir: String, decoder: JSONDecoder) throws {
@@ -287,6 +289,70 @@ func testRemoteFileBrowserStaleRequestGuard(testDir: String) throws {
         message: "goToPath can still clear loading state for a newer in-flight request"
     )
     print("[PASS] Loading state is cleared only by the active request")
+
+    print("")
+}
+
+func testPinnedTabClosePreservesVisibleStateUntilUnpinSucceeds(testDir: String) throws {
+    print("Test: Pinned tab close preserves visible state")
+    print("------------------------------------------------")
+
+    let root = URL(fileURLWithPath: testDir).deletingLastPathComponent()
+    let fileViewModelPath = root.appendingPathComponent("Homeboy/Extensions/RemoteFileEditor/RemoteFileEditorViewModel.swift")
+    let logViewModelPath = root.appendingPathComponent("Homeboy/Extensions/RemoteLogViewer/RemoteLogViewerViewModel.swift")
+
+    let fileSource = try String(contentsOf: fileViewModelPath, encoding: .utf8)
+    let logSource = try String(contentsOf: logViewModelPath, encoding: .utf8)
+
+    guard fileSource.contains("_ = try await cli.filePinRemove(projectId: projectId, path: file.path)\n                    closeOpenFileTab(id)") else {
+        throw NSError(domain: "ContractTest", code: 86,
+            userInfo: [NSLocalizedDescriptionKey: "Remote File close does not wait for pinned unpin before removing the tab"])
+    }
+    print("[PASS] Pinned file close removes the tab only after unpin succeeds")
+
+    guard fileSource.contains("Failed to unpin file:") else {
+        throw NSError(domain: "ContractTest", code: 87,
+            userInfo: [NSLocalizedDescriptionKey: "Remote File close does not surface pinned unpin failures"])
+    }
+    print("[PASS] Pinned file close surfaces unpin failure")
+
+    guard logSource.contains("try await unpinLog(path: log.path)\n                    closeOpenLogTab(id)") else {
+        throw NSError(domain: "ContractTest", code: 88,
+            userInfo: [NSLocalizedDescriptionKey: "Remote Log close does not wait for pinned unpin before removing the tab"])
+    }
+    print("[PASS] Pinned log close removes the tab only after unpin succeeds")
+
+    guard logSource.contains("Failed to unpin log:") else {
+        throw NSError(domain: "ContractTest", code: 89,
+            userInfo: [NSLocalizedDescriptionKey: "Remote Log close does not surface pinned unpin failures"])
+    }
+    print("[PASS] Pinned log close surfaces unpin failure")
+
+    print("")
+}
+
+func testRemoteLogTailPickerOnlyShowsSupportedCounts(testDir: String) throws {
+    print("Test: Remote Log tail picker supported counts")
+    print("------------------------------------------------")
+
+    let root = URL(fileURLWithPath: testDir).deletingLastPathComponent()
+    let viewModelPath = root.appendingPathComponent("Homeboy/Extensions/RemoteLogViewer/RemoteLogViewerViewModel.swift")
+    let viewPath = root.appendingPathComponent("Homeboy/Extensions/RemoteLogViewer/Views/RemoteLogViewerView.swift")
+
+    let viewModelSource = try String(contentsOf: viewModelPath, encoding: .utf8)
+    let viewSource = try String(contentsOf: viewPath, encoding: .utf8)
+
+    guard viewModelSource.contains("static let tailOptions = [50, 100, 500, 1000]") else {
+        throw NSError(domain: "ContractTest", code: 90,
+            userInfo: [NSLocalizedDescriptionKey: "Remote Log tail options changed without updating this contract"])
+    }
+    print("[PASS] Tail options contain only explicit line counts")
+
+    guard !viewSource.contains("count == 0 ? \"All\"") else {
+        throw NSError(domain: "ContractTest", code: 91,
+            userInfo: [NSLocalizedDescriptionKey: "Remote Log tail picker still contains dead All display branch"])
+    }
+    print("[PASS] Tail picker does not render unsupported All option")
 
     print("")
 }

--- a/tests/FileLogDBContractTests.swift
+++ b/tests/FileLogDBContractTests.swift
@@ -7,6 +7,7 @@ func runFileLogDBContractTests(testDir: String, fixturesDir: String, decoder: JS
     try testRemoteLogViewerPinCommandShape(testDir: testDir)
     try testRemoteFileEditorPinCommandShape(testDir: testDir)
     try testRemoteFileEditorModelAndPathShape(testDir: testDir)
+    try testRemoteFileBrowserStaleRequestGuard(testDir: testDir)
 }
 
 func testDbDescribe(fixturesDir: String, decoder: JSONDecoder) throws {
@@ -201,6 +202,72 @@ func testRemoteFileEditorModelAndPathShape(testDir: String) throws {
             userInfo: [NSLocalizedDescriptionKey: "Remote File Editor still contains duplicated prefix-drop path conversion"])
     }
     print("[PASS] Duplicated prefix-drop path conversion is absent")
+
+    print("")
+}
+
+func testRemoteFileBrowserStaleRequestGuard(testDir: String) throws {
+    print("Test: Remote File Browser stale request guard")
+    print("---------------------------------------------")
+
+    let browserPath = URL(fileURLWithPath: testDir)
+        .deletingLastPathComponent()
+        .appendingPathComponent("Homeboy/Core/SSH/RemoteFileBrowser.swift")
+    let browserSource = try String(contentsOf: browserPath, encoding: .utf8)
+    let goToPathSource = try sourceSlice(
+        browserSource,
+        from: "func goToPath(_ path: String) async {",
+        to: "    /// Navigate to parent directory"
+    )
+
+    try assertContains(
+        browserSource,
+        "private var requestGeneration = 0",
+        message: "RemoteFileBrowser does not track file-list request generations"
+    )
+    print("[PASS] Browser tracks request generations")
+
+    try assertContains(
+        browserSource,
+        "private var activeListRequest: FileListRequest?",
+        message: "RemoteFileBrowser does not retain the active file-list request identity"
+    )
+    print("[PASS] Browser retains active request identity")
+
+    try assertContains(
+        browserSource,
+        "activeListRequest = nil",
+        message: "RemoteFileBrowser reconnect does not invalidate in-flight file-list requests"
+    )
+    print("[PASS] Reconnect invalidates in-flight requests")
+
+    try assertContains(
+        goToPathSource,
+        "let request = FileListRequest(generation: requestGeneration, projectId: projectId, path: path)",
+        message: "goToPath does not capture generation, project, and path before awaiting file list"
+    )
+    print("[PASS] Navigation captures generation/project/path")
+
+    try assertContains(
+        goToPathSource,
+        "guard activeListRequest == request else { return }\n            currentPath = path",
+        message: "goToPath can still apply stale file-list entries after a newer request wins"
+    )
+    print("[PASS] Stale success results are discarded before mutating entries")
+
+    try assertContains(
+        goToPathSource,
+        "guard activeListRequest == request else { return }\n            self.error = error.toDisplayableError",
+        message: "goToPath can still show stale errors after a newer request wins"
+    )
+    print("[PASS] Stale errors are discarded")
+
+    try assertContains(
+        goToPathSource,
+        "if activeListRequest == request {\n            isLoading = false\n        }",
+        message: "goToPath can still clear loading state for a newer in-flight request"
+    )
+    print("[PASS] Loading state is cleared only by the active request")
 
     print("")
 }

--- a/tests/FileLogDBContractTests.swift
+++ b/tests/FileLogDBContractTests.swift
@@ -7,6 +7,8 @@ func runFileLogDBContractTests(testDir: String, fixturesDir: String, decoder: JS
     try testRemoteLogViewerPinCommandShape(testDir: testDir)
     try testRemoteFileEditorPinCommandShape(testDir: testDir)
     try testRemoteFileEditorModelAndPathShape(testDir: testDir)
+    try testPinnedTabClosePreservesVisibleStateUntilUnpinSucceeds(testDir: testDir)
+    try testRemoteLogTailPickerOnlyShowsSupportedCounts(testDir: testDir)
 }
 
 func testDbDescribe(fixturesDir: String, decoder: JSONDecoder) throws {
@@ -201,6 +203,70 @@ func testRemoteFileEditorModelAndPathShape(testDir: String) throws {
             userInfo: [NSLocalizedDescriptionKey: "Remote File Editor still contains duplicated prefix-drop path conversion"])
     }
     print("[PASS] Duplicated prefix-drop path conversion is absent")
+
+    print("")
+}
+
+func testPinnedTabClosePreservesVisibleStateUntilUnpinSucceeds(testDir: String) throws {
+    print("Test: Pinned tab close preserves visible state")
+    print("------------------------------------------------")
+
+    let root = URL(fileURLWithPath: testDir).deletingLastPathComponent()
+    let fileViewModelPath = root.appendingPathComponent("Homeboy/Extensions/RemoteFileEditor/RemoteFileEditorViewModel.swift")
+    let logViewModelPath = root.appendingPathComponent("Homeboy/Extensions/RemoteLogViewer/RemoteLogViewerViewModel.swift")
+
+    let fileSource = try String(contentsOf: fileViewModelPath, encoding: .utf8)
+    let logSource = try String(contentsOf: logViewModelPath, encoding: .utf8)
+
+    guard fileSource.contains("_ = try await cli.filePinRemove(projectId: projectId, path: file.path)\n                    closeOpenFileTab(id)") else {
+        throw NSError(domain: "ContractTest", code: 83,
+            userInfo: [NSLocalizedDescriptionKey: "Remote File close does not wait for pinned unpin before removing the tab"])
+    }
+    print("[PASS] Pinned file close removes the tab only after unpin succeeds")
+
+    guard fileSource.contains("Failed to unpin file:") else {
+        throw NSError(domain: "ContractTest", code: 84,
+            userInfo: [NSLocalizedDescriptionKey: "Remote File close does not surface pinned unpin failures"])
+    }
+    print("[PASS] Pinned file close surfaces unpin failure")
+
+    guard logSource.contains("try await unpinLog(path: log.path)\n                    closeOpenLogTab(id)") else {
+        throw NSError(domain: "ContractTest", code: 85,
+            userInfo: [NSLocalizedDescriptionKey: "Remote Log close does not wait for pinned unpin before removing the tab"])
+    }
+    print("[PASS] Pinned log close removes the tab only after unpin succeeds")
+
+    guard logSource.contains("Failed to unpin log:") else {
+        throw NSError(domain: "ContractTest", code: 86,
+            userInfo: [NSLocalizedDescriptionKey: "Remote Log close does not surface pinned unpin failures"])
+    }
+    print("[PASS] Pinned log close surfaces unpin failure")
+
+    print("")
+}
+
+func testRemoteLogTailPickerOnlyShowsSupportedCounts(testDir: String) throws {
+    print("Test: Remote Log tail picker supported counts")
+    print("------------------------------------------------")
+
+    let root = URL(fileURLWithPath: testDir).deletingLastPathComponent()
+    let viewModelPath = root.appendingPathComponent("Homeboy/Extensions/RemoteLogViewer/RemoteLogViewerViewModel.swift")
+    let viewPath = root.appendingPathComponent("Homeboy/Extensions/RemoteLogViewer/Views/RemoteLogViewerView.swift")
+
+    let viewModelSource = try String(contentsOf: viewModelPath, encoding: .utf8)
+    let viewSource = try String(contentsOf: viewPath, encoding: .utf8)
+
+    guard viewModelSource.contains("static let tailOptions = [50, 100, 500, 1000]") else {
+        throw NSError(domain: "ContractTest", code: 87,
+            userInfo: [NSLocalizedDescriptionKey: "Remote Log tail options changed without updating this contract"])
+    }
+    print("[PASS] Tail options contain only explicit line counts")
+
+    guard !viewSource.contains("count == 0 ? \"All\"") else {
+        throw NSError(domain: "ContractTest", code: 88,
+            userInfo: [NSLocalizedDescriptionKey: "Remote Log tail picker still contains dead All display branch"])
+    }
+    print("[PASS] Tail picker does not render unsupported All option")
 
     print("")
 }


### PR DESCRIPTION
## Summary
- Keep pinned Remote File and Remote Log tabs visible until the CLI unpin succeeds, surfacing errors instead of hiding still-pinned tabs.
- Remove the dead Remote Log tail picker `All` display branch now that only explicit counts are supported.
- Add contract coverage for pinned close behavior and the supported tail picker options.

Closes #74.
Closes #75.

## Testing
- `DEVELOPER_DIR=\"/Applications/Xcode.app/Contents/Developer\" xcodegen generate --spec project.yml`
- `DEVELOPER_DIR=\"/Applications/Xcode.app/Contents/Developer\" xcodebuild -project Homeboy.xcodeproj -scheme Homeboy -configuration Debug -derivedDataPath .build/DerivedData build`
- `swift tests/ContractTests.swift tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the pinned tab close failure handling, removed the stale log picker branch, added contract coverage, and ran the requested validation commands for Chris to review.