### PR TITLE
Fix pinned tab reload reconciliation

### DIFF
--- a/Homeboy/Extensions/RemoteFileEditor/RemoteFileEditorViewModel.swift
+++ b/Homeboy/Extensions/RemoteFileEditor/RemoteFileEditorViewModel.swift
@@ -82,7 +82,7 @@ class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
         case .projectModified(_, let fields):
             // Reload pinned files if remoteFiles changed
             if fields.contains(.remoteFiles) {
-                loadPinnedFiles()
+                reconcilePinnedFiles()
             }
         default:
             break
@@ -95,6 +95,26 @@ class RemoteFileEditorViewModel: ObservableObject, ConfigurationObserving {
 
         // Select first file if available
         if let first = openFiles.first {
+            selectedFileId = first.id
+        }
+    }
+
+    private func reconcilePinnedFiles() {
+        let pinnedFiles = ConfigurationManager.shared.safeActiveProject.remoteFiles.pinnedFiles
+        var pinnedByPath: [String: PinnedRemoteFile] = [:]
+        for pinned in pinnedFiles {
+            pinnedByPath[pinned.path] = pinned
+        }
+
+        for index in openFiles.indices {
+            openFiles[index].isPinned = pinnedByPath[openFiles[index].path] != nil
+        }
+
+        for pinned in pinnedFiles where !openFiles.contains(where: { $0.path == pinned.path }) {
+            openFiles.append(OpenFile(from: pinned))
+        }
+
+        if selectedFileId == nil, let first = openFiles.first {
             selectedFileId = first.id
         }
     }

