### PR TITLE
Add Homeboy agent-task mission control

### DIFF
--- a/Homeboy.xcodeproj/project.pbxproj
+++ b/Homeboy.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		01A60A483E896F2DBAC46E66 /* HomeboyCLI+AgentTaskCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E835EDA2D0CF593612C0FB /* HomeboyCLI+AgentTaskCommands.swift */; };
 		023BC7FBF76D2C19E8B8559D /* DeployerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2FB01E9289515A3AC24A927 /* DeployerViewModel.swift */; };
 		023E9AE450BF036FF40C0E76 /* ProjectConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C794768AF4898995F64DB92D /* ProjectConfiguration.swift */; };
 		02AD314100925D82AE384CE8 /* GeneralSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8974EB4ED392FD3B52D70FD3 /* GeneralSettingsTab.swift */; };
@@ -73,6 +74,7 @@
 		790A549F1DA4887FA2EF100F /* ServersSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF87669DD8D8EEF387C64926 /* ServersSettingsTab.swift */; };
 		79F089B7341476178AB41022 /* RemoteFileEditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42681ABDD9AC38676CDB315E /* RemoteFileEditorViewModel.swift */; };
 		7B4A55712A56BDD9EE21F504 /* HomeboyCLI+FileDatabaseCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B800E302E25370AFEB2EAA7 /* HomeboyCLI+FileDatabaseCommands.swift */; };
+		7DBB46236685B028468818A3 /* AgentTasksViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E082836B3884E2FC30985B /* AgentTasksViewModel.swift */; };
 		7EE844A0691D39F31A685114 /* ProjectSwitcherView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA62EB2C6FD0532AE4CCD204 /* ProjectSwitcherView.swift */; };
 		807E4729F90F95A12FAB99B7 /* CollapsibleSplitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED098FFBF749CD6DD355B1B /* CollapsibleSplitView.swift */; };
 		8327EB6B86BD82A5A8F0E466 /* ServerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBD189DF7919CB05353FDC9 /* ServerConfig.swift */; };
@@ -80,6 +82,7 @@
 		85A8C46096DE6DFF3BD11E63 /* FindableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385944CD36C9E1B61CE23EDE /* FindableTextView.swift */; };
 		85F4F94606B3D49BEFDC227F /* DeploymentService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFAD6C5159792F08A987DC9 /* DeploymentService.swift */; };
 		86C712A03FB9FC626DC46371 /* ArtifactVersionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60913533AA72054F3D79625C /* ArtifactVersionParser.swift */; };
+		896B9762C747BFEE12C4B53A /* AgentTasksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F4186F8B0094DD42F86329 /* AgentTasksView.swift */; };
 		8B8811A6AB7570F644C36FC5 /* VersionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13F8D60E3516F29F554438A0 /* VersionParser.swift */; };
 		8D62AD324E3C99747FA53FCB /* ComponentsSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830D15DCC64EB9AF17F822E0 /* ComponentsSettingsTab.swift */; };
 		9057B57BD09E3D8A025D305D /* ExtensionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12EA4D980446363E3B0B3D1 /* ExtensionManager.swift */; };
@@ -238,6 +241,7 @@
 		C3B52F387CC902FB445FC922 /* HomeboyCLI+CommandBrowserCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+CommandBrowserCommands.swift"; sourceTree = "<group>"; };
 		C489D03946456721B73D70EA /* AppWarning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppWarning.swift; sourceTree = "<group>"; };
 		C503C8896286EA38288A139F /* DataTableColumn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataTableColumn.swift; sourceTree = "<group>"; };
+		C6E082836B3884E2FC30985B /* AgentTasksViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentTasksViewModel.swift; sourceTree = "<group>"; };
 		C794768AF4898995F64DB92D /* ProjectConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfiguration.swift; sourceTree = "<group>"; };
 		CC77F3DE919D687C5088735B /* ContentContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentContext.swift; sourceTree = "<group>"; };
 		CEFAD6C5159792F08A987DC9 /* DeploymentService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeploymentService.swift; sourceTree = "<group>"; };
@@ -246,6 +250,7 @@
 		D5F58D23C61F57585387766D /* QualityModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QualityModels.swift; sourceTree = "<group>"; };
 		D870E69E9C29278BC862CD04 /* HomeboyCLI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeboyCLI.swift; sourceTree = "<group>"; };
 		D8D33E39732C375690D3AC46 /* HomeboyCLIModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeboyCLIModels.swift; sourceTree = "<group>"; };
+		D9F4186F8B0094DD42F86329 /* AgentTasksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentTasksView.swift; sourceTree = "<group>"; };
 		DA7F7ED4B0D0B46D19BF8438 /* HomeboyCLI+StackCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+StackCommands.swift"; sourceTree = "<group>"; };
 		DF87669DD8D8EEF387C64926 /* ServersSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServersSettingsTab.swift; sourceTree = "<group>"; };
 		E0202298D08128098B45807E /* DatabaseBrowserViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseBrowserViewModel.swift; sourceTree = "<group>"; };
@@ -254,6 +259,7 @@
 		E134C3E1AFDFB8B9C3BFA989 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E2FF4CDA2AE7652A449E74D8 /* ConfigurationObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationObserver.swift; sourceTree = "<group>"; };
 		E32E869268148C1260D05F85 /* CLIExtensionTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIExtensionTypes.swift; sourceTree = "<group>"; };
+		E3E835EDA2D0CF593612C0FB /* HomeboyCLI+AgentTaskCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeboyCLI+AgentTaskCommands.swift"; sourceTree = "<group>"; };
 		E7C2AF5C1F794564BF7DC0F4 /* RemoteFileBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileBrowserView.swift; sourceTree = "<group>"; };
 		E8A3033E40F9E3B41E1E41BB /* WordPressSSHExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSSHExtension.swift; sourceTree = "<group>"; };
 		EA62EB2C6FD0532AE4CCD204 /* ProjectSwitcherView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectSwitcherView.swift; sourceTree = "<group>"; };
@@ -284,6 +290,15 @@
 				35595CC7BEFD826A8FE56039 /* RigsViewModel.swift */,
 			);
 			path = Rigs;
