### PR TITLE
feat: add Homeboy Lab cockpit

### DIFF
--- a/Homeboy.xcodeproj/project.pbxproj
+++ b/Homeboy.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		27D41F217F00E3A8171BEC63 /* AppWarning.swift in Sources */ = {isa = PBXBuildFile; fileRef = C489D03946456721B73D70EA /* AppWarning.swift */; };
 		29AC5918A42B81DE1D250360 /* ContentContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC77F3DE919D687C5088735B /* ContentContext.swift */; };
 		2A0D8EC80F531D2458B4F000 /* DatabaseSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99F53066BAD2365203BC1A21 /* DatabaseSettingsTab.swift */; };
+		2B66E2C66072EA7F119F138A /* HomeboyLabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2734F8A242983E0642DBD72B /* HomeboyLabView.swift */; };
 		2BDBF9B46483155A6701C845 /* ConfigurationChangeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4847DDB6175D9E32C423C8C /* ConfigurationChangeType.swift */; };
 		2FA2E2EB6635082599CF1172 /* RigsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35595CC7BEFD826A8FE56039 /* RigsViewModel.swift */; };
 		306DE99757A1BBA6E328A8FF /* HomeboyCLI+WorkspaceCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = A087DAB3F4E912476EC93E01 /* HomeboyCLI+WorkspaceCommands.swift */; };
@@ -50,6 +51,7 @@
 		58782E3C2B83E467318758D3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E134C3E1AFDFB8B9C3BFA989 /* Assets.xcassets */; };
 		58C9903BC07607162259D792 /* SSHKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9B567AD7EF6AEAFF4650E3 /* SSHKeyManager.swift */; };
 		59B9942920AA8A82C6687BA1 /* ExtensionActionsBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84CD4544E216646E96957DA /* ExtensionActionsBar.swift */; };
+		5A062EFBFD4AC1A479B90C02 /* HomeboyCLI+RunnerCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E87D23CDA0D3B452F3CB752 /* HomeboyCLI+RunnerCommands.swift */; };
 		5A7E75D51012C3ED36EA7853 /* CLIExtensionTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E32E869268148C1260D05F85 /* CLIExtensionTypes.swift */; };
 		5A9B1A9B7984F57035A97D82 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D06A62D2DDC840DC6A12CC7 /* KeychainService.swift */; };
 		5B3425AA6A8A9C4C9EF5E29F /* FileBrowserSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD70F8136E9691D7528CB581 /* FileBrowserSidebarView.swift */; };
@@ -94,6 +96,7 @@
 		A34392C1F77DDF4B0B386D8C /* DataTableConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = F915FEEAF97ADD6EAADF6E4A /* DataTableConstants.swift */; };
 		A387D3BAF65EFBE5A44AA37C /* CommandBrowserEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0075D42A490CE7EF713A874F /* CommandBrowserEntry.swift */; };
 		A40B645FCF64C59E6F1EC4FC /* HomeboyCLI+QualityCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC23AFFAB50FD8AFD042E644 /* HomeboyCLI+QualityCommands.swift */; };
+		A6C1285910873B6C02B4CE79 /* HomeboyDaemonClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C1F6860A60F30A9D01D6E9A /* HomeboyDaemonClient.swift */; };
 		A744C6D0692C0EF9B142E839 /* HomeboyCLI+LogCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CB4FFA7533765478562751F /* HomeboyCLI+LogCommands.swift */; };
 		A79AD1D6F7DD14F02410D120 /* LogTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670327C19CE0F089CFF35DD1 /* LogTextView.swift */; };
 		AB378FCB8518F6BED6EEFB6F /* DisplayableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C195A8A1462489E882BC187 /* DisplayableError.swift */; };
@@ -127,6 +130,7 @@
 		EC9244E3C614561638C57AB7 /* RunHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE68C48FE619E6E7F8BB5F1 /* RunHistoryView.swift */; };
 		EEA581470DC8B48027F54228 /* InlineWarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DC18F8D8A50F464D296BB74 /* InlineWarningView.swift */; };
 		F34BB35C6C33E774792043ED /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B2C9499D9E9A17D32109EF /* SettingsView.swift */; };
+		FA9088059644CB053678418A /* HomeboyLabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E7EFDB7496ED01FDCCC77B /* HomeboyLabViewModel.swift */; };
 		FB914712293D43F2D7D80F80 /* CreateProjectSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91949A849E1F8F3490BBEC6A /* CreateProjectSheet.swift */; };
 		FDC7A36317A54E1EE4486D4A /* GitOperationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC13102738FFBE2F5695F78 /* GitOperationsView.swift */; };
 		FE865BA85263630F8BF6A608 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2507DAC42BC6CDA2DF39CE /* AuthManager.swift */; };
@@ -142,8 +146,10 @@
 		13F8D60E3516F29F554438A0 /* VersionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionParser.swift; sourceTree = "<group>"; };
 		14349D465EC79FD6D1D8C70C /* DatabaseTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseTypes.swift; sourceTree = "<group>"; };
 		19D0AC4BB8035D3A38DF8F83 /* CommandBrowserCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBrowserCatalog.swift; sourceTree = "<group>"; };
+		1C1F6860A60F30A9D01D6E9A /* HomeboyDaemonClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeboyDaemonClient.swift; sourceTree = "<group>"; };
 		20129FFBFEEBA4948B8DA194 /* WarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarningView.swift; sourceTree = "<group>"; };
 		21391AE5E442FFA2A2843821 /* SiteListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteListView.swift; sourceTree = "<group>"; };
+		2734F8A242983E0642DBD72B /* HomeboyLabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeboyLabView.swift; sourceTree = "<group>"; };
 		2E7289F91C0EA517A3DE5DB9 /* RemoteFileBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileBrowser.swift; sourceTree = "<group>"; };
 		2FC13102738FFBE2F5695F78 /* GitOperationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitOperationsView.swift; sourceTree = "<group>"; };
 		3320B46DC4876237EA4C9ACE /* GitOperationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitOperationsViewModel.swift; sourceTree = "<group>"; };
@@ -168,7 +174,9 @@
 		4C3C30739F765981B37603DD /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		4ED098FFBF749CD6DD355B1B /* CollapsibleSplitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleSplitView.swift; sourceTree = "<group>"; };
 		514BD1BE8868C181AD9401CF /* LogContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogContentView.swift; sourceTree = "<group>"; };
+		53E7EFDB7496ED01FDCCC77B /* HomeboyLabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeboyLabViewModel.swift; sourceTree = "<group>"; };
 		5BA9BAC48CD6CC681F9FD2C5 /* ExtensionManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionManifest.swift; sourceTree = "<group>"; };
+		5E87D23CDA0D3B452F3CB752 /* HomeboyCLI+RunnerCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+RunnerCommands.swift"; sourceTree = "<group>"; };
 		60913533AA72054F3D79625C /* ArtifactVersionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactVersionParser.swift; sourceTree = "<group>"; };
 		61EC8F9095C4AC67383B9F4A /* ConfigGapsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigGapsView.swift; sourceTree = "<group>"; };
 		64DFC1DFC648B2D106BA5361 /* ExtensionsSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsSettingsTab.swift; sourceTree = "<group>"; };
@@ -413,6 +421,7 @@
 			children = (
 				A7A27F9F448DAC4DF35613F9 /* APIClient.swift */,
 				3A6FE3DEAD139D529B6724D8 /* APITypes.swift */,