--- a/Homeboy/Extensions/RemoteLogViewer/RemoteLogViewerViewModel.swift
+++ b/Homeboy/Extensions/RemoteLogViewer/RemoteLogViewerViewModel.swift
@@ -60,7 +60,7 @@ class RemoteLogViewerViewModel: ObservableObject, ConfigurationObserving {
         case .projectModified(_, let fields):
             // Reload pinned logs if remoteLogs changed
             if fields.contains(.remoteLogs) {
-                loadPinnedLogs()
+                reconcilePinnedLogs()
             }
         default:
             break
@@ -74,6 +74,31 @@ class RemoteLogViewerViewModel: ObservableObject, ConfigurationObserving {
 
         // Select first log if available
         if let first = openLogs.first {
+            selectedLogId = first.id
+        }
+    }
+
+    private func reconcilePinnedLogs() {
+        let pinnedLogs = ConfigurationManager.shared.safeActiveProject.remoteLogs.pinnedLogs
+        var pinnedByPath: [String: PinnedRemoteLog] = [:]
+        for pinned in pinnedLogs {
+            pinnedByPath[pinned.path] = pinned
+        }
+
+        for index in openLogs.indices {
+            if let pinned = pinnedByPath[openLogs[index].path] {
+                openLogs[index].isPinned = true
+                openLogs[index].tailLines = max(1, pinned.tailLines)
+            } else {
+                openLogs[index].isPinned = false
+            }
+        }
+
+        for pinned in pinnedLogs where !openLogs.contains(where: { $0.path == pinned.path }) {
+            openLogs.append(OpenLog(from: pinned))
+        }
+
+        if selectedLogId == nil, let first = openLogs.first {
             selectedLogId = first.id
         }
     }

--- a/tests/FileLogDBContractTests.swift
+++ b/tests/FileLogDBContractTests.swift
@@ -7,6 +7,7 @@ func runFileLogDBContractTests(testDir: String, fixturesDir: String, decoder: JS
     try testRemoteLogViewerPinCommandShape(testDir: testDir)
     try testRemoteFileEditorPinCommandShape(testDir: testDir)
     try testRemoteFileEditorModelAndPathShape(testDir: testDir)
+    try testRemoteFileAndLogPinnedReloadReconciliation(testDir: testDir)
 }
 
 func testDbDescribe(fixturesDir: String, decoder: JSONDecoder) throws {
@@ -69,6 +70,60 @@ func testDbDescribe(fixturesDir: String, decoder: JSONDecoder) throws {
     for table in tables {
         print("    - \(table.Name) (\(table.Rows ?? "?") rows)")
     }
+    print("")
+}
+
+func testRemoteFileAndLogPinnedReloadReconciliation(testDir: String) throws {
+    print("Test: Remote File/Log pinned reload reconciliation")
+    print("--------------------------------------------------")
+
+    let root = URL(fileURLWithPath: testDir).deletingLastPathComponent()
+    let fileViewModelPath = root.appendingPathComponent("Homeboy/Extensions/RemoteFileEditor/RemoteFileEditorViewModel.swift")
+    let logViewModelPath = root.appendingPathComponent("Homeboy/Extensions/RemoteLogViewer/RemoteLogViewerViewModel.swift")
+
+    let fileSource = try String(contentsOf: fileViewModelPath, encoding: .utf8)
+    let logSource = try String(contentsOf: logViewModelPath, encoding: .utf8)
+
+    guard fileSource.contains("reconcilePinnedFiles()") else {
+        throw NSError(domain: "ContractTest", code: 83,
+            userInfo: [NSLocalizedDescriptionKey: "RemoteFileEditorViewModel does not reconcile pinned files on config reload"])
+    }
+    print("[PASS] Remote File Editor uses a pinned-file reconcile path")
+
+    guard logSource.contains("reconcilePinnedLogs()") else {
+        throw NSError(domain: "ContractTest", code: 84,
+            userInfo: [NSLocalizedDescriptionKey: "RemoteLogViewerViewModel does not reconcile pinned logs on config reload"])
+    }
+    print("[PASS] Remote Log Viewer uses a pinned-log reconcile path")
+
+    guard fileSource.contains("openFiles[index].isPinned = pinnedByPath[openFiles[index].path] != nil") else {
+        throw NSError(domain: "ContractTest", code: 85,
+            userInfo: [NSLocalizedDescriptionKey: "Remote File Editor reconcile path does not update existing file pin state"])
+    }
+    print("[PASS] Existing file tabs keep their tab identity while pin state changes")
+
+    guard logSource.contains("openLogs[index].isPinned = true")
+        && logSource.contains("openLogs[index].tailLines = max(1, pinned.tailLines)")
+        && logSource.contains("openLogs[index].isPinned = false") else {
+        throw NSError(domain: "ContractTest", code: 86,
+            userInfo: [NSLocalizedDescriptionKey: "Remote Log Viewer reconcile path does not update existing log pin metadata"])
+    }
+    print("[PASS] Existing log tabs keep their tab identity while pin metadata changes")
+
+    guard fileSource.contains("openFiles.append(OpenFile(from: pinned))")
+        && logSource.contains("openLogs.append(OpenLog(from: pinned))") else {
+        throw NSError(domain: "ContractTest", code: 87,
+            userInfo: [NSLocalizedDescriptionKey: "Pinned reload reconciliation does not append newly pinned tabs"])
+    }
+    print("[PASS] Newly pinned files and logs are appended without replacing temporary tabs")
+
+    guard fileSource.contains("openFiles = config.remoteFiles.pinnedFiles.map")
+        && logSource.contains("openLogs = config.remoteLogs.pinnedLogs.map") else {
+        throw NSError(domain: "ContractTest", code: 88,
+            userInfo: [NSLocalizedDescriptionKey: "Project-switch pinned tab reset loaders are missing"])
+    }
+    print("[PASS] Project-switch full reset loaders remain available")
+
     print("")
 }
 


### PR DESCRIPTION
## Summary
- Reconcile Remote File Editor pinned config changes into existing open tabs instead of replacing the full tab list.
- Reconcile Remote Log Viewer pinned config changes in place, including tail-line metadata for pinned logs.
- Add contract coverage for pinned reload reconciliation while preserving project-switch full resets.

Closes #71.

## Testing
- `DEVELOPER_DIR=\"/Applications/Xcode.app/Contents/Developer\" xcodegen generate --spec project.yml`
- `DEVELOPER_DIR=\"/Applications/Xcode.app/Contents/Developer\" xcodebuild -project Homeboy.xcodeproj -scheme Homeboy -configuration Debug -derivedDataPath .build/DerivedData build`
- `swift tests/ContractTests.swift tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the pinned tab reconciliation implementation and contract coverage; Chris remains responsible for review and merge.