+			sourceTree = "<group>";
+		};
+		15AA4D572DE7DF56383454E5 /* AgentTasks */ = {
+			isa = PBXGroup;
+			children = (
+				D9F4186F8B0094DD42F86329 /* AgentTasksView.swift */,
+				C6E082836B3884E2FC30985B /* AgentTasksViewModel.swift */,
+			);
+			path = AgentTasks;
 			sourceTree = "<group>";
 		};
 		2DE44D1E578B8119641FCA42 /* SSH */ = {
@@ -434,6 +449,7 @@
 				811079398986364AA0E0542A /* CLIVersionChecker.swift */,
 				19D0AC4BB8035D3A38DF8F83 /* CommandBrowserCatalog.swift */,
 				D870E69E9C29278BC862CD04 /* HomeboyCLI.swift */,
+				E3E835EDA2D0CF593612C0FB /* HomeboyCLI+AgentTaskCommands.swift */,
 				C3B52F387CC902FB445FC922 /* HomeboyCLI+CommandBrowserCommands.swift */,
 				4B800E302E25370AFEB2EAA7 /* HomeboyCLI+FileDatabaseCommands.swift */,
 				9CB4FFA7533765478562751F /* HomeboyCLI+LogCommands.swift */,
@@ -462,6 +478,7 @@
 		7CD7DF7C95F543DB47F1055F /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				15AA4D572DE7DF56383454E5 /* AgentTasks */,
 				92301854AF9D7FCE0328DB48 /* CommandBrowser */,
 				8007D7D3CCEF3F80C36AA686 /* Components */,
 				48CA5756F2D78ADA9FCD0AFD /* Extensions */,
@@ -796,6 +813,8 @@
 				BA03F27144E7C71BE3BC30E4 /* APIAuthWorkspaceView.swift in Sources */,
 				5C04267FDCF7C82C4BE9B087 /* APIClient.swift in Sources */,
 				D3D2FEA38CB8A09E0ED93B73 /* APITypes.swift in Sources */,
+				896B9762C747BFEE12C4B53A /* AgentTasksView.swift in Sources */,
+				7DBB46236685B028468818A3 /* AgentTasksViewModel.swift in Sources */,
 				E6403DF4F6747B97ED009C1A /* AppConfiguration.swift in Sources */,
 				3CBF41346F060E438864152C /* AppError.swift in Sources */,
 				61876E7ACDA5C3D7A5D2E40F /* AppPaths.swift in Sources */,
@@ -858,6 +877,7 @@
 				FDC7A36317A54E1EE4486D4A /* GitOperationsView.swift in Sources */,
 				0D616728E30CB0C012851F18 /* GitOperationsViewModel.swift in Sources */,
 				57C3AE0D20A591DEE69B0FF0 /* HomeboyApp.swift in Sources */,
+				01A60A483E896F2DBAC46E66 /* HomeboyCLI+AgentTaskCommands.swift in Sources */,
 				D5421FF656190A21F439C40A /* HomeboyCLI+CommandBrowserCommands.swift in Sources */,
 				7B4A55712A56BDD9EE21F504 /* HomeboyCLI+FileDatabaseCommands.swift in Sources */,
 				A744C6D0692C0EF9B142E839 /* HomeboyCLI+LogCommands.swift in Sources */,

--- a/Homeboy/App/ContentView.swift
+++ b/Homeboy/App/ContentView.swift
@@ -16,6 +16,7 @@ enum CoreTool: String, CaseIterable, Identifiable {
     case deployer = "Deployer"
     case bench = "Bench"
     case lab = "Lab"
+    case agentTasks = "Agent Tasks"
     case runHistory = "Run History"
     case release = "Release"
     case rigs = "Rigs"
@@ -36,6 +37,7 @@ enum CoreTool: String, CaseIterable, Identifiable {
         case .deployer: return "arrow.up.to.line"
         case .bench: return "speedometer"
         case .lab: return "desktopcomputer.and.arrow.down"
+        case .agentTasks: return "point.3.connected.trianglepath.dotted"
         case .runHistory: return "clock.arrow.circlepath"
         case .release: return "tag"
         case .rigs: return "shippingbox.and.arrow.backward"
@@ -61,7 +63,7 @@ enum CoreTool: String, CaseIterable, Identifiable {
             return true
         case .settings:
             return true
-        case .deployer, .bench, .lab, .runHistory, .release, .rigs, .stackManager, .git, .quality:
+        case .deployer, .bench, .lab, .agentTasks, .runHistory, .release, .rigs, .stackManager, .git, .quality:
             return hasComponents
         case .remoteFileEditor, .remoteLogViewer:
             return hasRemoteTarget
@@ -132,6 +134,8 @@ struct ContentView: View {
                 .opacity(selectedItem == .coreTool(.bench) ? 1 : 0)
             HomeboyLabView()
                 .opacity(selectedItem == .coreTool(.lab) ? 1 : 0)
+            AgentTasksView()
+                .opacity(selectedItem == .coreTool(.agentTasks) ? 1 : 0)
             RunHistoryView()
                 .opacity(selectedItem == .coreTool(.runHistory) ? 1 : 0)
             ReleaseWorkflowView()

--- a/Homeboy/Core/CLI/HomeboyCLI+AgentTaskCommands.swift
+++ b/Homeboy/Core/CLI/HomeboyCLI+AgentTaskCommands.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+@MainActor
+extension HomeboyCLI {
+    func agentTaskProviders(runnerID: String?) async throws -> JSONValue {
+        try await agentTaskCommand(["providers"], runnerID: runnerID)
+    }
+
+    func agentTaskList(runnerID: String?) async throws -> JSONValue {
+        try await agentTaskCommand(["list", "--limit", "100"], runnerID: runnerID)
+    }
+
+    func agentTaskStatus(id: String, runnerID: String?) async throws -> JSONValue {
+        try await agentTaskCommand(["status", id, "--full"], runnerID: runnerID)
+    }
+
+    func agentTaskLogs(id: String, runnerID: String?) async throws -> JSONValue {
+        try await agentTaskCommand(["logs", id, "--full"], runnerID: runnerID)
+    }
+
+    func agentTaskArtifacts(id: String, runnerID: String?) async throws -> JSONValue {
+        try await agentTaskCommand(["artifacts", id, "--full"], runnerID: runnerID)
+    }
+
+    func agentTaskSubmit(plan: JSONValue, runID: String, runNow: Bool, runnerID: String?) async throws -> JSONValue {
+        var arguments = runnerArguments(runnerID) + ["agent-task", "submit", "--plan", "-"]
+        if runNow {
+            // Core owns execution after durable submission; Desktop never launches a provider directly.
+            arguments = runnerArguments(runnerID) + ["agent-task", "run-plan", "--plan", "-", "--record-run-id", runID]
+        } else {
+            arguments += ["--run-id", runID]
+        }
+        return try await agentTaskStdinCommand(arguments, input: plan.prettyPrintedJSONString)
+    }
+
+    func agentTaskCancel(id: String, runnerID: String?) async throws -> JSONValue {
+        try await agentTaskCommand(["cancel", id, "--reason", "Cancelled from Homeboy Desktop"], runnerID: runnerID)
+    }
+
+    func agentTaskRetry(id: String, runnerID: String?) async throws -> JSONValue {
+        try await agentTaskCommand(["retry", id, "--run"], runnerID: runnerID)
+    }
+
+    func agentTaskResume(id: String, runnerID: String?) async throws -> JSONValue {
+        try await agentTaskCommand(["resume", id, "--full"], runnerID: runnerID)
+    }
+
+    func agentTaskPromoteDryRun(runID: String, worktree: String, verify: String, runnerID: String?) async throws -> JSONValue {
+        var arguments = ["promote", runID, "--to-worktree", worktree, "--dry-run"]
+        if !verify.isEmpty {
+            arguments += ["--verify", verify]
+        }
+        return try await agentTaskCommand(arguments, runnerID: runnerID)
+    }
+
+    private func agentTaskCommand(_ command: [String], runnerID: String?) async throws -> JSONValue {
+        try await executeCommandWithOutputFile(
+            runnerArguments(runnerID) + ["agent-task"] + command,
+            dataType: JSONValue.self,
+            source: "Agent Tasks",
+            timeout: 120
+        )
+    }
+
+    private func agentTaskStdinCommand(_ arguments: [String], input: String) async throws -> JSONValue {
+        let response = try await cli.executeWithStdin(arguments, stdin: input, timeout: 120)
+        let result = try response.decodeResponse(JSONValue.self)
+        guard result.success, let data = result.data else {
+            throw CLIBridgeError.executionFailed(exitCode: response.exitCode, message: response.errorOutput)
+        }
+        return data
+    }
+
+    private func runnerArguments(_ runnerID: String?) -> [String] {
+        guard let runnerID, runnerID != HomeboyRunner.localDefault.id else { return [] }
+        return ["--runner", runnerID]
+    }
+}

--- a/Homeboy/Views/AgentTasks/AgentTasksView.swift
+++ b/Homeboy/Views/AgentTasks/AgentTasksView.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+
+struct AgentTasksView: View {
+    @StateObject private var viewModel = AgentTasksViewModel()
+
+    var body: some View {
+        HSplitView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    missionForm
+                    runs
+                }
+                .padding()
+            }
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    runDetail
+                    promotion
+                }
+                .padding()
+            }
+            .frame(minWidth: 540)
+        }
+        .frame(minWidth: 1120, minHeight: 700)
+        .navigationTitle("Agent Tasks")
+        .task { viewModel.load() }
+        .onChange(of: viewModel.selectedRunnerID) { _, _ in Task { await viewModel.refresh() } }
+        .onChange(of: viewModel.selectedRunID) { _, _ in Task { await viewModel.loadSelectedRun() } }
+    }
+
+    private var missionForm: some View {
+        GroupBox("New Mission") {
+            VStack(alignment: .leading, spacing: 10) {
+                Picker("Lab runner", selection: $viewModel.selectedRunnerID) {
+                    ForEach(viewModel.runners) { runner in Text(runner.id).tag(runner.id) }
+                }
+                if let runner = viewModel.selectedRunner {
+                    Text("\(runner.kind) runner\(runner.concurrencyLimit.map { " · capacity \($0)" } ?? "")")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                TextField("Goal", text: $viewModel.goal, axis: .vertical)
+                TextField("Source refs (one per line)", text: $viewModel.sourceRefs, axis: .vertical)
+                TextField("Workspace", text: $viewModel.workspace)
+                TextField("Provider backend", text: $viewModel.provider)
+                HStack {
+                    Stepper("Concurrency: \(viewModel.concurrency)", value: $viewModel.concurrency, in: 1...32)
+                    Stepper("Attempts: \(viewModel.attempts)", value: $viewModel.attempts, in: 1...10)
+                }
+                TextField("Policy JSON", text: $viewModel.policy, axis: .vertical)
+                    .font(.system(.caption, design: .monospaced))
+                Toggle("Run immediately after durable submission", isOn: $viewModel.runNow)
+                Button(viewModel.runNow ? "Submit & Run" : "Queue Mission") { viewModel.submit() }
+                    .buttonStyle(.borderedProminent)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var runs: some View {
+        GroupBox("Durable Runs") {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Homeboy lifecycle state")
+                    Spacer()
+                    Button { Task { await viewModel.refresh() } } label: { Image(systemName: "arrow.clockwise") }
+                }
+                ForEach(0..<viewModel.runs.count, id: \.self) { index in
+                    let run = viewModel.runs[index]
+                    Button {
+                        viewModel.selectedRunID = run.value(at: ["run_id"]).stringValue
+                    } label: {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(run.value(at: ["run_id"]).stringValue)
+                                .font(.caption.monospaced())
+                            Text("\(run.value(at: ["state"]).stringValue)  \(run.value(at: ["counts"]).stringValue)")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(7)
+                    .background(viewModel.selectedRunID == run.value(at: ["run_id"]).stringValue ? Color.accentColor.opacity(0.14) : Color(nsColor: .controlBackgroundColor))
+                    .cornerRadius(6)
+                }
+            }
+        }
+    }
+
+    private var runDetail: some View {
+        GroupBox("Mission Control") {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Button("Cancel") { viewModel.cancel() }
+                    Button("Retry") { viewModel.retry() }
+                    Button("Resume") { viewModel.resume() }
+                    Spacer()
+                    if viewModel.isLoading { ProgressView() }
+                }
+                contractSection("Status / Fanout", viewModel.status)
+                contractSection("Events / Attempts / Failures", viewModel.logs)
+                contractSection("Artifacts / Evidence / Replay / PR", viewModel.artifacts)
+                if let error = viewModel.error { InlineErrorView(error) }
+            }
+        }
+    }
+
+    private var promotion: some View {
+        GroupBox("Promotion Preview") {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Dry-runs Homeboy promotion from the selected durable run. No patch is applied from Desktop.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                TextField("Managed worktree handle", text: $viewModel.promotionWorktree)
+                TextField("Verification command", text: $viewModel.verificationCommand)
+                Button("Dry-run Promotion") { viewModel.dryRunPromotion() }
+                if !viewModel.promotionResult.isEmpty {
+                    Text(viewModel.promotionResult)
+                        .font(.system(.caption2, design: .monospaced))
+                        .textSelection(.enabled)
+                }
+            }
+        }
+    }
+
+    private func contractSection(_ title: String, _ value: JSONValue) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(title).font(.headline)
+            Text(value.prettyPrintedJSONString)
+                .font(.system(.caption2, design: .monospaced))
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(8)
+                .background(Color(nsColor: .textBackgroundColor))
+                .cornerRadius(6)
+        }
+    }
+}