+				1C1F6860A60F30A9D01D6E9A /* HomeboyDaemonClient.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -432,6 +441,7 @@
 				BC23AFFAB50FD8AFD042E644 /* HomeboyCLI+QualityCommands.swift */,
 				0DD2E86E7655D2ED45CB0E31 /* HomeboyCLI+RigBenchReleaseCommands.swift */,
 				BFAF5103FCB24063514E519F /* HomeboyCLI+RunCommands.swift */,
+				5E87D23CDA0D3B452F3CB752 /* HomeboyCLI+RunnerCommands.swift */,
 				DA7F7ED4B0D0B46D19BF8438 /* HomeboyCLI+StackCommands.swift */,
 				A087DAB3F4E912476EC93E01 /* HomeboyCLI+WorkspaceCommands.swift */,
 				D8D33E39732C375690D3AC46 /* HomeboyCLIModels.swift */,
@@ -455,6 +465,7 @@
 				92301854AF9D7FCE0328DB48 /* CommandBrowser */,
 				8007D7D3CCEF3F80C36AA686 /* Components */,
 				48CA5756F2D78ADA9FCD0AFD /* Extensions */,
+				8ED6A8EAFE27B075CDD8C830 /* Lab */,
 				144F0E432A914DE9F141CEFA /* Rigs */,
 				38FA3F3D4C5F5FD7C14C524A /* RunHistory */,
 				F08C0BC0AC87CDDCAA5955CF /* Settings */,
@@ -510,6 +521,15 @@
 				20129FFBFEEBA4948B8DA194 /* WarningView.swift */,
 			);
 			path = Components;