--- a/Homeboy/Views/AgentTasks/AgentTasksViewModel.swift
+++ b/Homeboy/Views/AgentTasks/AgentTasksViewModel.swift
@@ -1,0 +1,200 @@
+import Foundation
+
+@MainActor
+final class AgentTasksViewModel: ObservableObject {
+    @Published var runners: [HomeboyRunner] = [HomeboyRunner.localDefault]
+    @Published var selectedRunnerID = HomeboyRunner.localDefault.id
+    @Published var providers: JSONValue = .null
+    @Published var runs: [JSONValue] = []
+    @Published var selectedRunID: String?
+    @Published var status: JSONValue = .null
+    @Published var logs: JSONValue = .null
+    @Published var artifacts: JSONValue = .null
+    @Published var goal = ""
+    @Published var sourceRefs = ""
+    @Published var workspace = ""
+    @Published var provider = ""
+    @Published var concurrency = 1
+    @Published var attempts = 1
+    @Published var policy = "{}"
+    @Published var runNow = false
+    @Published var promotionWorktree = ""
+    @Published var verificationCommand = ""
+    @Published var promotionResult = ""
+    @Published var isLoading = false
+    @Published var error: (any DisplayableError)?
+
+    private let cli = HomeboyCLI.shared
+
+    var selectedRunner: HomeboyRunner? {
+        runners.first { $0.id == selectedRunnerID }
+    }
+
+    func load() {
+        guard cli.isInstalled else {
+            error = AppError("Homeboy CLI is not installed. Install via Settings -> CLI.", source: "Agent Tasks")
+            return
+        }
+        Task { await refresh() }
+    }
+
+    func refresh() async {
+        isLoading = true
+        error = nil
+        do {
+            async let runnerTask = cli.runnerList()
+            async let providerTask = cli.agentTaskProviders(runnerID: selectedRunnerID)
+            async let runTask = cli.agentTaskList(runnerID: selectedRunnerID)
+            runners = try await runnerTask
+            providers = try await providerTask
+            if provider.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                provider = firstAvailableProviderBackend(in: providers) ?? ""
+            }
+            runs = (try await runTask).value(at: ["runs"]).arrayValue ?? []
+            if selectedRunID == nil || !runs.contains(where: { $0.value(at: ["run_id"]).stringValue == selectedRunID }) {
+                selectedRunID = runs.first?.value(at: ["run_id"]).stringValue
+            }
+            await loadSelectedRun()
+        } catch {
+            self.error = error.toDisplayableError(source: "Agent Tasks")
+        }
+        isLoading = false
+    }
+
+    func loadSelectedRun() async {
+        guard let selectedRunID else {
+            status = .null
+            logs = .null
+            artifacts = .null
+            return
+        }
+        do {
+            async let statusTask = cli.agentTaskStatus(id: selectedRunID, runnerID: selectedRunnerID)
+            async let logTask = cli.agentTaskLogs(id: selectedRunID, runnerID: selectedRunnerID)
+            async let artifactTask = cli.agentTaskArtifacts(id: selectedRunID, runnerID: selectedRunnerID)
+            status = try await statusTask
+            logs = try await logTask
+            artifacts = try await artifactTask
+        } catch {
+            self.error = error.toDisplayableError(source: "Agent Tasks")
+        }
+    }
+
+    func submit() {
+        guard !goal.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            error = AppError("A mission goal is required.", source: "Agent Tasks")
+            return
+        }
+        guard !provider.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            error = AppError("Select an active or available provider backend before submitting.", source: "Agent Tasks")
+            return
+        }
+        do {
+            let plan = try makePlan()
+            let runID = "desktop-run-\(UUID().uuidString.lowercased())"
+            Task {
+                do {
+                    _ = try await cli.agentTaskSubmit(plan: plan, runID: runID, runNow: runNow, runnerID: selectedRunnerID)
+                    selectedRunID = runID
+                    await refresh()
+                } catch {
+                    self.error = error.toDisplayableError(source: "Agent Tasks")
+                }
+            }
+        } catch {
+            self.error = error.toDisplayableError(source: "Agent Tasks")
+        }
+    }
+
+    func cancel() { perform { try await self.cli.agentTaskCancel(id: $0, runnerID: self.selectedRunnerID) } }
+    func retry() { perform { try await self.cli.agentTaskRetry(id: $0, runnerID: self.selectedRunnerID) } }
+    func resume() { perform { try await self.cli.agentTaskResume(id: $0, runnerID: self.selectedRunnerID) } }
+
+    func dryRunPromotion() {
+        guard let selectedRunID, !promotionWorktree.isEmpty else {
+            error = AppError("Select a durable run and enter a managed worktree handle.", source: "Agent Tasks")
+            return
+        }
+        Task {
+            do {
+                let result = try await cli.agentTaskPromoteDryRun(runID: selectedRunID, worktree: promotionWorktree, verify: verificationCommand, runnerID: selectedRunnerID)
+                promotionResult = result.prettyPrintedJSONString
+            } catch {
+                self.error = error.toDisplayableError(source: "Agent Tasks")
+            }
+        }
+    }
+
+    private func perform(_ action: @escaping (String) async throws -> JSONValue) {
+        guard let selectedRunID else { return }
+        Task {
+            do {
+                _ = try await action(selectedRunID)
+                await refresh()
+            } catch {
+                self.error = error.toDisplayableError(source: "Agent Tasks")
+            }
+        }
+    }
+
+    private func makePlan() throws -> JSONValue {
+        let policyData = Data(policy.utf8)
+        let policyValue = try JSONDecoder().decode(JSONValue.self, from: policyData)
+        guard case .object = policyValue else {
+            throw CLIBridgeError.invalidResponse("Policy must be a JSON object.")
+        }
+
+        var workspaceValue: [String: JSONValue] = [
+            "mode": .string(workspace.isEmpty ? "ephemeral" : "existing")
+        ]
+        if !workspace.isEmpty {
+            workspaceValue["root"] = .string(workspace)
+        }
+        let task: JSONValue = .object([
+            "schema": .string("homeboy/agent-task-request/v1"),
+            "task_id": .string("desktop-mission"),
+            "instructions": .string(goal),
+            "executor": .object(["backend": .string(provider)]),
+            "source_refs": .array(sourceRefs.split(separator: "\n").map {
+                .object(["kind": .string("reference"), "uri": .string(String($0))])
+            }),
+            "workspace": .object(workspaceValue),
+            "policy": policyValue
+        ])
+        return .object([
+            "schema": .string("homeboy/agent-task-plan/v1"),
+            "plan_id": .string("desktop-mission-\(UUID().uuidString.lowercased())"),
+            "tasks": .array([task]),
+            "options": .object([
+                "max_concurrency": .int(concurrency),
+                "retry": .object(["max_attempts": .int(attempts)])
+            ]),
+            "metadata": .object([
+                "source_refs": .array(sourceRefs.split(separator: "\n").map { .string(String($0)) })
+            ])
+        ])
+    }
+
+    private func firstAvailableProviderBackend(in response: JSONValue) -> String? {
+        response.value(at: ["providers"]).arrayValue?
+            .first {
+                ["active", "available"].contains($0.value(at: ["status"]).stringValue)
+                    && !$0.value(at: ["backend"]).stringValue.isEmpty
+            }?
+            .value(at: ["backend"]).stringValue
+    }
+}
+
+extension JSONValue {
+    func value(at path: [String]) -> JSONValue {
+        path.reduce(self) { value, key in
+            guard case .object(let object) = value else { return .null }
+            return object[key] ?? .null
+        }
+    }
+
+    var arrayValue: [JSONValue]? {
+        guard case .array(let value) = self else { return nil }
+        return value
+    }
+}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Homeboy Desktop connects to your servers and shows you a unified view of all you
 
 ### Built-in Tools
 
+**Agent Tasks** — Mission control for durable, headless Homeboy agent-task runs
+- Creates queueable or immediate plans from goals, source refs, workspace, provider, concurrency, attempts, and policy
+- Renders Homeboy-owned status, fanout cells, events, artifacts, diagnostics, replay bundles, and PR evidence
+- Uses Homeboy's promotion dry-run and verification contract; Desktop never applies patches itself
+
 **Deployer** — Push code to any server with a click
 - One-click deployment of plugins, themes, and packages
 - Version comparison (see what's outdated before you deploy)

--- a/docs/AGENT-TASK-MISSION-CONTROL.md
+++ b/docs/AGENT-TASK-MISSION-CONTROL.md
@@ -1,0 +1,21 @@
+# Agent-Task Mission Control
+
+Homeboy Desktop is a visual control surface for Homeboy-owned `agent-task` lifecycle records. It is not a chat client and does not execute providers, manage task state, or apply patches itself.
+
+## Contract Boundary
+
+The Agent Tasks workspace calls `homeboy agent-task contract`, `providers`, `list`, `status --full`, `logs --full`, `artifacts --full`, `submit`, `run-plan`, `cancel`, `retry`, `resume`, and `promote --dry-run` through the structured CLI result envelope. Contract data is retained as `JSONValue`, so new Homeboy fields appear in the UI without Desktop maintaining duplicate command or lifecycle models.
+
+## Implemented Workflow
+
+- Build a mission from a goal, newline-delimited source references, workspace, provider backend, concurrency, attempts, and JSON policy.
+- Queue with `submit` or run with `run-plan`; Homeboy persists the durable run and owns provider dispatch.
+- Select a runner, inspect its Homeboy-backed run list, and view full lifecycle, fanout, event, failure, timeout/no-op, artifact, evidence, replay, and diagnostic payloads.
+- Cancel, retry, or resume through the corresponding Homeboy lifecycle command.
+- Dry-run promotion of the selected durable run into a managed worktree with an optional deterministic verification command.
+
+## Core Blocker
+
+The local daemon currently exposes generic `/jobs` and `/runs/{id}/artifacts` endpoints, not a stable agent-task endpoint family for provider discovery, durable run listing, cursor-based events, lifecycle actions, promotion, or runner capacity. Desktop therefore uses the typed CLI contract. A Homeboy core daemon API must provide those agent-task operations before this workspace can replace CLI polling with live daemon updates.
+
+Desktop composes the v1 plan using Homeboy's checked-in fixture shape: `plan_id`, request `task_id`, structured `source_refs`, `workspace`, and `policy`, plus `options.max_concurrency` and `options.retry.max_attempts`. A non-mutating `validate-plan` command would still let Desktop prove a draft is admissible before it creates a durable run.

--- a/tests/AgentTaskContractTests.swift
+++ b/tests/AgentTaskContractTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+func runAgentTaskContractTests(testDir: String, fixturesDir: String) throws {
+    print("Test: agent-task mission-control contract")
+    print("-----------------------------------------")
+
+    let fixtureURL = URL(fileURLWithPath: "\(fixturesDir)/agent-task-plan.json")
+    let data = try Data(contentsOf: fixtureURL)
+    let fixture = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+    let task = try requiredObject(requiredArray(fixture, "tasks")[0] as! [String: Any])
+    let options = try requiredObject(fixture["options"])
+    let retry = try requiredObject(options["retry"])
+
+    try assertEqual(fixture["schema"] as? String, "homeboy/agent-task-plan/v1", "plan uses the v1 schema")
+    try assertEqual(fixture["plan_id"] as? String, "desktop-mission-fixture", "plan uses plan_id, not id")
+    try assertEqual(task["schema"] as? String, "homeboy/agent-task-request/v1", "task uses the request schema")
+    try assertEqual(task["task_id"] as? String, "desktop-mission", "task uses task_id, not id")
+    try assertEqual((try requiredObject(task["executor"]))["backend"] as? String, "opencode", "task declares executor.backend")
+    try assertTrue(task["workspace"] is [String: Any], "task workspace is structured")
+    try assertTrue(task["policy"] is [String: Any], "task policy is structured")
+    try assertEqual(options["max_concurrency"] as? Int, 2, "concurrency belongs under options")
+    try assertEqual(retry["max_attempts"] as? Int, 3, "retry count belongs under options.retry")
+    try assertTrue(fixture["max_attempts"] == nil, "plan has no invented top-level max_attempts")
+
+    let repoRoot = URL(fileURLWithPath: testDir).deletingLastPathComponent()
+    let viewModel = try String(contentsOf: repoRoot.appendingPathComponent("Homeboy/Views/AgentTasks/AgentTasksViewModel.swift"), encoding: .utf8)
+    let commands = try String(contentsOf: repoRoot.appendingPathComponent("Homeboy/Core/CLI/HomeboyCLI+AgentTaskCommands.swift"), encoding: .utf8)
+    try assertContains(viewModel, "\"plan_id\"", message: "mission encoder uses plan_id")
+    try assertContains(viewModel, "\"task_id\"", message: "mission encoder uses task_id")
+    try assertContains(viewModel, "\"options\"", message: "mission encoder emits options")
+    try assertContains(viewModel, "\"retry\": .object([\"max_attempts\"", message: "mission encoder emits options.retry.max_attempts")
+    try assertDoesNotContain(viewModel, "\n            \"max_attempts\": .int(attempts),", message: "mission encoder omits top-level max_attempts")
+    try assertContains(viewModel, "value(at: [\"runs\"])", message: "run list reads the data payload directly")
+    try assertDoesNotContain(viewModel, "aggregate_path", message: "promotion does not expose runner-local aggregate paths")
+    try assertContains(viewModel, "firstAvailableProviderBackend", message: "provider backend defaults from the provider contract")
+    try assertContains(viewModel, "[\"active\", \"available\"]", message: "provider default accepts active or available backends")
+    try assertContains(viewModel, "Select an active or available provider backend", message: "submit blocks without a provider backend")
+    try assertContains(commands, "[\"agent-task\", \"run-plan\", \"--plan\", \"-\", \"--record-run-id\", runID]", message: "run-now uses the exact durable run-plan argv")
+    try assertContains(commands, "[\"promote\", runID, \"--to-worktree\", worktree, \"--dry-run\"]", message: "promotion uses the durable run id")
+    print("[PASS] Agent-task plan and CLI argv contract")
+    print("")
+}
+
+private func requiredObject(_ value: Any?) throws -> [String: Any] {
+    guard let object = value as? [String: Any] else {
+        throw NSError(domain: "AgentTaskContract", code: 1, userInfo: [NSLocalizedDescriptionKey: "Expected JSON object"])
+    }
+    return object
+}
+
+private func requiredArray(_ object: [String: Any], _ key: String) throws -> [Any] {
+    guard let array = object[key] as? [Any], !array.isEmpty else {
+        throw NSError(domain: "AgentTaskContract", code: 2, userInfo: [NSLocalizedDescriptionKey: "Expected non-empty \(key) array"])
+    }
+    return array
+}
+
+private func assertEqual<T: Equatable>(_ actual: T?, _ expected: T, _ message: String) throws {
+    guard actual == expected else {
+        throw NSError(domain: "AgentTaskContract", code: 3, userInfo: [NSLocalizedDescriptionKey: message])
+    }
+    print("[PASS] \(message)")
+}
+
+private func assertTrue(_ condition: Bool, _ message: String) throws {
+    guard condition else {
+        throw NSError(domain: "AgentTaskContract", code: 4, userInfo: [NSLocalizedDescriptionKey: message])
+    }
+    print("[PASS] \(message)")
+}

--- a/tests/ContractTestRunner.swift
+++ b/tests/ContractTestRunner.swift
@@ -19,6 +19,7 @@ func runTests(testDir: String) throws {
     try runHistoryContractTests(testDir: testDir, fixturesDir: fixturesDir, decoder: decoder)
     try runStackGitAPIAuthContractTests(testDir: testDir, fixturesDir: fixturesDir, decoder: decoder)
     try runQualityAuditReviewTriageContractTests(testDir: testDir, fixturesDir: fixturesDir, decoder: decoder)
+    try runAgentTaskContractTests(testDir: testDir, fixturesDir: fixturesDir)
 
     print("")
     print("All contract tests passed")

--- a/tests/ContractTests.swift
+++ b/tests/ContractTests.swift
@@ -22,6 +22,7 @@ let aggregateFiles = [
     "RunHistoryContractTests.swift",
     "StackGitAPIAuthContractTests.swift",
     "QualityAuditReviewTriageContractTests.swift",
+    "AgentTaskContractTests.swift",
     "ContractTestRunner.swift",
 
 ].map { testsDir.appendingPathComponent($0).path }

--- a/tests/fixtures/agent-task-plan.json
+++ b/tests/fixtures/agent-task-plan.json
@@ -1,0 +1,19 @@
+{
+  "schema": "homeboy/agent-task-plan/v1",
+  "plan_id": "desktop-mission-fixture",
+  "tasks": [
+    {
+      "schema": "homeboy/agent-task-request/v1",
+      "task_id": "desktop-mission",
+      "executor": { "backend": "opencode" },
+      "instructions": "Implement the requested mission.",
+      "source_refs": [{ "kind": "reference", "uri": "https://github.com/Extra-Chill/homeboy-desktop/issues/82" }],
+      "workspace": { "mode": "existing", "root": "/workspace/homeboy-desktop" },
+      "policy": { "write": "patch_only" }
+    }
+  ],
+  "options": {
+    "max_concurrency": 2,
+    "retry": { "max_attempts": 3 }
+  }
+}


### PR DESCRIPTION
## Summary
- add a native Agent Tasks command-center workspace over Homeboy-owned lifecycle contracts
- create queued or immediate durable runs with runner, provider, workspace, concurrency, retry, source, and policy controls
- inspect status, fanout, events, failures, artifacts, evidence, replay, and PR payloads
- expose cancel, retry, resume, and managed-worktree promotion preview controls
- default to available providers and show runner kind/capacity without duplicating orchestration state
- enforce current Homeboy plan and CLI contracts with dedicated fixtures and tests

Fixes #82.

## How to test
1. Check out this branch on macOS with Xcode installed.
2. Run `swift tests/ContractTests.swift tests`.
3. Confirm all contract tests pass, including `agent-task mission-control contract`.
4. Run `xcodebuild -project Homeboy.xcodeproj -scheme Homeboy -configuration Debug build CODE_SIGNING_ALLOWED=NO`.
5. Confirm the build succeeds.
6. Launch Homeboy, open **Agent Tasks**, select a runner and provider, queue a mission, and confirm its durable run appears.
7. Select the run and verify status/events/artifacts render; exercise cancel, retry, resume, and dry-run promotion against a disposable managed worktree.

## Architecture
Desktop remains a thin visual CLI client. Homeboy owns provider execution, durable lifecycle, runner placement, evidence, and promotion. Arbitrary lifecycle payloads remain typed JSON rather than duplicated desktop models.

## Known core boundary
Homeboy daemon does not yet expose a stable agent-task endpoint family or plan validation/schema endpoint, so this workspace uses the structured CLI envelope. The exact boundary is documented in `docs/AGENT-TASK-MISSION-CONTROL.md`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.6-sol) and Homeboy
- **Used for:** Implemented and reviewed the native mission-control workspace, corrected it against live Homeboy contracts, added deterministic contract tests, and used Homeboy for finalization. Chris reviewed and owns the change.