+			sourceTree = "<group>";
+		};
+		8ED6A8EAFE27B075CDD8C830 /* Lab */ = {
+			isa = PBXGroup;
+			children = (
+				2734F8A242983E0642DBD72B /* HomeboyLabView.swift */,
+				53E7EFDB7496ED01FDCCC77B /* HomeboyLabViewModel.swift */,
+			);
+			path = Lab;
 			sourceTree = "<group>";
 		};
 		9035A8A5FC0007090577B120 /* Quality */ = {
@@ -845,10 +865,14 @@
 				A40B645FCF64C59E6F1EC4FC /* HomeboyCLI+QualityCommands.swift in Sources */,
 				46238C2E19607D4410D23FA2 /* HomeboyCLI+RigBenchReleaseCommands.swift in Sources */,
 				19F0A3B40B6B6BA59A201C7F /* HomeboyCLI+RunCommands.swift in Sources */,
+				5A062EFBFD4AC1A479B90C02 /* HomeboyCLI+RunnerCommands.swift in Sources */,
 				6861D39F7EB9C8E226731A6A /* HomeboyCLI+StackCommands.swift in Sources */,
 				306DE99757A1BBA6E328A8FF /* HomeboyCLI+WorkspaceCommands.swift in Sources */,
 				278021F9D228BBDA95267231 /* HomeboyCLI.swift in Sources */,
 				CC892914AFEB03C734959003 /* HomeboyCLIModels.swift in Sources */,
+				A6C1285910873B6C02B4CE79 /* HomeboyDaemonClient.swift in Sources */,
+				2B66E2C66072EA7F119F138A /* HomeboyLabView.swift in Sources */,
+				FA9088059644CB053678418A /* HomeboyLabViewModel.swift in Sources */,
 				E832787BA1F926FB3A085E09 /* InlineErrorView.swift in Sources */,
 				EEA581470DC8B48027F54228 /* InlineWarningView.swift in Sources */,
 				5BDE52F8E2A18B1F50AD060A /* JSONValue.swift in Sources */,

--- a/Homeboy/App/ContentView.swift
+++ b/Homeboy/App/ContentView.swift
@@ -15,6 +15,7 @@ enum CoreTool: String, CaseIterable, Identifiable {
     case commandBrowser = "Commands"
     case deployer = "Deployer"
     case bench = "Bench"
+    case lab = "Lab"
     case runHistory = "Run History"
     case release = "Release"
     case rigs = "Rigs"
@@ -34,6 +35,7 @@ enum CoreTool: String, CaseIterable, Identifiable {
         case .commandBrowser: return "terminal"
         case .deployer: return "arrow.up.to.line"
         case .bench: return "speedometer"
+        case .lab: return "desktopcomputer.and.arrow.down"
         case .runHistory: return "clock.arrow.circlepath"
         case .release: return "tag"
         case .rigs: return "shippingbox.and.arrow.backward"
@@ -59,7 +61,7 @@ enum CoreTool: String, CaseIterable, Identifiable {
             return true
         case .settings:
             return true
-        case .deployer, .bench, .runHistory, .release, .rigs, .stackManager, .git, .quality:
+        case .deployer, .bench, .lab, .runHistory, .release, .rigs, .stackManager, .git, .quality:
             return hasComponents
         case .remoteFileEditor, .remoteLogViewer:
             return hasRemoteTarget
@@ -128,6 +130,8 @@ struct ContentView: View {
                 .opacity(selectedItem == .coreTool(.deployer) ? 1 : 0)
             BenchView()
                 .opacity(selectedItem == .coreTool(.bench) ? 1 : 0)
+            HomeboyLabView()
+                .opacity(selectedItem == .coreTool(.lab) ? 1 : 0)
             RunHistoryView()
                 .opacity(selectedItem == .coreTool(.runHistory) ? 1 : 0)
             ReleaseWorkflowView()

--- a/Homeboy/Core/API/HomeboyDaemonClient.swift
+++ b/Homeboy/Core/API/HomeboyDaemonClient.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+actor HomeboyDaemonClient {
+    private let baseURL: URL
+    private let decoder: JSONDecoder
+
+    init(baseURL: String) throws {
+        guard let url = URL(string: baseURL) else {
+            throw URLError(.badURL)
+        }
+        self.baseURL = url
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        self.decoder = decoder
+    }
+
+    func listJobs() async throws -> [DaemonJob] {
+        let response: DaemonAPIResponse<DaemonJobsOutput> = try await request("/jobs")
+        return response.body.jobs
+    }
+
+    func showJob(id: String) async throws -> DaemonJob {
+        let response: DaemonAPIResponse<DaemonJobOutput> = try await request("/jobs/\(id)")
+        return response.body.job
+    }
+
+    func jobEvents(id: String) async throws -> [DaemonJobEvent] {
+        let response: DaemonAPIResponse<DaemonJobEventsOutput> = try await request("/jobs/\(id)/events")
+        return response.body.events
+    }
+
+    func cancelJob(id: String) async throws -> DaemonJob {
+        let response: DaemonAPIResponse<DaemonJobOutput> = try await request("/jobs/\(id)/cancel", method: "POST")
+        return response.body.job
+    }
+
+    func enqueue(kind: String, body: [String: JSONValue]) async throws -> DaemonJobEnqueueOutput {
+        let response: DaemonAPIResponse<DaemonJobEnqueueOutput> = try await request(
+            "/\(kind)",
+            method: "POST",
+            body: JSONValue.object(body)
+        )
+        return response.body
+    }
+
+    func listArtifacts(runId: String) async throws -> [RunArtifact] {
+        let response: DaemonAPIResponse<RunsArtifactsOutput> = try await request("/runs/\(runId)/artifacts")
+        return response.body.artifacts
+    }
+
+    func artifactSyncManifest(runId: String) async throws -> [RunArtifactSyncItem] {
+        let response: DaemonAPIResponse<RunsArtifactSyncOutput> = try await request("/runs/\(runId)/artifacts/sync")
+        return response.body.artifacts
+    }
+
+    func downloadArtifact(runId: String, artifactId: String) async throws -> URL {
+        let url = baseURL.appending(path: "runs/\(runId)/artifacts/\(artifactId)")
+        let (downloadURL, response) = try await URLSession.shared.download(from: url)
+        guard let httpResponse = response as? HTTPURLResponse, (200..<300).contains(httpResponse.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+
+        let suggestedName = response.suggestedFilename ?? artifactId
+        let destination = FileManager.default.temporaryDirectory
+            .appendingPathComponent("homeboy-artifact-\(UUID().uuidString)-\(suggestedName)")
+        try FileManager.default.moveItem(at: downloadURL, to: destination)
+        return destination
+    }
+
+    private func request<T: Decodable>(
+        _ path: String,
+        method: String = "GET",
+        body: JSONValue? = nil
+    ) async throws -> T {
+        let url = baseURL.appending(path: path.trimmingCharacters(in: CharacterSet(charactersIn: "/")))
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        if let body {
+            request.httpBody = try JSONEncoder().encode(body)
+        }
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            throw HomeboyDaemonError(statusCode: httpResponse.statusCode, body: String(data: data, encoding: .utf8) ?? "")
+        }
+
+        let envelope = try decoder.decode(DaemonEnvelope<T>.self, from: data)
+        guard envelope.success, let decoded = envelope.data else {
+            throw HomeboyDaemonError(statusCode: httpResponse.statusCode, body: String(data: data, encoding: .utf8) ?? "")
+        }
+        return decoded
+    }
+}
+
+struct HomeboyDaemonError: LocalizedError {
+    let statusCode: Int
+    let body: String
+
+    var errorDescription: String? {
+        "Homeboy daemon request failed (HTTP \(statusCode)): \(body)"
+    }
+}

--- a/Homeboy/Core/CLI/HomeboyCLI+RunnerCommands.swift
+++ b/Homeboy/Core/CLI/HomeboyCLI+RunnerCommands.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+@MainActor
+extension HomeboyCLI {
+    func runnerList() async throws -> [HomeboyRunner] {
+        let output: RunnerListOutput = try await cli.executeCommand(
+            ["runner", "list"],
+            dataType: RunnerListOutput.self,
+            source: "Homeboy Lab",
+            timeout: 30
+        )
+
+        let configured = output.entities
+        if configured.contains(where: { $0.id == HomeboyRunner.localDefault.id }) {
+            return configured
+        }
+
+        return [HomeboyRunner.localDefault] + configured
+    }
+
+    func runnerDoctor(id: String) async throws -> RunnerDoctorOutput {
+        try await cli.executeCommand(
+            ["runner", "doctor", id],
+            dataType: RunnerDoctorOutput.self,
+            source: "Homeboy Lab",
+            timeout: 120
+        )
+    }
+
+    func runnerConnect(id: String) async throws -> RunnerConnection {
+        let output: RunnerConnectionOutput = try await cli.executeCommand(
+            ["runner", "connect", id],
+            dataType: RunnerConnectionOutput.self,
+            source: "Homeboy Lab",
+            timeout: 120
+        )
+        guard let connection = output.extra?.connection else {
+            throw CLIBridgeError.invalidResponse("Runner connect response missing connection report")
+        }
+        return connection
+    }
+
+    func runnerStatus(id: String) async throws -> RunnerConnection {
+        let output: RunnerConnectionOutput = try await cli.executeCommand(
+            ["runner", "status", id],
+            dataType: RunnerConnectionOutput.self,
+            source: "Homeboy Lab",
+            timeout: 30
+        )
+        guard let connection = output.extra?.connection else {
+            throw CLIBridgeError.invalidResponse("Runner status response missing connection report")
+        }
+        return connection
+    }
+
+    func runnerDisconnect(id: String) async throws -> RunnerConnection {
+        let output: RunnerConnectionOutput = try await cli.executeCommand(
+            ["runner", "disconnect", id],
+            dataType: RunnerConnectionOutput.self,
+            source: "Homeboy Lab",
+            timeout: 30
+        )
+        guard let connection = output.extra?.connection else {
+            throw CLIBridgeError.invalidResponse("Runner disconnect response missing connection report")
+        }
+        return connection
+    }
+
+    func runsArtifactGet(runId: String, artifactId: String, outputPath: String) async throws {
+        let response = try await cli.execute(
+            ["runs", "artifact", "get", runId, artifactId, "--output", outputPath],
+            timeout: 120
+        )
+        guard response.success else {
+            throw CLIBridgeError.executionFailed(exitCode: response.exitCode, message: response.errorOutput)
+        }
+    }
+}

--- a/Homeboy/Core/CLI/HomeboyCLIModels.swift
+++ b/Homeboy/Core/CLI/HomeboyCLIModels.swift
@@ -1064,6 +1064,30 @@ struct RunsArtifactsOutput: Decodable {
     let artifacts: [RunArtifact]
 }
 
+struct RunsArtifactSyncOutput: Decodable {
+    let command: String
+    let runId: String
+    let artifacts: [RunArtifactSyncItem]
+}
+
+struct RunArtifactSyncItem: Decodable, Identifiable {
+    let id: String
+    let pathToken: String
+    let runId: String
+    let kind: String
+    let artifactType: String
+    let downloadPath: String
+    let sha256: String?
+    let sizeBytes: Int64?
+    let mime: String?
+    let createdAt: String
+
+    private enum CodingKeys: String, CodingKey {
+        case id, pathToken, runId, kind, downloadPath, sha256, sizeBytes, mime, createdAt
+        case artifactType = "type"
+    }
+}
+
 struct RunsFindingsOutput: Decodable {
     let command: String
     let runId: String
@@ -1285,4 +1309,247 @@ struct ConfigGapDetail: Decodable, Identifiable {
     let command: String
     
     var id: String { "\(componentId).\(field)" }
+}
+
+// MARK: - Homeboy Lab Runner Models
+
+struct RunnerListOutput: Decodable {
+    let command: String
+    let entities: [HomeboyRunner]
+}
+
+struct RunnerShowOutput: Decodable {
+    let command: String
+    let id: String?
+    let entity: HomeboyRunner?
+}
+
+struct RunnerConnectionOutput: Decodable {
+    let command: String
+    let id: String?
+    let extra: RunnerExtra?
+}
+
+struct RunnerExtra: Decodable {
+    let connection: RunnerConnection?
+}
+
+struct RunnerConnection: Decodable {
+    let action: String
+    let runnerId: String
+    let connected: Bool?
+    let disconnected: Bool?
+    let localUrl: String?
+    let remoteDaemonAddress: String?
+    let tunnelPid: Int?
+    let remoteDaemonPid: Int?
+    let homeboyVersion: String?
+    let sessionPath: String?
+    let failureKind: String?
+    let failureMessage: String?
+    let session: RunnerSession?
+}
+
+struct RunnerSession: Decodable {
+    let runnerId: String
+    let serverId: String?
+    let remoteDaemonAddress: String
+    let localPort: Int
+    let localUrl: String
+    let tunnelPid: Int?
+    let remoteDaemonPid: Int?
+    let homeboyVersion: String
+    let connectedAt: String
+}
+
+struct HomeboyRunner: Decodable, Identifiable {
+    let id: String
+    let kind: String
+    let serverId: String?
+    let workspaceRoot: String?
+    let homeboyPath: String?
+    let daemon: Bool
+    let concurrencyLimit: Int?
+    let artifactPolicy: String?
+    let env: [String: JSONValue]
+    let resources: [String: JSONValue]
+
+    static let localDefault = HomeboyRunner(
+        id: "local",
+        kind: "local",
+        serverId: nil,
+        workspaceRoot: nil,
+        homeboyPath: nil,
+        daemon: false,
+        concurrencyLimit: nil,
+        artifactPolicy: nil,
+        env: [:],
+        resources: [:]
+    )
+}
+
+struct RunnerDoctorOutput: Decodable {
+    let command: String
+    let runnerId: String
+    let runner: RunnerTargetSummary
+    let status: String
+    let capabilities: RunnerCapabilities
+    let resources: RunnerResources
+    let checks: [RunnerCheck]
+}
+
+struct RunnerTargetSummary: Decodable {
+    let targetType: String
+    let registry: RunnerRegistrySummary?
+    let server: RunnerServerSummary?
+
+    private enum CodingKeys: String, CodingKey {
+        case targetType = "type"
+        case registry
+        case server
+    }
+}
+
+struct RunnerRegistrySummary: Decodable {
+    let id: String
+    let kind: String
+}
+
+struct RunnerServerSummary: Decodable {
+    let id: String
+    let host: String
+    let user: String
+    let port: Int
+    let isLocalhost: Bool
+}
+
+struct RunnerCapabilities: Decodable {
+    let localExecution: Bool
+    let sshExecution: Bool
+    let git: Bool
+    let githubCli: Bool
+    let node: Bool
+    let npm: Bool
+    let pnpm: Bool
+    let php: Bool
+    let composer: Bool
+    let docker: Bool
+    let playwright: Bool
+    let browserReady: Bool
+    let workspaceWritable: Bool
+    let artifactStoreAvailable: Bool
+}
+
+struct RunnerResources: Decodable {
+    let homeboy: RunnerHomeboyProbe
+    let system: RunnerSystemProbe
+    let cpu: RunnerCPUProbe
+    let memory: RunnerMemoryProbe?
+    let disk: RunnerDiskProbe?
+    let workspaceRoot: String
+    let artifactRoot: String
+    let tools: [String: RunnerToolProbe]
+}
+
+struct RunnerHomeboyProbe: Decodable {
+    let version: String
+    let path: String?
+}
+
+struct RunnerSystemProbe: Decodable {
+    let os: String
+    let arch: String
+    let kernel: String?
+}
+
+struct RunnerCPUProbe: Decodable {
+    let count: Int
+}
+
+struct RunnerMemoryProbe: Decodable {
+    let totalMb: Int64
+    let availableMb: Int64?
+}
+
+struct RunnerDiskProbe: Decodable {
+    let path: String
+    let totalMb: Int64
+    let availableMb: Int64
+}
+
+struct RunnerToolProbe: Decodable {
+    let available: Bool
+    let path: String?
+    let version: String?
+    let error: String?
+}
+
+struct RunnerCheck: Decodable, Identifiable {
+    let id: String
+    let status: String
+    let message: String
+    let remediation: String?
+    let details: [String: String]
+}
+
+struct DaemonEnvelope<T: Decodable>: Decodable {
+    let success: Bool
+    let data: T?
+}
+
+struct DaemonAPIResponse<T: Decodable>: Decodable {
+    let status: Int
+    let endpoint: String
+    let body: T
+}
+
+struct DaemonJobsOutput: Decodable {
+    let command: String
+    let jobs: [DaemonJob]
+}
+
+struct DaemonJobOutput: Decodable {
+    let command: String
+    let job: DaemonJob
+}
+
+struct DaemonJobEventsOutput: Decodable {
+    let command: String
+    let jobId: String
+    let events: [DaemonJobEvent]
+}
+
+struct DaemonJobEnqueueOutput: Decodable {
+    let command: String
+    let job: DaemonJob
+    let poll: DaemonJobPoll
+    let request: JSONValue
+}
+
+struct DaemonJobPoll: Decodable {
+    let job: String
+    let events: String
+}
+
+struct DaemonJob: Decodable, Identifiable {
+    let id: String
+    let operation: String
+    let status: String
+    let createdAtMs: UInt64
+    let updatedAtMs: UInt64
+    let startedAtMs: UInt64?
+    let finishedAtMs: UInt64?
+    let eventCount: Int
+    let staleReason: String?
+}
+
+struct DaemonJobEvent: Decodable, Identifiable {
+    let sequence: UInt64
+    let jobId: String
+    let kind: String
+    let timestampMs: UInt64
+    let message: String?
+    let data: JSONValue?
+
+    var id: String { "\(jobId):\(sequence)" }
 }

--- a/Homeboy/Views/Lab/HomeboyLabView.swift
+++ b/Homeboy/Views/Lab/HomeboyLabView.swift
@@ -1,0 +1,475 @@
+import SwiftUI
+
+struct HomeboyLabView: View {
+    @StateObject private var viewModel = HomeboyLabViewModel()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            HSplitView {
+                sidebar
+                    .frame(minWidth: 320, idealWidth: 380)
+                detail
+                    .frame(minWidth: 720)
+            }
+        }
+        .frame(minWidth: 1120, minHeight: 700)
+        .onAppear {
+            viewModel.loadInitialState()
+        }
+        .onChange(of: viewModel.selectedRunnerID) { _, _ in
+            viewModel.selectedRunnerDidChange()
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Homeboy Lab")
+                        .font(.title2.bold())
+                    Text("Runner cockpit backed by Homeboy runner, daemon job, and artifact contracts")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                if viewModel.isLoadingRunners || viewModel.isRunningDoctor || viewModel.isLoadingJobs {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+
+                Button {
+                    viewModel.loadRunners()
+                } label: {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.bordered)
+            }
+
+            if let warning = viewModel.warning {
+                InlineWarningView(warning)
+            }
+            if let error = viewModel.error {
+                InlineErrorView(error)
+            }
+        }
+        .padding()
+    }
+
+    private var sidebar: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            GroupBox("Runner") {
+                VStack(alignment: .leading, spacing: 10) {
+                    Picker("Execution target", selection: $viewModel.selectedRunnerID) {
+                        ForEach(viewModel.runners) { runner in
+                            Text(runnerLabel(runner))
+                                .tag(runner.id)
+                        }
+                    }
+                    .pickerStyle(.menu)
+
+                    if let runner = viewModel.selectedRunner {
+                        VStack(alignment: .leading, spacing: 6) {
+                            labelRow("Kind", runner.kind)
+                            labelRow("Workspace", runner.workspaceRoot ?? "default")
+                            labelRow("Homeboy", runner.homeboyPath ?? "PATH")
+                            if let limit = runner.concurrencyLimit {
+                                labelRow("Concurrency", String(limit))
+                            }
+                            labelRow("Daemon", runner.daemon ? "preferred" : "manual")
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            GroupBox("Connection") {
+                VStack(alignment: .leading, spacing: 10) {
+                    statusLine(
+                        title: viewModel.isLocalSelected ? "Local MacBook" : "Daemon tunnel",
+                        status: viewModel.isLocalSelected ? "default" : (viewModel.isConnected ? "connected" : "disconnected")
+                    )
+
+                    if let url = viewModel.daemonURL {
+                        labelRow("Daemon URL", url)
+                    }
+                    if let message = viewModel.connection?.failureMessage {
+                        Text(message)
+                            .font(.caption)
+                            .foregroundColor(.red)
+                            .textSelection(.enabled)
+                    }
+
+                    HStack {
+                        Button("Doctor") {
+                            Task { await viewModel.runDoctor() }
+                        }
+                        .disabled(viewModel.isRunningDoctor)
+
+                        if !viewModel.isLocalSelected {
+                            Button(viewModel.isConnected ? "Disconnect" : "Connect") {
+                                if viewModel.isConnected {
+                                    viewModel.disconnectSelectedRunner()
+                                } else {
+                                    viewModel.connectSelectedRunner()
+                                }
+                            }
+                            .disabled(viewModel.isConnecting)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            GroupBox("Start Job") {
+                VStack(alignment: .leading, spacing: 10) {
+                    Picker("Action", selection: $viewModel.selectedAction) {
+                        ForEach(viewModel.actions, id: \.self) { action in
+                            Text(action).tag(action)
+                        }
+                    }
+
+                    Picker("Component", selection: $viewModel.selectedComponentID) {
+                        ForEach(viewModel.components) { component in
+                            Text(component.id).tag(Optional(component.id))
+                        }
+                    }
+
+                    TextField("Extra args", text: $viewModel.extraArguments)
+                        .textFieldStyle(.roundedBorder)
+                        .help("Passed as the daemon job body args array. Mutating flags are rejected by Homeboy core.")
+
+                    Button {
+                        viewModel.startRemoteJob()
+                    } label: {
+                        Label("Queue on Runner", systemImage: "play.circle")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!viewModel.canStartRemoteJob)
+
+                    if viewModel.isLocalSelected {
+                        Text("Local execution remains the default. Use the existing Quality, Bench, Rigs, and Run History tools for local runs.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    } else if !viewModel.isConnected {
+                        Text("Connect this runner before queuing daemon-backed jobs.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            Spacer()
+        }
+        .padding()
+    }
+
+    private var detail: some View {
+        VSplitView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    dependencyNote
+                    doctorSection
+                    jobsSection
+                }
+                .padding()
+            }
+            jobDetailSection
+                .frame(minHeight: 260, idealHeight: 320)
+        }
+    }
+
+    private var dependencyNote: some View {
+        GroupBox("Runner Execution Contract") {
+            Text("Desktop uses merged Homeboy runner registry, doctor, connect/status, daemon jobs, and artifact APIs. First-class `homeboy <command> --runner` execution is still tracked in Extra-Chill/homeboy#2529, so this cockpit queues daemon job-ready endpoints where a connected runner exposes them and leaves transport semantics to Homeboy core.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .textSelection(.enabled)
+        }
+    }
+
+    private var doctorSection: some View {
+        GroupBox("Readiness") {
+            if let report = viewModel.doctorReport {
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack(spacing: 12) {
+                        statusBadge(report.status)
+                        labelRow("Homeboy", report.resources.homeboy.version)
+                        labelRow("System", "\(report.resources.system.os) / \(report.resources.system.arch)")
+                        labelRow("CPU", "\(report.resources.cpu.count) cores")
+                        if let memory = report.resources.memory {
+                            labelRow("Memory", "\(memory.totalMb) MB")
+                        }
+                    }
+
+                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 120), spacing: 8)], alignment: .leading, spacing: 8) {
+                        capabilityChip("Git", report.capabilities.git)
+                        capabilityChip("GitHub CLI", report.capabilities.githubCli)
+                        capabilityChip("Node", report.capabilities.node)
+                        capabilityChip("PHP", report.capabilities.php)
+                        capabilityChip("Docker", report.capabilities.docker)
+                        capabilityChip("Playwright", report.capabilities.playwright)
+                        capabilityChip("Browser", report.capabilities.browserReady)
+                        capabilityChip("Workspace", report.capabilities.workspaceWritable)
+                        capabilityChip("Artifacts", report.capabilities.artifactStoreAvailable)
+                    }
+
+                    Divider()
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        ForEach(report.checks) { check in
+                            VStack(alignment: .leading, spacing: 3) {
+                                HStack {
+                                    statusBadge(check.status)
+                                    Text(check.id)
+                                        .font(.caption.monospaced())
+                                    Text(check.message)
+                                        .font(.caption)
+                                    Spacer()
+                                }
+                                if let remediation = check.remediation, !remediation.isEmpty {
+                                    Text(remediation)
+                                        .font(.caption2)
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                Text("Run runner doctor to inspect readiness checks.")
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private var jobsSection: some View {
+        GroupBox("Active Jobs") {
+            if viewModel.isLocalSelected {
+                Text("Local jobs are shown in Run History. Remote daemon jobs appear here after a Lab runner is connected.")
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else if !viewModel.isConnected {
+                Text("No daemon connection for selected runner.")
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else if viewModel.jobs.isEmpty {
+                Text("No daemon jobs reported.")
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                Table(viewModel.jobs, selection: $viewModel.selectedJobID) {
+                    TableColumn("Status") { job in statusBadge(job.status) }
+                        .width(min: 90, ideal: 110)
+                    TableColumn("Operation") { job in Text(job.operation).font(.body.monospaced()) }
+                        .width(min: 160, ideal: 220)
+                    TableColumn("Updated") { job in Text(formatMillis(job.updatedAtMs)) }
+                        .width(min: 150, ideal: 180)
+                    TableColumn("Events") { job in Text(String(job.eventCount)).monospacedDigit() }
+                        .width(min: 60, ideal: 80)
+                    TableColumn("ID") { job in
+                        Text(job.id)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .font(.body.monospaced())
+                            .textSelection(.enabled)
+                    }
+                }
+                .frame(minHeight: 220)
+                .onChange(of: viewModel.selectedJobID) { _, id in
+                    Task { await viewModel.selectJob(id) }
+                }
+            }
+        }
+    }
+
+    private var jobDetailSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("Job Events & Artifacts")
+                    .font(.headline)
+                Spacer()
+                Button("Refresh Jobs") {
+                    Task { await viewModel.refreshJobs() }
+                }
+                .disabled(viewModel.isLoadingJobs || !viewModel.isConnected)
+                Button("Cancel") {
+                    viewModel.cancelSelectedJob()
+                }
+                .disabled(viewModel.selectedJob == nil || viewModel.selectedJob.map { ["succeeded", "failed", "cancelled"].contains($0.status) } == true)
+            }
+
+            if let job = viewModel.selectedJob {
+                HStack(spacing: 12) {
+                    statusBadge(job.status)
+                    Text(job.id)
+                        .font(.caption.monospaced())
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .textSelection(.enabled)
+                    Spacer()
+                }
+            }
+
+            HSplitView {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 6) {
+                        ForEach(viewModel.events) { event in
+                            VStack(alignment: .leading, spacing: 2) {
+                                HStack {
+                                    Text("#\(event.sequence)")
+                                        .font(.caption.monospacedDigit())
+                                        .foregroundColor(.secondary)
+                                    Text(event.kind)
+                                        .font(.caption.bold())
+                                    Text(formatMillis(event.timestampMs))
+                                        .font(.caption2.monospacedDigit())
+                                        .foregroundColor(.secondary)
+                                }
+                                if let message = event.message {
+                                    Text(message)
+                                        .font(.caption.monospaced())
+                                        .textSelection(.enabled)
+                                }
+                                if let data = event.data {
+                                    Text(data.prettyPrintedJSONString)
+                                        .font(.caption2.monospaced())
+                                        .foregroundColor(.secondary)
+                                        .textSelection(.enabled)
+                                }
+                            }
+                            .padding(6)
+                            .background(Color(nsColor: .controlBackgroundColor))
+                            .cornerRadius(6)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 4)
+                }
+
+                artifactsPane
+                    .frame(minWidth: 260, idealWidth: 320)
+            }
+        }
+        .padding()
+    }
+
+    private var artifactsPane: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Artifacts")
+                .font(.subheadline.bold())
+            if viewModel.artifacts.isEmpty {
+                Text("No downloadable artifact manifest for the selected job yet.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            } else {
+                ForEach(viewModel.artifacts) { artifact in
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Text(artifact.kind)
+                                .font(.caption.bold())
+                            Spacer()
+                            if let size = artifact.sizeBytes {
+                                Text(formatBytes(size))
+                                    .font(.caption2.monospacedDigit())
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        Text(artifact.downloadPath)
+                            .font(.caption2.monospaced())
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .textSelection(.enabled)
+                        Button("Download & Open") {
+                            viewModel.downloadAndOpenArtifact(artifact)
+                        }
+                        .disabled(viewModel.isLoadingArtifacts)
+                    }
+                    .padding(8)
+                    .background(Color(nsColor: .controlBackgroundColor))
+                    .cornerRadius(6)
+                }
+            }
+            Spacer()
+        }
+        .padding(.leading, 8)
+    }
+
+    private func runnerLabel(_ runner: HomeboyRunner) -> String {
+        if runner.id == HomeboyRunner.localDefault.id {
+            return "Local MacBook"
+        }
+        return "\(runner.id) (\(runner.kind))"
+    }
+
+    private func labelRow(_ title: String, _ value: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text(title)
+                .font(.caption.bold())
+                .foregroundColor(.secondary)
+            Text(value)
+                .font(.caption.monospaced())
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
+        }
+    }
+
+    private func statusLine(title: String, status: String) -> some View {
+        HStack {
+            Text(title)
+                .font(.caption.bold())
+            Spacer()
+            statusBadge(status)
+        }
+    }
+
+    private func capabilityChip(_ title: String, _ available: Bool) -> some View {
+        Label(title, systemImage: available ? "checkmark.circle.fill" : "xmark.circle")
+            .font(.caption)
+            .foregroundColor(available ? .green : .secondary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color(nsColor: .controlBackgroundColor))
+            .cornerRadius(10)
+    }
+
+    private func statusBadge(_ status: String) -> some View {
+        Text(status.uppercased())
+            .font(.caption2.bold())
+            .foregroundColor(.white)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(statusColor(status))
+            .cornerRadius(6)
+    }
+
+    private func statusColor(_ status: String) -> Color {
+        switch status.lowercased() {
+        case "ok", "succeeded", "connected", "default": return .green
+        case "warn", "warning", "queued", "running": return .orange
+        case "failed", "error", "cancelled", "disconnected": return .red
+        default: return .secondary
+        }
+    }
+
+    private func formatMillis(_ value: UInt64) -> String {
+        let date = Date(timeIntervalSince1970: TimeInterval(value) / 1000)
+        return date.formatted(date: .abbreviated, time: .standard)
+    }
+
+    private func formatBytes(_ bytes: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+    }
+}
+
+#Preview {
+    HomeboyLabView()
+}

--- a/Homeboy/Views/Lab/HomeboyLabViewModel.swift
+++ b/Homeboy/Views/Lab/HomeboyLabViewModel.swift
@@ -1,0 +1,342 @@
+import AppKit
+import Foundation
+
+@MainActor
+final class HomeboyLabViewModel: ObservableObject {
+    @Published var runners: [HomeboyRunner] = [HomeboyRunner.localDefault]
+    @Published var selectedRunnerID = HomeboyRunner.localDefault.id
+    @Published var doctorReport: RunnerDoctorOutput?
+    @Published var connection: RunnerConnection?
+    @Published var jobs: [DaemonJob] = []
+    @Published var selectedJobID: String?
+    @Published var selectedJob: DaemonJob?
+    @Published var events: [DaemonJobEvent] = []
+    @Published var artifacts: [RunArtifactSyncItem] = []
+    @Published var components: [DeployableComponent] = []
+    @Published var selectedComponentID: String?
+    @Published var selectedAction = "audit"
+    @Published var extraArguments = ""
+    @Published var isLoadingRunners = false
+    @Published var isRunningDoctor = false
+    @Published var isConnecting = false
+    @Published var isLoadingJobs = false
+    @Published var isStartingJob = false
+    @Published var isLoadingArtifacts = false
+    @Published var error: (any DisplayableError)?
+    @Published var warning: AppWarning?
+
+    let actions = ["audit", "lint", "test", "bench"]
+
+    private let cli = HomeboyCLI.shared
+    private var pollingTask: Task<Void, Never>?
+
+    var selectedRunner: HomeboyRunner? {
+        runners.first { $0.id == selectedRunnerID }
+    }
+
+    var selectedComponent: DeployableComponent? {
+        components.first { $0.id == selectedComponentID }
+    }
+
+    var isLocalSelected: Bool {
+        selectedRunnerID == HomeboyRunner.localDefault.id || selectedRunner?.kind == "local"
+    }
+
+    var isConnected: Bool {
+        connection?.connected == true
+    }
+
+    var daemonURL: String? {
+        connection?.localUrl ?? connection?.session?.localUrl
+    }
+
+    var canStartRemoteJob: Bool {
+        !isLocalSelected && isConnected && selectedComponent != nil && !isStartingJob
+    }
+
+    init() {
+        loadComponents()
+    }
+
+    deinit {
+        pollingTask?.cancel()
+    }
+
+    func loadInitialState() {
+        loadComponents()
+        loadRunners()
+    }
+
+    func loadComponents() {
+        let project = ConfigurationManager.shared.activeProject ?? ConfigurationManager.shared.safeActiveProject
+        components = ConfigurationManager.shared.loadComponentsForProject(project).map { DeployableComponent(from: $0) }
+        if selectedComponentID == nil || !components.contains(where: { $0.id == selectedComponentID }) {
+            selectedComponentID = components.first?.id
+        }
+    }
+
+    func loadRunners() {
+        guard cli.isInstalled else {
+            error = AppError("Homeboy CLI is not installed. Install via Settings -> CLI.", source: "Homeboy Lab")
+            return
+        }
+
+        isLoadingRunners = true
+        error = nil
+        warning = nil
+
+        Task {
+            do {
+                runners = try await cli.runnerList()
+                if !runners.contains(where: { $0.id == selectedRunnerID }) {
+                    selectedRunnerID = HomeboyRunner.localDefault.id
+                }
+                await refreshSelectedRunner()
+            } catch {
+                runners = [HomeboyRunner.localDefault]
+                selectedRunnerID = HomeboyRunner.localDefault.id
+                warning = AppWarning(
+                    "This Homeboy CLI does not expose the Wave 1 runner registry yet. Local execution remains available; install a Homeboy build containing Extra-Chill/homeboy#2533, #2534, and #2536 to use Lab runners.",
+                    source: "Homeboy Lab"
+                )
+            }
+            isLoadingRunners = false
+        }
+    }
+
+    func refreshSelectedRunner() async {
+        doctorReport = nil
+        connection = nil
+        jobs = []
+        selectedJobID = nil
+        selectedJob = nil
+        events = []
+        artifacts = []
+        await runDoctor()
+        await loadRunnerStatus()
+        await refreshJobs()
+    }
+
+    func selectedRunnerDidChange() {
+        pollingTask?.cancel()
+        Task { await refreshSelectedRunner() }
+    }
+
+    func runDoctor() async {
+        guard cli.isInstalled else { return }
+        isRunningDoctor = true
+        error = nil
+        do {
+            doctorReport = try await cli.runnerDoctor(id: selectedRunnerID)
+        } catch {
+            self.error = error.toDisplayableError(source: "Homeboy Lab")
+        }
+        isRunningDoctor = false
+    }
+
+    func connectSelectedRunner() {
+        guard !isLocalSelected else { return }
+        isConnecting = true
+        error = nil
+        Task {
+            do {
+                connection = try await cli.runnerConnect(id: selectedRunnerID)
+                await refreshJobs()
+            } catch {
+                self.error = error.toDisplayableError(source: "Homeboy Lab")
+            }
+            isConnecting = false
+        }
+    }
+
+    func disconnectSelectedRunner() {
+        guard !isLocalSelected else { return }
+        isConnecting = true
+        error = nil
+        Task {
+            do {
+                connection = try await cli.runnerDisconnect(id: selectedRunnerID)
+                pollingTask?.cancel()
+                jobs = []
+                selectedJobID = nil
+                selectedJob = nil
+                events = []
+            } catch {
+                self.error = error.toDisplayableError(source: "Homeboy Lab")
+            }
+            isConnecting = false
+        }
+    }
+
+    func loadRunnerStatus() async {
+        guard !isLocalSelected else { return }
+        do {
+            connection = try await cli.runnerStatus(id: selectedRunnerID)
+        } catch {
+            warning = AppWarning("Runner status is unavailable: \(error.localizedDescription)", source: "Homeboy Lab")
+        }
+    }
+
+    func startRemoteJob() {
+        guard canStartRemoteJob, let component = selectedComponent else { return }
+        isStartingJob = true
+        error = nil
+        Task {
+            do {
+                let client = try daemonClient()
+                var body: [String: JSONValue] = ["component": .string(component.id)]
+                if !component.localPath.isEmpty {
+                    body["path"] = .string(component.localPath)
+                }
+                let args = ShellCommandLineParser.arguments(from: extraArguments)
+                if !args.isEmpty {
+                    body["args"] = .array(args.map(JSONValue.string))
+                }
+                let output = try await client.enqueue(kind: selectedAction, body: body)
+                selectedJobID = output.job.id
+                selectedJob = output.job
+                await refreshJobs()
+                startPollingSelectedJob()
+            } catch {
+                self.error = error.toDisplayableError(source: "Homeboy Lab")
+            }
+            isStartingJob = false
+        }
+    }
+
+    func refreshJobs() async {
+        guard !isLocalSelected, isConnected else { return }
+        isLoadingJobs = true
+        do {
+            let client = try daemonClient()
+            jobs = try await client.listJobs().sorted { $0.updatedAtMs > $1.updatedAtMs }
+            if let selectedJobID, jobs.contains(where: { $0.id == selectedJobID }) {
+                await selectJob(selectedJobID)
+            } else if let first = jobs.first {
+                selectedJobID = first.id
+                await selectJob(first.id)
+            }
+        } catch {
+            self.error = error.toDisplayableError(source: "Homeboy Lab")
+        }
+        isLoadingJobs = false
+    }
+
+    func selectJob(_ id: String?) async {
+        selectedJobID = id
+        events = []
+        artifacts = []
+        guard let id, !isLocalSelected, isConnected else {
+            selectedJob = nil
+            return
+        }
+
+        do {
+            let client = try daemonClient()
+            async let jobTask = client.showJob(id: id)
+            async let eventsTask = client.jobEvents(id: id)
+            selectedJob = try await jobTask
+            events = try await eventsTask
+            loadArtifactsFromResultEvents()
+            startPollingSelectedJob()
+        } catch {
+            self.error = error.toDisplayableError(source: "Homeboy Lab")
+        }
+    }
+
+    func cancelSelectedJob() {
+        guard let id = selectedJobID else { return }
+        Task {
+            do {
+                let client = try daemonClient()
+                selectedJob = try await client.cancelJob(id: id)
+                await refreshJobs()
+            } catch {
+                self.error = error.toDisplayableError(source: "Homeboy Lab")
+            }
+        }
+    }
+
+    func downloadAndOpenArtifact(_ artifact: RunArtifactSyncItem) {
+        isLoadingArtifacts = true
+        Task {
+            do {
+                let client = try daemonClient()
+                let url = try await client.downloadArtifact(runId: artifact.runId, artifactId: artifact.id)
+                NSWorkspace.shared.open(url)
+            } catch {
+                self.error = error.toDisplayableError(source: "Homeboy Lab")
+            }
+            isLoadingArtifacts = false
+        }
+    }
+
+    private func loadArtifactsFromResultEvents() {
+        let runIds = events.compactMap { event -> String? in
+            guard event.kind == "result", let data = event.data else { return nil }
+            return firstRunId(in: data)
+        }
+        guard let runId = runIds.first else { return }
+
+        isLoadingArtifacts = true
+        Task {
+            do {
+                artifacts = try await daemonClient().artifactSyncManifest(runId: runId)
+            } catch {
+                warning = AppWarning("Job completed, but artifacts are not available yet: \(error.localizedDescription)", source: "Homeboy Lab")
+            }
+            isLoadingArtifacts = false
+        }
+    }
+
+    private func startPollingSelectedJob() {
+        pollingTask?.cancel()
+        guard let id = selectedJobID else { return }
+
+        pollingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                guard let self else { return }
+                if await self.pollJob(id) {
+                    return
+                }
+            }
+        }
+    }
+
+    private func pollJob(_ id: String) async -> Bool {
+        do {
+            let client = try daemonClient()
+            selectedJob = try await client.showJob(id: id)
+            events = try await client.jobEvents(id: id)
+            loadArtifactsFromResultEvents()
+            return selectedJob.map { ["succeeded", "failed", "cancelled"].contains($0.status) } ?? true
+        } catch {
+            return true
+        }
+    }
+
+    private func daemonClient() throws -> HomeboyDaemonClient {
+        guard let daemonURL else {
+            throw HomeboyDaemonError(statusCode: 0, body: "Runner is not connected to a Homeboy daemon")
+        }
+        return try HomeboyDaemonClient(baseURL: daemonURL)
+    }
+
+    private func firstRunId(in value: JSONValue) -> String? {
+        switch value {
+        case .object(let object):
+            if let runId = object["run_id"]?.stringValue, !runId.isEmpty, runId != "null" {
+                return runId
+            }
+            if let runId = object["runId"]?.stringValue, !runId.isEmpty, runId != "null" {
+                return runId
+            }
+            return object.values.compactMap(firstRunId).first
+        case .array(let values):
+            return values.compactMap(firstRunId).first
+        default:
+            return nil
+        }
+    }
+}

--- a/docs/HOMEBOY-LAB.md
+++ b/docs/HOMEBOY-LAB.md
@@ -1,0 +1,16 @@
+# Homeboy Lab Desktop Cockpit
+
+Homeboy Desktop treats Lab runners as Homeboy core execution targets. The app shells out to the `homeboy runner` CLI contracts and talks to the loopback daemon URL returned by `homeboy runner connect`; it does not implement SSH, tunnel, or daemon transport logic itself.
+
+## Consumed Core Contracts
+
+- `homeboy runner list` provides configured local and SSH runner records.
+- `homeboy runner doctor <runner-id>` provides readiness, resources, capabilities, and checks.
+- `homeboy runner connect|status|disconnect <runner-id>` owns daemon bootstrap and tunnel session state.
+- Daemon `GET /jobs`, `GET /jobs/:id`, `GET /jobs/:id/events`, and `POST /jobs/:id/cancel` provide active job state.
+- Daemon `POST /audit|/lint|/test|/bench` queues non-mutating job-ready runs where the connected runner exposes them.
+- Daemon `GET /runs/:id/artifacts/sync` and `GET /runs/:id/artifacts/:artifact-id` provide artifact listing and retrieval.
+
+## Current Execution Dependency
+
+First-class runner execution is still tracked in Extra-Chill/homeboy#2529. Until that lands, Desktop keeps local execution as the default and limits the Lab cockpit to connected daemon job-ready endpoints. When Homeboy core adds `homeboy <command> --runner` or equivalent stable command wrappers, Desktop should route existing action surfaces through those CLI wrappers instead of adding transport code.


### PR DESCRIPTION
## Summary
- Adds a Homeboy Lab cockpit view with runner selection, readiness/doctor output, connection status, daemon job polling, event rendering, and artifact download/open affordances.
- Adds Desktop wrappers for merged Homeboy core runner contracts (`runner list`, `doctor`, `connect`, `status`, `disconnect`) and daemon HTTP APIs instead of implementing SSH or daemon transport in Desktop.
- Documents the current execution boundary: first-class runner execution remains blocked on Extra-Chill/homeboy#2529, so Desktop queues daemon job-ready endpoints where available and keeps local execution as the default.

Closes #80.

## Verification
- `xcodegen generate --spec project.yml`
- `xcodebuild -project Homeboy.xcodeproj -scheme Homeboy -configuration Debug -derivedDataPath .build/DerivedData build`
- `xcodebuild -project Homeboy.xcodeproj -scheme Homeboy -configuration Release -derivedDataPath .build/DerivedDataRelease build`
- `git diff --check`

## Blockers / follow-ups
- `xcodebuild ... test` is not available because the `Homeboy` scheme is not configured for the test action.
- `homeboy lint --path /Users/chubes/Developer/homeboy-desktop@feat-homeboy-lab-cockpit-80` is blocked locally because the installed Homeboy configuration cannot resolve the `swift` extension.
- Full remote command selection depends on Extra-Chill/homeboy#2529; this PR intentionally consumes the current merged contracts and does not add Desktop transport logic.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Desktop runner cockpit, CLI/API wrappers, contract-boundary documentation, verification commands, and PR draft. Chris remains responsible for review, testing, and merge decisions.